### PR TITLE
[CIO-HEARTBEAT] Deterministic Heartbeat & Service Health

### DIFF
--- a/core/nats/heartbeat.py
+++ b/core/nats/heartbeat.py
@@ -1,0 +1,104 @@
+"""Deterministic CIO heartbeat handler over NATS request-reply."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from motor.motor_asyncio import AsyncIOMotorClient
+from opentelemetry.trace import Status, StatusCode
+from redis.asyncio import Redis
+
+from otel_init import get_tracer
+
+
+class HeartbeatService:
+    """Serves `cio.heartbeat` responses with dependency health and telemetry."""
+
+    def __init__(
+        self,
+        *,
+        version: str,
+        redis_url: str | None = None,
+        mongo_url: str | None = None,
+        response_budget_ms: float = 20.0,
+    ):
+        self.version = version
+        self.redis_url = redis_url or os.getenv("REDIS_URL")
+        self.mongo_url = mongo_url or os.getenv("MONGO_URL")
+        self.response_budget_ms = response_budget_ms
+        self.tracer = get_tracer(__name__)
+
+    async def check_redis_health(self) -> bool:
+        if not self.redis_url:
+            return False
+
+        client = Redis.from_url(self.redis_url)
+        try:
+            return bool(await client.ping())
+        except Exception:
+            return False
+        finally:
+            await client.aclose()
+
+    async def check_mongo_health(self) -> bool:
+        if not self.mongo_url:
+            return False
+
+        client = AsyncIOMotorClient(self.mongo_url, serverSelectionTimeoutMS=500)
+        try:
+            response = await client.admin.command("ping")
+            return float(response.get("ok", 0)) == 1.0
+        except Exception:
+            return False
+        finally:
+            client.close()
+
+    async def build_heartbeat(self) -> dict[str, Any]:
+        start = time.perf_counter()
+
+        with self.tracer.start_as_current_span("cio.heartbeat") as span:
+            redis_ok, mongo_ok = (
+                await self.check_redis_health(),
+                await self.check_mongo_health(),
+            )
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+            status_code = "GOVERNANCE_ACTIVE" if redis_ok and mongo_ok else "DEGRADED"
+            payload = {
+                "status": "OK",
+                "status_code": status_code,
+                "timestamp": datetime.now(UTC).isoformat(),
+                "version": self.version,
+                "dependencies": {
+                    "redis": "connected" if redis_ok else "disconnected",
+                    "mongo": "connected" if mongo_ok else "disconnected",
+                },
+                "response_time_ms": elapsed_ms,
+            }
+
+            span.set_attribute("service.health.status", payload["status"])
+            span.set_attribute("service.health.status_code", status_code)
+            span.set_attribute("service.health.redis", redis_ok)
+            span.set_attribute("service.health.mongo", mongo_ok)
+            span.set_attribute("service.health.response_time_ms", elapsed_ms)
+            span.set_attribute(
+                "service.health.under_budget", elapsed_ms < self.response_budget_ms
+            )
+
+            if elapsed_ms >= self.response_budget_ms:
+                span.set_status(
+                    Status(StatusCode.ERROR, "heartbeat_response_over_budget")
+                )
+
+            return payload
+
+    async def handle_request(self, msg: Any) -> None:
+        payload = await self.build_heartbeat()
+        await msg.respond(json.dumps(payload, separators=(",", ":")).encode())
+
+    async def start(self, nats_client: Any) -> None:
+        await nats_client.subscribe("cio.heartbeat", cb=self.handle_request)

--- a/docs/HEARTBEAT_SPEC.md
+++ b/docs/HEARTBEAT_SPEC.md
@@ -1,0 +1,41 @@
+# CIO Heartbeat Spec
+
+## Subject
+- `cio.heartbeat` (NATS request-reply)
+
+## Objective
+Provide deterministic governance liveness with dependency connectivity checks so clients can decide whether governance is active.
+
+## Response Schema
+```json
+{
+  "status": "OK",
+  "status_code": "GOVERNANCE_ACTIVE | DEGRADED",
+  "timestamp": "2026-02-26T03:00:00+00:00",
+  "version": "1.0.0",
+  "dependencies": {
+    "redis": "connected | disconnected",
+    "mongo": "connected | disconnected"
+  },
+  "response_time_ms": 1.23
+}
+```
+
+## Status Codes
+- `GOVERNANCE_ACTIVE`: Redis and MongoDB connectivity checks succeeded.
+- `DEGRADED`: At least one dependency health check failed.
+
+## Latency Contract
+- Target response budget: `< 20ms` from receipt to reply.
+- The heartbeat handler records span attributes for status and timing.
+
+## Telemetry
+Heartbeat execution is wrapped in an OpenTelemetry span: `cio.heartbeat`.
+
+Span attributes:
+- `service.health.status`
+- `service.health.status_code`
+- `service.health.redis`
+- `service.health.mongo`
+- `service.health.response_time_ms`
+- `service.health.under_budget`

--- a/main.py
+++ b/main.py
@@ -3,9 +3,12 @@ Petrosa CIO - Sovereign Gatekeeper and Strategy Controller
 """
 
 import logging
