### PR TITLE
[CIO-STRATEGIST] MCP Discovery of Existing Schemas

### DIFF
--- a/apps/strategist/__init__.py
+++ b/apps/strategist/__init__.py
@@ -1,0 +1,1 @@
+"""Strategist application modules."""

--- a/apps/strategist/defaults.py
+++ b/apps/strategist/defaults.py
@@ -1,0 +1,43 @@
+"""Default strategist governance schemas exposed via MCP tools."""
+
+from pydantic import BaseModel, Field
+
+
+class RiskLimits(BaseModel):
+    """Risk limits controlling exposure and drawdown safeguards."""
+
+    max_drawdown_pct: float = Field(
+        0.2,
+        ge=0.0,
+        le=1.0,
+        description="Maximum tolerated portfolio drawdown in fraction format.",
+    )
+    max_position_size_pct: float = Field(
+        0.1,
+        ge=0.0,
+        le=1.0,
+        description="Upper bound for a single position as fraction of capital.",
+    )
+    volatility_scale_threshold: float = Field(
+        0.03,
+        ge=0.0,
+        description="Volatility breach threshold that triggers position scaling.",
+    )
+
+
+class ExecutionPolicy(BaseModel):
+    """Execution policy for strategist-directed trade orchestration."""
+
+    allowed_modes: list[str] = Field(
+        default_factory=lambda: ["deterministic", "ml_light"],
+        description="Strategy modes allowed for autonomous execution.",
+    )
+    require_manual_approval: bool = Field(
+        False,
+        description="Whether manual approval is required before publishing signals.",
+    )
+    heartbeat_timeout_ms: int = Field(
+        200,
+        ge=10,
+        description="Heartbeat timeout used by downstream services for fail-safe mode.",
+    )

