### PR TITLE
[CIO-STRATEGIST] Audit Snapshots & Rollback Engine

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -1,20 +1,48 @@
-"""Configuration manager for strategist MCP tool operations."""
+"""Configuration manager with snapshot and rollback support."""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Callable
+from uuid import uuid4
+
+from apps.nurse.enforcer import ConfigSnapshotter
+
+PayloadValidator = Callable[[str, dict[str, Any]], dict[str, Any]]
 
 
 class ConfigManager:
-    """In-memory config manager with optional MongoDB audit persistence."""
+    """Config manager with optional MongoDB/Redis side effects."""
 
-    def __init__(self, audit_collection: Any | None = None):
+    def __init__(
+        self,
+        audit_collection: Any | None = None,
+        history_collection: Any | None = None,
+        redis_client: Any | None = None,
+        payload_validator: PayloadValidator | None = None,
+    ):
         self.audit_collection = audit_collection
+        self.snapshotter = ConfigSnapshotter(history_collection=history_collection)
+        self.redis_client = redis_client
+        self.payload_validator = payload_validator
         self._configs: dict[str, dict[str, Any]] = {}
+        self._audit_events: list[dict[str, Any]] = []
+
+    def set_payload_validator(self, validator: PayloadValidator) -> None:
+        self.payload_validator = validator
 
     def get_config(self, model_name: str) -> dict[str, Any] | None:
         return self._configs.get(model_name)
+
+    async def _persist_audit(self, document: dict[str, Any]) -> None:
+        self._audit_events.append(document)
+        if self.audit_collection is not None:
+            await self.audit_collection.insert_one(document)
+
+    def _validate(self, model_name: str, payload: dict[str, Any]) -> dict[str, Any]:
+        if self.payload_validator is None:
+            return payload
+        return self.payload_validator(model_name, payload)
 
     async def set_config(
         self,
@@ -24,16 +52,79 @@ class ConfigManager:
         thought_trace: str,
         actor: str = "mcp_strategist",
     ) -> dict[str, Any]:
+        validated_payload = self._validate(model_name, payload)
+        previous = self._configs.get(model_name)
+
+        audit_id = str(uuid4())
+        if previous is not None:
+            await self.snapshotter.snapshot(
+                model_name=model_name,
+                payload=previous,
+                source_audit_id=audit_id,
+            )
+
+        self._configs[model_name] = validated_payload
+
         document = {
+            "audit_id": audit_id,
+            "event_type": "config_update",
             "model": model_name,
-            "payload": payload,
+            "payload": validated_payload,
             "thought_trace": thought_trace,
             "actor": actor,
             "updated_at": datetime.now(UTC).isoformat(),
         }
-        self._configs[model_name] = payload
-
-        if self.audit_collection is not None:
-            await self.audit_collection.insert_one(document)
+        await self._persist_audit(document)
 
         return document