+import os
 
 from fastapi import FastAPI
+from nats import connect as nats_connect
 
+from core.nats.heartbeat import HeartbeatService
 from otel_init import attach_logging_handler, instrument_fastapi_app, setup_telemetry
 
 # Setup logging
@@ -18,6 +21,8 @@ app = FastAPI(
     description="Sovereign Gatekeeper and Strategy Controller",
     version="1.0.0",
 )
+app.state.nats_client = None
+app.state.heartbeat_service = None
 
 
 @app.on_event("startup")
@@ -26,7 +31,25 @@ async def startup_event():
     setup_telemetry(service_name="petrosa-cio")
     instrument_fastapi_app(app)
     attach_logging_handler()
+    app.state.heartbeat_service = HeartbeatService(version=app.version)
+
+    nats_url = os.getenv("NATS_URL")
+    if nats_url:
+        try:
+            app.state.nats_client = await nats_connect(nats_url, connect_timeout=1)
+            await app.state.heartbeat_service.start(app.state.nats_client)
+            logger.info("NATS heartbeat listener active on subject cio.heartbeat")
+        except Exception as exc:
+            logger.warning(f"NATS heartbeat listener disabled: {exc}")
+
     logger.info("Petrosa CIO service started")
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    """Graceful shutdown for optional NATS connection."""
+    if app.state.nats_client is not None:
+        await app.state.nats_client.close()
 
 
 @app.get("/health/liveness")

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,81 @@
+"""Tests for NATS heartbeat service."""
+
+import json
+import statistics
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.nats.heartbeat import HeartbeatService
+
+
+class FakeMsg:
+    def __init__(self):
+        self.replies = []
+
+    async def respond(self, payload: bytes) -> None:
+        self.replies.append(payload)
+
+
+@pytest.mark.asyncio
+async def test_build_heartbeat_includes_liveness_metadata():
+    service = HeartbeatService(version="1.0.0")
+    service.check_redis_health = AsyncMock(return_value=True)
+    service.check_mongo_health = AsyncMock(return_value=True)
+
+    payload = await service.build_heartbeat()
+
+    assert payload["status"] == "OK"
+    assert payload["status_code"] == "GOVERNANCE_ACTIVE"
+    assert payload["version"] == "1.0.0"
+    assert "timestamp" in payload
+    assert payload["dependencies"]["redis"] == "connected"
+    assert payload["dependencies"]["mongo"] == "connected"
+
+
+@pytest.mark.asyncio
+async def test_build_heartbeat_marks_degraded_on_dependency_failure():
+    service = HeartbeatService(version="1.0.0")
+    service.check_redis_health = AsyncMock(return_value=True)
+    service.check_mongo_health = AsyncMock(return_value=False)
+
+    payload = await service.build_heartbeat()
+
+    assert payload["status"] == "OK"
+    assert payload["status_code"] == "DEGRADED"
+    assert payload["dependencies"]["redis"] == "connected"
+    assert payload["dependencies"]["mongo"] == "disconnected"
+
+
+@pytest.mark.asyncio
+async def test_handle_request_replies_with_json_payload():
+    service = HeartbeatService(version="1.0.0")
+    service.check_redis_health = AsyncMock(return_value=True)
+    service.check_mongo_health = AsyncMock(return_value=True)
+
+    msg = FakeMsg()
+    await service.handle_request(msg)
+
+    assert len(msg.replies) == 1
+    payload = json.loads(msg.replies[0].decode())
+    assert payload["status"] == "OK"
+    assert payload["version"] == "1.0.0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.performance
+async def test_heartbeat_p95_under_20ms_for_100_requests():
+    service = HeartbeatService(version="1.0.0")
+    service.check_redis_health = AsyncMock(return_value=True)
+    service.check_mongo_health = AsyncMock(return_value=True)
+
+    latencies = []
+    for _ in range(100):
+        start = time.perf_counter()
+        await service.build_heartbeat()
+        latencies.append((time.perf_counter() - start) * 1000.0)
+
+    p95 = sorted(latencies)[94]
+    assert p95 < 20.0
+    assert statistics.mean(latencies) < 20.0


### PR DESCRIPTION
## Summary
- add `HeartbeatService` for `cio.heartbeat` NATS request-reply handling
- return deterministic heartbeat payload with `status`, UTC `timestamp`, `version`, dependency connectivity, and response timing
- include Redis and MongoDB connectivity checks (`check_redis_health`, `check_mongo_health`)
- wrap heartbeat execution in OpenTelemetry span with `service.health.*` attributes
- wire heartbeat listener in `main.py` startup (enabled when `NATS_URL` is set)
- document heartbeat contract in `docs/HEARTBEAT_SPEC.md`
- add tests for metadata, degraded status, request reply behavior, and p95 latency under 20ms

## Validation
- `.venv/bin/python -m ruff format core/nats/heartbeat.py tests/test_heartbeat.py main.py`
- `.venv/bin/python -m ruff check core/nats/heartbeat.py tests/test_heartbeat.py main.py`
- `.venv/bin/python -m pytest tests/test_heartbeat.py tests/test_interceptor.py tests/test_contracts.py tests/test_probe.py -q`

Closes #4
