### PR TITLE
[CIO-ALERTS] Triple-Redundant Alerting & Distiller

### DIFF
--- a/apps/nurse/alert_distiller.py
+++ b/apps/nurse/alert_distiller.py
@@ -1,0 +1,95 @@
+"""Signal distillation for bursty alert streams."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from core.alerting.manager import AlertEvent
+
+
+@dataclass(slots=True)
+class _Bucket:
+    template: AlertEvent
+    first_ts: float
+    last_ts: float
+    count: int
+
+
+class AlertDistiller:
+    """Aggregates repetitive alerts into summary notifications."""
+
+    def __init__(self, aggregation_window_seconds: int = 300):
+        self.aggregation_window_seconds = aggregation_window_seconds
+        self._buckets: dict[str, _Bucket] = {}
+
+    @staticmethod
+    def _key(event: AlertEvent) -> str:
+        return "|".join(
+            [
+                event.source,
+                event.category,
+                event.severity,
+                event.symbol or "",
+                event.message,
+            ]
+        )
+
+    def ingest(self, event: AlertEvent, now: float | None = None) -> None:
+        now_ts = now if now is not None else time.time()
+        key = self._key(event)
+
+        if key not in self._buckets:
+            self._buckets[key] = _Bucket(
+                template=event,
+                first_ts=now_ts,
+                last_ts=now_ts,
+                count=1,
+            )
+            return
+
+        bucket = self._buckets[key]
+        bucket.last_ts = now_ts
+        bucket.count += 1
+
+    def flush(
+        self, now: float | None = None, *, force: bool = False
+    ) -> list[AlertEvent]:
+        now_ts = now if now is not None else time.time()
+        emitted: list[AlertEvent] = []
+        to_delete: list[str] = []
+
+        for key, bucket in self._buckets.items():
+            elapsed = now_ts - bucket.last_ts
+            if not force and elapsed < self.aggregation_window_seconds:
+                continue
+
+            template = bucket.template
+            if bucket.count == 1:
+                emitted.append(template)
+            else:
+                summary_context = dict(template.context)
+                summary_context[
+                    "aggregation_window_seconds"
+                ] = self.aggregation_window_seconds
+                emitted.append(
+                    AlertEvent(
+                        source=template.source,
+                        category=template.category,
+                        message=(
+                            f"Summary Alert: {bucket.count} similar events for "
+                            f"{template.symbol or 'global'} - {template.message}"
+                        ),
+                        severity=template.severity,
+                        symbol=template.symbol,
+                        count=bucket.count,
+                        context=summary_context,
+                    )
+                )
+
+            to_delete.append(key)
+
+        for key in to_delete:
+            del self._buckets[key]
+
+        return emitted

--- a/core/alerting/__init__.py
+++ b/core/alerting/__init__.py
@@ -1,0 +1,1 @@
+"""Alerting modules."""

--- a/core/alerting/manager.py
+++ b/core/alerting/manager.py
@@ -1,0 +1,138 @@
+"""Triple-redundant alerting manager and channels."""
+
+from __future__ import annotations
+
+import smtplib
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from email.message import EmailMessage
+from enum import StrEnum
+from typing import Any
+
+from prometheus_client import CollectorRegistry, Counter
+
+from otel_init import get_tracer
+
+
+class AlertSeverity(StrEnum):
+    """Alert severities for governance and system failures."""
+
+    INFO = "INFO"
+    WARNING = "WARNING"
+    CRITICAL = "CRITICAL"
+
+
+@dataclass(slots=True)
+class AlertEvent:
+    """Canonical alert payload sent to all channels."""
+
+    source: str
+    category: str
+    message: str
+    severity: AlertSeverity
+    symbol: str | None = None
+    count: int = 1
+    context: dict[str, Any] = field(default_factory=dict)
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+class AlertChannel:
+    """Channel interface."""
+
+    async def send(self, event: AlertEvent) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class OtelChannel(AlertChannel):
+    """OpenTelemetry span-based alert channel."""
+
+    def __init__(self, tracer_name: str = "core.alerting.manager"):
+        self.tracer = get_tracer(tracer_name)
+
+    async def send(self, event: AlertEvent) -> None:
+        with self.tracer.start_as_current_span("cio.alert.dispatch") as span:
+            span.set_attribute("alert.source", event.source)
+            span.set_attribute("alert.category", event.category)
+            span.set_attribute("alert.severity", event.severity)
+            span.set_attribute("alert.message", event.message)
+            span.set_attribute("alert.count", event.count)
+            if event.symbol is not None:
+                span.set_attribute("alert.symbol", event.symbol)
+            if event.context.get("trace_id"):
+                span.set_attribute("alert.trace_id", str(event.context["trace_id"]))
+            if event.context.get("reasoning_trace"):
+                span.set_attribute(
+                    "alert.reasoning_trace", str(event.context["reasoning_trace"])
+                )
+            if event.context.get("audit_log_url"):
+                span.set_attribute(
+                    "alert.audit_log_url", str(event.context["audit_log_url"])
+                )
+
+
+class GrafanaChannel(AlertChannel):
+    """Prometheus metric counter channel for Grafana alerting."""
+
+    def __init__(self, registry: CollectorRegistry | None = None):
+        self.counter = Counter(
+            "cio_alert_events_total",
+            "Total alert events emitted by CIO alert manager",
+            ["severity", "category", "source"],
+            registry=registry,
+        )
+
+    async def send(self, event: AlertEvent) -> None:
+        self.counter.labels(
+            severity=event.severity,
+            category=event.category,
+            source=event.source,
+        ).inc(event.count)
+
+
+class EmailChannel(AlertChannel):
+    """SMTP channel for critical/human-facing alert messages."""
+
+    def __init__(
+        self,
+        *,
+        smtp_host: str,
+        smtp_port: int,
+        sender: str,
+        recipients: list[str],
+        smtp_factory: Any = smtplib.SMTP,
+    ):
+        self.smtp_host = smtp_host
+        self.smtp_port = smtp_port
+        self.sender = sender
+        self.recipients = recipients
+        self.smtp_factory = smtp_factory
+
+    async def send(self, event: AlertEvent) -> None:
+        msg = EmailMessage()
+        msg["Subject"] = f"[{event.severity}] {event.category}"
+        msg["From"] = self.sender
+        msg["To"] = ", ".join(self.recipients)
+        body = [
+            f"message: {event.message}",
+            f"source: {event.source}",
+            f"severity: {event.severity}",
+            f"trace_id: {event.context.get('trace_id', '')}",
+            f"reasoning_trace: {event.context.get('reasoning_trace', '')}",
+            f"audit_log_url: {event.context.get('audit_log_url', '')}",
+            f"count: {event.count}",
+        ]
+        msg.set_content("\n".join(body))
+
+        with self.smtp_factory(self.smtp_host, self.smtp_port) as smtp:
+            smtp.send_message(msg)
+
+
+class AlertManager:
+    """Dispatches alerts to all configured channels."""
+
+    def __init__(self, channels: list[AlertChannel]):
+        self.channels = channels
+
+    async def dispatch(self, event: AlertEvent) -> None:
+        for channel in self.channels:
+            await channel.send(event)

--- a/core/monitoring/__init__.py
+++ b/core/monitoring/__init__.py
@@ -1,0 +1,1 @@
+"""Monitoring modules."""

--- a/core/monitoring/heartbeat_watcher.py
+++ b/core/monitoring/heartbeat_watcher.py
@@ -1,0 +1,55 @@
+"""Heartbeat watchdog that emits critical alerts after stale intervals."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from core.alerting.manager import AlertEvent, AlertManager, AlertSeverity
+
+
+class HeartbeatWatcher:
+    """Monitors heartbeat recency and triggers CRITICAL alerts on timeout."""
+
+    def __init__(
+        self,
+        *,
+        alert_manager: AlertManager,
+        stale_after_seconds: int = 60,
+        clock: Any = time.time,
+    ):
+        self.alert_manager = alert_manager
+        self.stale_after_seconds = stale_after_seconds
+        self.clock = clock
+        self.last_heartbeat_ts: float | None = None
+        self.last_critical_alert_ts: float | None = None
+
+    def record_heartbeat(self) -> None:
+        self.last_heartbeat_ts = float(self.clock())
+
+    async def check_health(self) -> bool:
+        now = float(self.clock())
+        if self.last_heartbeat_ts is None:
+            return True
+
+        elapsed = now - self.last_heartbeat_ts
+        if elapsed <= self.stale_after_seconds:
+            return True
+
+        if self.last_critical_alert_ts is None or (
+            now - self.last_critical_alert_ts >= self.stale_after_seconds
+        ):
+            event = AlertEvent(
+                source="heartbeat_watcher",
+                category="system_health",
+                message=(
+                    "Heartbeat stale for more than "
+                    f"{self.stale_after_seconds} seconds"
+                ),
+                severity=AlertSeverity.CRITICAL,
+                context={"stale_seconds": int(elapsed)},
+            )
+            await self.alert_manager.dispatch(event)
+            self.last_critical_alert_ts = now
+
+        return False

