### PR TITLE
[CIO-PROXY] Intent-to-Signal Proxy

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Application modules for petrosa-cio."""

--- a/apps/nurse/__init__.py
+++ b/apps/nurse/__init__.py
@@ -1,0 +1,1 @@
+"""Nurse domain modules."""

--- a/apps/nurse/enforcer.py
+++ b/apps/nurse/enforcer.py
@@ -1,0 +1,34 @@
+"""Deterministic Nurse policy enforcement."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class EnforcerResult:
+    """Outcome of intent policy enforcement."""
+
+    approved: bool
+    reason: str | None = None
+
+
+class NurseEnforcer:
+    """Simple deterministic validation gate for incoming intent payloads."""
+
+    VALID_ACTIONS = {"buy", "sell", "hold", "close"}
+
+    async def enforce(self, intent_payload: dict[str, Any]) -> EnforcerResult:
+        action = str(intent_payload.get("action", "")).lower()
+        if action not in self.VALID_ACTIONS:
+            return EnforcerResult(approved=False, reason="invalid_action")
+
+        confidence = intent_payload.get("confidence")
+        if confidence is not None:
+            try:
+                confidence_value = float(confidence)
+            except (TypeError, ValueError):
+                return EnforcerResult(approved=False, reason="invalid_confidence")
+            if not 0.0 <= confidence_value <= 1.0:
+                return EnforcerResult(approved=False, reason="invalid_confidence")
+
+        return EnforcerResult(approved=True)