--- a/apps/strategist/mcp_server.py
+++ b/apps/strategist/mcp_server.py
@@ -1,0 +1,120 @@
+"""MCP-compatible strategist server with dynamic schema tools."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from typing import Any
+
+from core.config_manager import ConfigManager
+from core.utils.schema_parser import generate_tools
+
+
+def validate_thought_trace(
+    fn: Callable[..., Awaitable[dict[str, Any]]],
+) -> Callable[..., Awaitable[dict[str, Any]]]:
+    @wraps(fn)
+    async def wrapper(self: MCPServer, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        arguments = kwargs.get("arguments") or {}
+        thought_trace = str(arguments.get("thought_trace", ""))
+        if len(thought_trace) < 100:
+            raise ValueError("thought_trace must be at least 100 characters")
+        return await fn(self, *args, **kwargs)
+
+    return wrapper
+
+
+class MCPServer:
+    """Minimal MCP JSON-RPC server supporting stdio transport."""
+
+    def __init__(
+        self,
+        *,
+        module_path: str = "apps.strategist.defaults",
+        config_manager: ConfigManager | None = None,
+    ):
+        self.module_path = module_path
+        self.config_manager = config_manager or ConfigManager()
+        self.tools = generate_tools(module_path)
+        self.tools_by_name = {tool["name"]: tool for tool in self.tools}
+
+    async def handle_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        method = request.get("method")
+        params = request.get("params") or {}
+        request_id = request.get("id")
+
+        try:
+            if method == "initialize":
+                result = {"protocolVersion": "2026-02", "server": "petrosa-cio-mcp"}
+            elif method == "tools/list":
+                result = {"tools": self.tools}
+            elif method == "tools/call":
+                result = await self._call_tool(params)
+            else:
+                raise ValueError(f"unsupported method: {method}")
+
+            return {"jsonrpc": "2.0", "id": request_id, "result": result}
+        except Exception as exc:
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32000, "message": str(exc)},
+            }
+
+    async def _call_tool(self, params: dict[str, Any]) -> dict[str, Any]:
+        tool_name = params.get("name")
+        arguments = params.get("arguments") or {}
+
+        if tool_name not in self.tools_by_name:
+            raise ValueError(f"unknown tool: {tool_name}")
+
+        if tool_name.startswith("get_"):
+            return await self._handle_get(tool_name)
+
+        if tool_name.startswith("set_"):
+            return await self._handle_set(tool_name, arguments=arguments)
+
+        raise ValueError(f"unsupported tool: {tool_name}")
+
+    async def _handle_get(self, tool_name: str) -> dict[str, Any]:
+        model_name = tool_name.removeprefix("get_")
+        return {
+            "model": model_name,
+            "config": self.config_manager.get_config(model_name),
+        }
+
+    @validate_thought_trace
+    async def _handle_set(
+        self,
+        tool_name: str,
+        *,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        model_name = tool_name.removeprefix("set_")
+        payload = arguments.get("payload")
+        if not isinstance(payload, dict):
+            raise ValueError("payload must be an object")
+
+        audit = await self.config_manager.set_config(
+            model_name,
+            payload,
+            thought_trace=arguments["thought_trace"],
+        )
+        return {"model": model_name, "updated": True, "audit": audit}
+
+    async def run_stdio(self) -> None:
+        """Run JSON-RPC loop over stdin/stdout (one JSON request per line)."""
+        while True:
+            line = await asyncio.to_thread(input)
+            if not line:
+                continue
+
+            request = json.loads(line)
+            response = await self.handle_request(request)
+            print(json.dumps(response), flush=True)
+
+
+def create_server(module_path: str = "apps.strategist.defaults") -> MCPServer:
+    return MCPServer(module_path=module_path)

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -1,0 +1,39 @@
+"""Configuration manager for strategist MCP tool operations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+
+class ConfigManager:
+    """In-memory config manager with optional MongoDB audit persistence."""
+
+    def __init__(self, audit_collection: Any | None = None):
+        self.audit_collection = audit_collection
+        self._configs: dict[str, dict[str, Any]] = {}
+
+    def get_config(self, model_name: str) -> dict[str, Any] | None:
+        return self._configs.get(model_name)
+
+    async def set_config(
+        self,
+        model_name: str,
+        payload: dict[str, Any],
+        *,
+        thought_trace: str,
+        actor: str = "mcp_strategist",
+    ) -> dict[str, Any]:
+        document = {
+            "model": model_name,
+            "payload": payload,
+            "thought_trace": thought_trace,
+            "actor": actor,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+        self._configs[model_name] = payload
+
+        if self.audit_collection is not None:
+            await self.audit_collection.insert_one(document)
+
+        return document

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utility modules."""

--- a/core/utils/schema_parser.py
+++ b/core/utils/schema_parser.py
@@ -1,0 +1,73 @@
+"""Dynamic reflection helpers for generating MCP tool definitions."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def _is_pydantic_model(candidate: Any) -> bool:
+    return (
+        inspect.isclass(candidate)
+        and issubclass(candidate, BaseModel)
+        and candidate is not BaseModel
+    )
+
+
+def discover_schema_models(module_path: str) -> dict[str, type[BaseModel]]:
+    module = importlib.import_module(module_path)
+    models: dict[str, type[BaseModel]] = {}
+
+    for name, obj in inspect.getmembers(module, _is_pydantic_model):
+        if obj.__module__ == module.__name__:
+            models[name] = obj
+
+    return models
+
+
+def generate_tools(module_path: str) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+
+    for name, model in discover_schema_models(module_path).items():
+        schema = model.model_json_schema()
+        description = inspect.getdoc(model) or f"Schema tool for {name}"
+
+        tools.append(
+            {
+                "name": f"get_{name}",
+                "description": f"Read current {name} config. {description}",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                },
+                "model": name,
+                "mode": "read",
+            }
+        )
+
+        tools.append(
+            {
+                "name": f"set_{name}",
+                "description": f"Update {name} config. {description}",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "payload": schema,
+                        "thought_trace": {
+                            "type": "string",
+                            "minLength": 100,
+                            "description": "Required reasoning trace for audit.",
+                        },
+                    },
+                    "required": ["payload", "thought_trace"],
+                },
+                "model": name,
+                "mode": "write",
+            }
+        )
+
+    return tools

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,0 +1,49 @@
+# MCP Tools
+
+This document describes MCP tools exposed by `apps/strategist/mcp_server.py`.
+
+## Transport
+- JSON-RPC via STDIO (`MCPServer.run_stdio`) for local desktop integration.
+
+## Discovery
+- Tool definitions are generated dynamically from Pydantic models in `apps/strategist/defaults.py`.
+- Every model produces:
+  - `get_<ModelName>`
+  - `set_<ModelName>`
+
+## Write Guard (`thought_trace`)
+All write tools (`set_*`) require:
+- `thought_trace` string
+- Minimum length: `100` characters
+
+If missing or shorter than 100 chars, the call is rejected.
+
+## Audit Link
+Every successful `set_*` call persists an audit document through `ConfigManager` including:
+- `model`
+- `payload`
+- `thought_trace`
+- `actor`
+- `updated_at`
+
+When configured with Mongo collection, this audit document is stored for retrospective reviews.
+
+## Example Call
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "set_RiskLimits",
+    "arguments": {
+      "payload": {
+        "max_drawdown_pct": 0.15,
+        "max_position_size_pct": 0.08,
+        "volatility_scale_threshold": 0.025
+      },
+      "thought_trace": "...at least 100 characters of reasoning explaining why this configuration update is safe..."
+    }
+  }
+}
+```

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,92 @@
+"""Tests for strategist MCP server behavior."""
+
+import pytest
+
+from apps.strategist.mcp_server import MCPServer
+from core.config_manager import ConfigManager
+
+
+class FakeCollection:
+    def __init__(self):
+        self.documents = []
+
+    async def insert_one(self, document):
+        self.documents.append(document)
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_lists_tools_from_defaults_models():
+    server = MCPServer()
+
+    response = await server.handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    )
+
+    assert "result" in response
+    names = {tool["name"] for tool in response["result"]["tools"]}
+    assert "get_RiskLimits" in names
+    assert "set_RiskLimits" in names
+
+
+@pytest.mark.asyncio
+async def test_set_tool_rejects_short_thought_trace():
+    server = MCPServer()
+
+    response = await server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "set_RiskLimits",
+                "arguments": {
+                    "payload": {
+                        "max_drawdown_pct": 0.2,
+                        "max_position_size_pct": 0.1,
+                        "volatility_scale_threshold": 0.03,
+                    },
+                    "thought_trace": "too short",
+                },
+            },
+        }
+    )
+
+    assert "error" in response
+    assert "thought_trace" in response["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_set_tool_persists_thought_trace_to_audit_collection():
+    collection = FakeCollection()
+    config_manager = ConfigManager(audit_collection=collection)
+    server = MCPServer(config_manager=config_manager)
+
+    trace = (
+        "The update reduces risk concentration by lowering drawdown and position limits "
+        "while preserving deterministic execution behavior under current volatility."
+    )
+
+    response = await server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "set_RiskLimits",
+                "arguments": {
+                    "payload": {
+                        "max_drawdown_pct": 0.15,
+                        "max_position_size_pct": 0.08,
+                        "volatility_scale_threshold": 0.025,
+                    },
+                    "thought_trace": trace,
+                },
+            },
+        }
+    )
+
+    assert "result" in response
+    assert response["result"]["updated"] is True
+    assert len(collection.documents) == 1
+    assert collection.documents[0]["thought_trace"] == trace
+    assert collection.documents[0]["model"] == "RiskLimits"

--- a/tests/test_schema_parser.py
+++ b/tests/test_schema_parser.py
@@ -1,0 +1,25 @@
+"""Tests for dynamic MCP schema tool generation."""
+
+from core.utils.schema_parser import discover_schema_models, generate_tools
+
+
+def test_discover_schema_models_from_defaults_module():
+    models = discover_schema_models("apps.strategist.defaults")
+
+    assert "RiskLimits" in models
+    assert "ExecutionPolicy" in models
+
+
+def test_generate_tools_builds_read_and_write_tool_pairs():
+    tools = generate_tools("apps.strategist.defaults")
+    names = {tool["name"] for tool in tools}
+
+    assert "get_RiskLimits" in names
+    assert "set_RiskLimits" in names
+    assert "get_ExecutionPolicy" in names
+    assert "set_ExecutionPolicy" in names
+
+    set_risk_limits = next(tool for tool in tools if tool["name"] == "set_RiskLimits")
+    assert "thought_trace" in set_risk_limits["input_schema"]["properties"]
+    assert "payload" in set_risk_limits["input_schema"]["required"]
+    assert "thought_trace" in set_risk_limits["input_schema"]["required"]


### PR DESCRIPTION
## Summary
- add strategist defaults schemas in `apps/strategist/defaults.py` and expose them for MCP reflection
- add dynamic schema parser in `core/utils/schema_parser.py` to generate `get_*` and `set_*` MCP tool definitions from Pydantic models
- implement MCP JSON-RPC server in `apps/strategist/mcp_server.py` with stdio loop (`initialize`, `tools/list`, `tools/call`)
- enforce mandatory `thought_trace` (min 100 chars) for all write tools using `validate_thought_trace`
- add `core/config_manager.py` with config update + audit persistence path for thought traces (Mongo collection supported)
- document tool catalog and write-guard rules in `docs/MCP_TOOLS.md`
- add tests for schema reflection and MCP write/audit behavior

## Validation
- `.venv/bin/python -m ruff format apps/strategist/defaults.py apps/strategist/mcp_server.py core/config_manager.py core/utils/schema_parser.py tests/test_schema_parser.py tests/test_mcp_server.py`
- `.venv/bin/python -m ruff check apps/strategist/defaults.py apps/strategist/mcp_server.py core/config_manager.py core/utils/schema_parser.py tests/test_schema_parser.py tests/test_mcp_server.py`
- `.venv/bin/python -m pytest tests/test_schema_parser.py tests/test_mcp_server.py tests/test_guard.py tests/test_interceptor.py tests/test_heartbeat.py tests/test_contracts.py tests/test_probe.py -q`

Closes #6