--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -1,0 +1,154 @@
+"""Tests for alert manager channels and distillation."""
+
+import pytest
+from prometheus_client import CollectorRegistry
+
+from apps.nurse.alert_distiller import AlertDistiller
+from core.alerting.manager import (
+    AlertEvent,
+    AlertManager,
+    AlertSeverity,
+    EmailChannel,
+    GrafanaChannel,
+    OtelChannel,
+)
+from core.monitoring.heartbeat_watcher import HeartbeatWatcher
+
+
+class FakeSMTP:
+    def __init__(self, host: str, port: int):
+        self.host = host
+        self.port = port
+        self.sent_messages = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        _ = exc_type, exc, tb
+        return False
+
+    def send_message(self, msg):
+        self.sent_messages.append(msg)
+
+
+class SMTPFactory:
+    def __init__(self):
+        self.instances = []
+
+    def __call__(self, host: str, port: int):
+        instance = FakeSMTP(host, port)
+        self.instances.append(instance)
+        return instance
+
+
+class RecordingChannel:
+    def __init__(self):
+        self.events = []
+
+    async def send(self, event: AlertEvent):
+        self.events.append(event)
+
+
+@pytest.mark.asyncio
+async def test_multi_channel_dispatch_includes_context_fields():
+    smtp_factory = SMTPFactory()
+    registry = CollectorRegistry()
+
+    otel_channel = OtelChannel()
+    grafana_channel = GrafanaChannel(registry=registry)
+    email_channel = EmailChannel(
+        smtp_host="localhost",
+        smtp_port=25,
+        sender="cio@example.com",
+        recipients=["ops@example.com"],
+        smtp_factory=smtp_factory,
+    )
+
+    manager = AlertManager([otel_channel, grafana_channel, email_channel])
+    event = AlertEvent(
+        source="nurse",
+        category="semantic_veto",
+        message="Trade vetoed by regime guard",
+        severity=AlertSeverity.WARNING,
+        symbol="BTCUSDT",
+        context={
+            "trace_id": "abc123",
+            "reasoning_trace": "Detailed reasoning trace from strategist",
+            "audit_log_url": "https://audit.local/log/1",
+        },
+    )
+
+    await manager.dispatch(event)
+
+    metric = grafana_channel.counter.labels(
+        severity=event.severity,
+        category=event.category,
+        source=event.source,
+    )
+    assert metric._value.get() == pytest.approx(1.0)  # noqa: SLF001
+
+    assert len(smtp_factory.instances) == 1
+    sent = smtp_factory.instances[0].sent_messages[0]
+    body = sent.get_content()
+    assert "abc123" in body
+    assert "Detailed reasoning trace" in body
+    assert "https://audit.local/log/1" in body
+
+
+@pytest.mark.asyncio
+async def test_distiller_groups_similar_events_into_summary_alert():
+    distiller = AlertDistiller(aggregation_window_seconds=300)
+
+    for _ in range(50):
+        distiller.ingest(
+            AlertEvent(
+                source="nurse",
+                category="semantic_veto",
+                message="Trade vetoed by regime guard",
+                severity=AlertSeverity.WARNING,
+                symbol="BTCUSDT",
+                context={
+                    "trace_id": "tid-1",
+                    "reasoning_trace": "trace",
+                    "audit_log_url": "https://audit.local/log/2",
+                },
+            ),
+            now=1000.0,
+        )
+
+    emitted = distiller.flush(now=1301.0)
+
+    assert len(emitted) == 1
+    summary = emitted[0]
+    assert summary.count == 50
+    assert "Summary Alert" in summary.message
+    assert summary.context["trace_id"] == "tid-1"
+    assert summary.context["audit_log_url"] == "https://audit.local/log/2"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_watcher_triggers_critical_alert_after_timeout():
+    recording = RecordingChannel()
+    manager = AlertManager([recording])
+
+    now = 1000.0
+
+    def clock():
+        return now
+
+    watcher = HeartbeatWatcher(
+        alert_manager=manager,
+        stale_after_seconds=60,
+        clock=clock,
+    )
+
+    watcher.record_heartbeat()
+
+    assert await watcher.check_health() is True
+
+    now = 1065.0
+    assert await watcher.check_health() is False
+    assert len(recording.events) == 1
+    assert recording.events[0].severity == AlertSeverity.CRITICAL
+    assert "Heartbeat stale" in recording.events[0].message


