### PR TITLE
[CIO-NURSE] Market Regime Semantic Guard

### DIFF
--- a/apps/nurse/guard.py
+++ b/apps/nurse/guard.py
@@ -1,0 +1,120 @@
+"""Market regime semantic guard for Nurse enforcement."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RegimePolicy(BaseModel):
+    """Policy payload loaded from Redis `policy:regime`."""
+
+    current_regime: str = "unknown"
+    vol_threshold_breach: bool = False
+    drawdown_limit_exceeded: bool = False
+    current_drawdown: float = 0.0
+    scale_down_factor: float = Field(default=0.5, ge=0.0, le=1.0)
+
+
+@dataclass(slots=True)
+class GuardDecision:
+    """Outcome returned by semantic guard."""
+
+    approved: bool
+    scale_factor: float
+    veto_reason: str | None
+    metadata: dict[str, Any]
+    saved_capital: float
+
+
+class RegimeGuard:
+    """Evaluates semantic risk rules using current market regime policy."""
+
+    def __init__(
+        self, redis_client: Any | None = None, redis_key: str = "policy:regime"
+    ):
+        self.redis_client = redis_client
+        self.redis_key = redis_key
+
+    async def get_current_regime(self) -> tuple[RegimePolicy, float]:
+        """Fetch and parse current regime policy from Redis."""
+        start = time.perf_counter()
+
+        if self.redis_client is None:
+            policy = RegimePolicy()
+            return policy, (time.perf_counter() - start) * 1000.0
+
+        raw = await self.redis_client.get(self.redis_key)
+        if not raw:
+            policy = RegimePolicy()
+            return policy, (time.perf_counter() - start) * 1000.0
+
+        if isinstance(raw, bytes):
+            raw = raw.decode()
+
+        payload = json.loads(raw)
+        policy = RegimePolicy(**payload)
+        return policy, (time.perf_counter() - start) * 1000.0
+
+    async def evaluate(self, intent_payload: dict[str, Any]) -> GuardDecision:
+        policy, lookup_ms = await self.get_current_regime()
+
+        quantity = float(intent_payload.get("quantity", 0.0))
+        current_drawdown = max(float(policy.current_drawdown), 0.0)
+
+        metadata = {
+            "current_regime": policy.current_regime,
+            "vol_threshold_breach": policy.vol_threshold_breach,
+            "drawdown_limit_exceeded": policy.drawdown_limit_exceeded,
+            "regime_lookup_ms": lookup_ms,
+        }
+
+        if policy.drawdown_limit_exceeded:
+            saved_capital = self.calculate_saved_capital(
+                signal_size=quantity,
+                current_drawdown=current_drawdown,
+                scale_factor=0.0,
+            )
+            return GuardDecision(
+                approved=False,
+                scale_factor=0.0,
+                veto_reason="drawdown_limit_exceeded",
+                metadata=metadata,
+                saved_capital=saved_capital,
+            )
+
+        if policy.vol_threshold_breach and quantity > 0:
+            saved_capital = self.calculate_saved_capital(
+                signal_size=quantity,
+                current_drawdown=current_drawdown,
+                scale_factor=policy.scale_down_factor,
+            )
+            return GuardDecision(
+                approved=True,
+                scale_factor=policy.scale_down_factor,
+                veto_reason=None,
+                metadata=metadata,
+                saved_capital=saved_capital,
+            )
+
+        return GuardDecision(
+            approved=True,
+            scale_factor=1.0,
+            veto_reason=None,
+            metadata=metadata,
+            saved_capital=0.0,
+        )
+
+    @staticmethod
+    def calculate_saved_capital(
+        signal_size: float,
+        current_drawdown: float,
+        scale_factor: float = 0.0,
+    ) -> float:
+        """Estimate capital preserved by block/scale decision."""
+        reduced_fraction = max(1.0 - scale_factor, 0.0)
+        return float(signal_size) * float(current_drawdown) * reduced_fraction

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -1,0 +1,86 @@
+"""Tests for market regime semantic guard."""
+
+import json
+
+import pytest
+
+from apps.nurse.enforcer import NurseEnforcer
+from apps.nurse.guard import RegimeGuard
+
+
+class FakeRedis:
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+    async def get(self, key: str):
+        _ = key
+        return json.dumps(self.payload)
+
+
+@pytest.mark.asyncio
+async def test_regime_guard_blocks_trade_on_drawdown_limit():
+    guard = RegimeGuard(
+        redis_client=FakeRedis(
+            {
+                "current_regime": "bearish",
+                "vol_threshold_breach": False,
+                "drawdown_limit_exceeded": True,
+                "current_drawdown": 0.05,
+            }
+        )
+    )
+
+    decision = await guard.evaluate({"action": "buy", "quantity": 2.0})
+
+    assert decision.approved is False
+    assert decision.veto_reason == "drawdown_limit_exceeded"
+    assert decision.metadata["current_regime"] == "bearish"
+    assert decision.saved_capital == pytest.approx(0.1)
+
+
+@pytest.mark.asyncio
+async def test_enforcer_scales_position_on_volatility_breach():
+    guard = RegimeGuard(
+        redis_client=FakeRedis(
+            {
+                "current_regime": "high_vol",
+                "vol_threshold_breach": True,
+                "drawdown_limit_exceeded": False,
+                "current_drawdown": 0.02,
+                "scale_down_factor": 0.4,
+            }
+        )
+    )
+    enforcer = NurseEnforcer(regime_guard=guard)
+
+    result = await enforcer.enforce({"action": "buy", "quantity": 5.0})
+
+    assert result.approved is True
+    assert result.metadata is not None
+    assert result.metadata["current_regime"] == "high_vol"
+    assert result.metadata["scale_factor"] == pytest.approx(0.4)
+    assert result.metadata["scaled_quantity"] == pytest.approx(2.0)
+    assert result.metadata["saved_capital"] == pytest.approx(0.06)
+
+
+@pytest.mark.asyncio
+async def test_enforcer_returns_semantic_veto_metadata_when_blocked():
+    guard = RegimeGuard(
+        redis_client=FakeRedis(
+            {
+                "current_regime": "drawdown",
+                "vol_threshold_breach": False,
+                "drawdown_limit_exceeded": True,
+                "current_drawdown": 0.03,
+            }
+        )
+    )
+    enforcer = NurseEnforcer(regime_guard=guard)
+
+    result = await enforcer.enforce({"action": "sell", "quantity": 4.0})
+
+    assert result.approved is False
+    assert result.reason == "drawdown_limit_exceeded"
+    assert result.metadata is not None
+    assert result.metadata["veto_type"] == "semantic"
+    assert result.metadata["saved_capital"] == pytest.approx(0.12)


### PR DESCRIPTION
## Summary
- add `apps/nurse/guard.py` with `RegimePolicy` model and semantic regime evaluation from Redis key `policy:regime`
- enforce semantic veto on drawdown limit breach and partial scale-down on volatility breach
- add saved-capital calculation for shadow ROI metadata (`calculate_saved_capital`)
- integrate `RegimeGuard` into `NurseEnforcer`, including `scale_position_size` helper and semantic veto metadata
- propagate semantic guard metadata into interceptor audit documents (`veto_type`, regime metadata, `pnl_metadata.saved_capital`)
- extend tests for guard behavior and semantic veto audit output

## Validation
- `.venv/bin/python -m ruff format apps/nurse/guard.py apps/nurse/enforcer.py core/nats/interceptor.py tests/test_guard.py tests/test_interceptor.py`
- `.venv/bin/python -m ruff check apps/nurse/guard.py apps/nurse/enforcer.py core/nats/interceptor.py tests/test_guard.py tests/test_interceptor.py`
- `.venv/bin/python -m pytest tests/test_guard.py tests/test_interceptor.py tests/test_heartbeat.py tests/test_contracts.py tests/test_probe.py -q`

Closes #5