+
+    async def rollback_to_version(
+        self,
+        audit_id: str,
+        *,
+        reason: str,
+        actor: str = "mcp_strategist",
+    ) -> dict[str, Any]:
+        target = next(
+            (
+                event
+                for event in reversed(self._audit_events)
+                if event.get("audit_id") == audit_id
+            ),
+            None,
+        )
+        if target is None:
+            raise ValueError(f"audit_id not found: {audit_id}")
+
+        if target.get("event_type") not in {"config_update", "config_rollback"}:
+            raise ValueError("target audit event is not rollback-capable")
+
+        model_name = target["model"]
+        current_payload = self._configs.get(model_name)
+
+        if current_payload is not None:
+            await self.snapshotter.snapshot(
+                model_name=model_name,
+                payload=current_payload,
+                source_audit_id=audit_id,
+            )
+
+        rollback_payload = self._validate(model_name, target["payload"])
+        self._configs[model_name] = rollback_payload
+
+        if self.redis_client is not None:
+            await self.redis_client.delete(f"policy:{model_name}")
+
+        rollback_event = {
+            "audit_id": str(uuid4()),
+            "event_type": "config_rollback",
+            "model": model_name,
+            "payload": rollback_payload,
+            "rolled_back_to_audit_id": audit_id,
+            "rollback_reason": reason,
+            "actor": actor,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+        await self._persist_audit(rollback_event)
+
+        return rollback_event

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -10,6 +10,8 @@ This document describes MCP tools exposed by `apps/strategist/mcp_server.py`.
 - Every model produces:
   - `get_<ModelName>`
   - `set_<ModelName>`
+- Additional control tool:
+  - `rollback_to_version`
 
 ## Write Guard (`thought_trace`)
 All write tools (`set_*`) require:
@@ -27,6 +29,13 @@ Every successful `set_*` call persists an audit document through `ConfigManager`
 - `updated_at`
 
 When configured with Mongo collection, this audit document is stored for retrospective reviews.
+
+`rollback_to_version` also emits an audited event with:
+- `event_type: config_rollback`
+- `rolled_back_to_audit_id`
+- `rollback_reason`
+
+During rollback, the manager flushes Redis policy cache for the affected key (`policy:<ModelName>`).
 
 ## Example Call
 ```json

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14,6 +14,14 @@ class FakeCollection:
         self.documents.append(document)
 
 
+class FakeRedis:
+    def __init__(self):
+        self.deleted_keys = []
+
+    async def delete(self, key: str):
+        self.deleted_keys.append(key)
+
+
 @pytest.mark.asyncio
 async def test_mcp_server_lists_tools_from_defaults_models():
     server = MCPServer()
@@ -26,6 +34,7 @@ async def test_mcp_server_lists_tools_from_defaults_models():
     names = {tool["name"] for tool in response["result"]["tools"]}
     assert "get_RiskLimits" in names
     assert "set_RiskLimits" in names
+    assert "rollback_to_version" in names
 
 
 @pytest.mark.asyncio
@@ -90,3 +99,83 @@ async def test_set_tool_persists_thought_trace_to_audit_collection():
     assert len(collection.documents) == 1
     assert collection.documents[0]["thought_trace"] == trace
     assert collection.documents[0]["model"] == "RiskLimits"
+
+
+@pytest.mark.asyncio
+async def test_rollback_tool_restores_previous_version_and_logs_event():
+    audit_collection = FakeCollection()
+    history_collection = FakeCollection()
+    redis = FakeRedis()
+    config_manager = ConfigManager(
+        audit_collection=audit_collection,
+        history_collection=history_collection,
+        redis_client=redis,
+    )
+    server = MCPServer(config_manager=config_manager)
+
+    trace = "a" * 120
+    first = await server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "set_RiskLimits",
+                "arguments": {
+                    "payload": {
+                        "max_drawdown_pct": 0.2,
+                        "max_position_size_pct": 0.1,
+                        "volatility_scale_threshold": 0.03,
+                    },
+                    "thought_trace": trace,
+                },
+            },
+        }
+    )
+    _ = first
+    second = await server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "set_RiskLimits",
+                "arguments": {
+                    "payload": {
+                        "max_drawdown_pct": 0.12,
+                        "max_position_size_pct": 0.07,
+                        "volatility_scale_threshold": 0.02,
+                    },
+                    "thought_trace": trace,
+                },
+            },
+        }
+    )
+
+    # Snapshot should be created before applying the second patch.
+    assert len(history_collection.documents) == 1
+
+    target_audit_id = second["result"]["audit"]["audit_id"]
+
+    rollback = await server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "rollback_to_version",
+                "arguments": {
+                    "audit_id": target_audit_id,
+                    "reason": "restore known safe profile",
+                },
+            },
+        }
+    )
+
+    assert rollback["result"]["rolled_back"] is True
+    assert rollback["result"]["event"]["event_type"] == "config_rollback"
+    assert (
+        rollback["result"]["event"]["rollback_reason"] == "restore known safe profile"
+    )
+    assert history_collection.documents != []
+    assert redis.deleted_keys == ["policy:RiskLimits"]


### PR DESCRIPTION
## Summary
- add pre-patch snapshotting support through `ConfigSnapshotter` integration in `ConfigManager`
- persist config snapshots to history collection before applying updates and before rollback actions
- add `rollback_to_version` in `ConfigManager` with rollback audit events and `rollback_reason`
- flush Redis policy cache key for affected model on rollback (`policy:<ModelName>`)
- add MCP tool `rollback_to_version` in strategist server
- add payload validation on set/rollback using discovered Pydantic model schemas
- update MCP docs with rollback behavior and cache flush notes
- extend tests to verify snapshot creation, rollback audit integrity, and Redis `DEL` call

## Validation
- `.venv/bin/python -m ruff check apps/nurse/enforcer.py core/config_manager.py apps/strategist/mcp_server.py tests/test_mcp_server.py --fix`
- `.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_schema_parser.py tests/test_guard.py tests/test_interceptor.py tests/test_heartbeat.py tests/test_contracts.py tests/test_probe.py -q`

Closes #7