### PR DESCRIPTION
## Summary
- add triple-channel alerting core in `core/alerting/manager.py` with:
  - `OtelChannel` (span-based dispatch)
  - `GrafanaChannel` (Prometheus counters for Grafana)
  - `EmailChannel` (SMTP notifications)
  - `AlertManager` orchestrator and canonical `AlertEvent`
- add `apps/nurse/alert_distiller.py` to aggregate repetitive veto events into summary alerts (5-minute window)
- add `core/monitoring/heartbeat_watcher.py` that emits CRITICAL alerts when heartbeat is stale for >60s
- include context propagation fields (`trace_id`, `reasoning_trace`, `audit_log_url`) in dispatched alerts
- add tests for multi-channel dispatch, distillation behavior, and heartbeat timeout alerting

## Validation
- `.venv/bin/python -m ruff format core/alerting/manager.py apps/nurse/alert_distiller.py core/monitoring/heartbeat_watcher.py tests/test_alerting.py`
- `.venv/bin/python -m ruff check tests/test_alerting.py --fix`
- `.venv/bin/python -m pytest tests/test_alerting.py tests/test_mcp_server.py tests/test_schema_parser.py tests/test_guard.py tests/test_interceptor.py tests/test_heartbeat.py tests/test_contracts.py tests/test_probe.py -q`

Closes #8