--- a/apps/nurse/roi_logger.py
+++ b/apps/nurse/roi_logger.py
@@ -1,0 +1,18 @@
+"""Shadow ROI audit logger."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+
+class RoiLogger:
+    """Async logger for audit_logs collection writes."""
+
+    def __init__(self, collection: Any | None = None):
+        self.collection = collection
+
+    async def log_audit(self, document: dict[str, Any]) -> None:
+        doc = dict(document)
+        doc.setdefault("logged_at", datetime.now(UTC).isoformat())
+
+        if self.collection is not None:
+            await self.collection.insert_one(doc)

--- a/core/nats/__init__.py
+++ b/core/nats/__init__.py
@@ -1,0 +1,1 @@
+"""NATS transport modules."""

--- a/core/nats/interceptor.py
+++ b/core/nats/interceptor.py
@@ -1,0 +1,111 @@
+"""NATS intent interception and promotion to trading signals."""
+
+import json
+import time
+from typing import Any
+
+from apps.nurse.enforcer import EnforcerResult, NurseEnforcer
+from apps.nurse.roi_logger import RoiLogger
+
+
+class NurseInterceptor:
+    """Intercepts `cio.intent.>` events and promotes approved payloads."""
+
+    def __init__(
+        self,
+        nats_client: Any,
+        enforcer: NurseEnforcer | None = None,
+        roi_logger: RoiLogger | None = None,
+        target_subject: str = "signals.trading",
+        max_latency_ms: float = 50.0,
+    ):
+        self.nats_client = nats_client
+        self.enforcer = enforcer or NurseEnforcer()
+        self.roi_logger = roi_logger or RoiLogger()
+        self.target_subject = target_subject
+        self.max_latency_ms = max_latency_ms
+
+    async def start(self) -> None:
+        """Start subscription loop for all CIO intents."""
+        await self.nats_client.subscribe("cio.intent.>", cb=self._on_message)
+
+    async def _on_message(self, msg: Any) -> None:
+        headers = self._normalize_headers(getattr(msg, "headers", None))
+        await self.handle_intent(msg.data, headers=headers)
+
+    async def handle_intent(
+        self,
+        data: bytes | str,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        start = time.perf_counter()
+        payload = self._decode_payload(data)
+        traceparent = self._extract_traceparent(headers)
+
+        result: EnforcerResult = await self.enforcer.enforce(payload)
+
+        promoted_payload = dict(payload)
+        if traceparent:
+            promoted_payload["_otel_trace_context"] = {"traceparent": traceparent}
+
+        status = "Approved" if result.approved else "Blocked"
+        audit_document = {
+            "status": status,
+            "reason": result.reason,
+            "subject_source": payload.get("_subject", "cio.intent"),
+            "subject_target": self.target_subject,
+            "potential_pnl": self._extract_potential_pnl(payload),
+            "payload": payload,
+            "traceparent": traceparent,
+        }
+
+        if result.approved:
+            await self.nats_client.publish(
+                self.target_subject,
+                json.dumps(promoted_payload, separators=(",", ":")).encode(),
+                headers=headers,
+            )
+
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        audit_document["processing_ms"] = elapsed_ms
+        audit_document["latency_budget_ms"] = self.max_latency_ms
+        audit_document["latency_budget_met"] = elapsed_ms < self.max_latency_ms
+
+        await self.roi_logger.log_audit(audit_document)
+
+        return {
+            "approved": result.approved,
+            "status": status,
+            "processing_ms": elapsed_ms,
+            "latency_budget_met": elapsed_ms < self.max_latency_ms,
+        }
+
+    @staticmethod
+    def _decode_payload(data: bytes | str) -> dict[str, Any]:
+        if isinstance(data, bytes):
+            return json.loads(data.decode())
+        if isinstance(data, str):
+            return json.loads(data)
+        raise TypeError("Intent payload must be bytes or JSON string")
+
+    @staticmethod
+    def _normalize_headers(headers: Any) -> dict[str, str]:
+        if not headers:
+            return {}
+        return {str(k).lower(): str(v) for k, v in dict(headers).items()}
+
+    @staticmethod
+    def _extract_traceparent(headers: dict[str, str] | None) -> str | None:
+        if not headers:
+            return None
+        return headers.get("traceparent")
+
+    @staticmethod
+    def _extract_potential_pnl(payload: dict[str, Any]) -> float:
+        for key in ("potential_pnl", "estimated_pnl", "expected_pnl"):
+            if key in payload:
+                try:
+                    return float(payload[key])
+                except (TypeError, ValueError):
+                    break
+        return 0.0

--- a/otel_init.py
+++ b/otel_init.py
@@ -206,11 +206,14 @@ def setup_telemetry(
     # 2. Manual attributes (deployment.environment, service.instance.id)
     # 3. Detected attributes (process, OTEL)
     # Resource.merge() gives precedence to the caller (left side)
-    # Use Resource.empty() if no attributes parsed for consistency
+    # Resource.empty() is not available in some OpenTelemetry versions.
+    # Fall back to creating an empty resource for cross-version compatibility.
     if otel_resource_attrs:
         base_resource = Resource.create(otel_resource_attrs)
     else:
-        base_resource = Resource.empty()
+        base_resource = (
+            Resource.empty() if hasattr(Resource, "empty") else Resource.create({})
+        )
 
     resource = (
         base_resource.merge(manual_resource)

--- a/tests/test_interceptor.py
+++ b/tests/test_interceptor.py
@@ -1,0 +1,148 @@
+"""Tests for CIO intent interception flow."""
+
+import json
+import statistics
+import time
+
+import pytest
+
+from apps.nurse.enforcer import EnforcerResult
+from core.nats.interceptor import NurseInterceptor
+
+
+class FakeNatsClient:
+    def __init__(self):
+        self.subscriptions = []
+        self.published = []
+
+    async def subscribe(self, subject, cb):
+        self.subscriptions.append((subject, cb))
+
+    async def publish(self, subject, payload, headers=None):
+        self.published.append((subject, payload, headers or {}))
+
+
+class FakeEnforcer:
+    def __init__(self, approved=True, reason=None):
+        self.approved = approved
+        self.reason = reason
+
+    async def enforce(self, payload):
+        return EnforcerResult(approved=self.approved, reason=self.reason)
+
+
+class FakeRoiLogger:
+    def __init__(self):
+        self.documents = []
+
+    async def log_audit(self, document):
+        self.documents.append(document)
+
+
+@pytest.mark.asyncio
+async def test_start_subscribes_to_intent_subject():
+    client = FakeNatsClient()
+    interceptor = NurseInterceptor(client)
+
+    await interceptor.start()
+
+    assert len(client.subscriptions) == 1
+    assert client.subscriptions[0][0] == "cio.intent.>"
+
+
+@pytest.mark.asyncio
+async def test_approved_intent_promotes_signal_and_logs_trace_context():
+    client = FakeNatsClient()
+    roi_logger = FakeRoiLogger()
+    interceptor = NurseInterceptor(
+        nats_client=client,
+        enforcer=FakeEnforcer(approved=True),
+        roi_logger=roi_logger,
+    )
+
+    intent = {
+        "strategy_id": "strat-1",
+        "symbol": "BTCUSDT",
+        "action": "buy",
+        "confidence": 0.9,
+        "potential_pnl": 42.5,
+    }
+
+    result = await interceptor.handle_intent(
+        json.dumps(intent).encode(),
+        headers={"traceparent": "00-abcd-efgh-01"},
+    )
+
+    assert result["approved"] is True
+    assert len(client.published) == 1
+    subject, payload, headers = client.published[0]
+    promoted = json.loads(payload.decode())
+
+    assert subject == "signals.trading"
+    assert promoted["strategy_id"] == intent["strategy_id"]
+    assert promoted["symbol"] == intent["symbol"]
+    assert promoted["_otel_trace_context"]["traceparent"] == "00-abcd-efgh-01"
+    assert headers["traceparent"] == "00-abcd-efgh-01"
+
+    assert len(roi_logger.documents) == 1
+    audit = roi_logger.documents[0]
+    assert audit["status"] == "Approved"
+    assert audit["potential_pnl"] == pytest.approx(42.5)
+    assert audit["latency_budget_met"] is True
+
+
+@pytest.mark.asyncio
+async def test_blocked_intent_does_not_publish_and_is_audited():
+    client = FakeNatsClient()
+    roi_logger = FakeRoiLogger()
+    interceptor = NurseInterceptor(
+        nats_client=client,
+        enforcer=FakeEnforcer(approved=False, reason="policy_block"),
+        roi_logger=roi_logger,
+    )
+
+    intent = {"symbol": "BTCUSDT", "action": "buy", "expected_pnl": "11.2"}
+    result = await interceptor.handle_intent(json.dumps(intent).encode(), headers={})
+
+    assert result["approved"] is False
+    assert client.published == []
+    assert roi_logger.documents[0]["status"] == "Blocked"
+    assert roi_logger.documents[0]["reason"] == "policy_block"
+    assert roi_logger.documents[0]["potential_pnl"] == pytest.approx(11.2)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_interceptor_latency_p95_under_50ms_for_100_messages():
+    client = FakeNatsClient()
+    roi_logger = FakeRoiLogger()
+    interceptor = NurseInterceptor(
+        nats_client=client,
+        enforcer=FakeEnforcer(approved=True),
+        roi_logger=roi_logger,
+        max_latency_ms=50.0,
+    )
+
+    latencies = []
+    for idx in range(100):
+        payload = {
+            "strategy_id": f"strat-{idx}",
+            "symbol": "BTCUSDT",
+            "action": "buy",
+            "confidence": 0.8,
+            "potential_pnl": idx / 10.0,
+        }
+        start = time.perf_counter()
+        result = await interceptor.handle_intent(
+            json.dumps(payload).encode(), headers={}
+        )
+        _ = result
+        latencies.append((time.perf_counter() - start) * 1000.0)
+
+    # P95 over 100 samples corresponds to index 94 in sorted list.
+    p95 = sorted(latencies)[94]
+
+    assert p95 < 50.0
+    assert statistics.mean(latencies) < 50.0
+    assert len(client.published) == 100
+    assert len(roi_logger.documents) == 100


### PR DESCRIPTION
## Summary
- implement `NurseInterceptor` for `cio.intent.>` interception and promotion to `signals.trading`
- add deterministic `NurseEnforcer` and async `RoiLogger` for `audit_logs` shadow ROI records
- propagate `traceparent` into promoted payload `_otel_trace_context`
- add integration-focused tests for routing, blocking, trace propagation, and 100-message latency envelope
- patch OpenTelemetry resource initialization compatibility (`Resource.empty()` fallback)

## Validation
- `.venv/bin/python -m ruff check apps/nurse/enforcer.py apps/nurse/roi_logger.py core/nats/interceptor.py tests/test_interceptor.py otel_init.py`
- `.venv/bin/python -m pytest tests/test_interceptor.py tests/test_contracts.py tests/test_probe.py -q`

Closes #3
