### PR TITLE
[CIO-CANARY] Standalone Nuclear Option

### DIFF
--- a/canary/encrypt_keys.py
+++ b/canary/encrypt_keys.py
@@ -1,0 +1,73 @@
+"""Encrypt Binance API credentials into keys.json.enc using OpenSSL AES-256-CBC."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import subprocess
+import tempfile
+
+
+def encrypt_payload(payload: dict[str, str], passphrase: str, output_path: str) -> None:
+    with tempfile.NamedTemporaryFile("w", delete=False) as plain_file:
+        json.dump(payload, plain_file)
+        plain_path = plain_file.name
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as pass_file:
+        pass_file.write(passphrase)
+        pass_path = pass_file.name
+
+    try:
+        subprocess.run(
+            [
+                "openssl",
+                "enc",
+                "-aes-256-cbc",
+                "-pbkdf2",
+                "-salt",
+                "-in",
+                plain_path,
+                "-out",
+                output_path,
+                "-pass",
+                f"file:{pass_path}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.remove(plain_path)
+        os.remove(pass_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Encrypt Binance credentials")
+    parser.add_argument("--output", default="keys.json.enc")
+    parser.add_argument("--api-key", required=True)
+    parser.add_argument("--secret", required=True)
+    parser.add_argument("--password", default="")
+    parser.add_argument("--testnet", action="store_true")
+    args = parser.parse_args(argv)
+
+    passphrase = getpass.getpass("Passphrase: ")
+    confirm = getpass.getpass("Confirm passphrase: ")
+    if passphrase != confirm:
+        raise ValueError("Passphrases do not match")
+
+    payload = {
+        "apiKey": args.api_key,
+        "secret": args.secret,
+        "password": args.password,
+        "testnet": args.testnet,
+    }
+
+    encrypt_payload(payload, passphrase, args.output)
+    print(f"Encrypted keys saved to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/canary/nuclear_option.py
+++ b/canary/nuclear_option.py
@@ -1,0 +1,238 @@
+"""Standalone emergency close-all script for Binance spot + futures.
+
+This file intentionally avoids any internal petrosa imports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class CloseAction:
+    market: str
+    symbol: str
+    side: str
+    amount: float
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Emergency close-all command")
+    parser.add_argument(
+        "--keys-file",
+        default="keys.json.enc",
+        help="Path to encrypted credentials file",
+    )
+    parser.add_argument(
+        "--passphrase-env",
+        default="NUCLEAR_PASSPHRASE",
+        help="Environment variable containing decryption passphrase",
+    )
+    parser.add_argument(
+        "--rate-limit-ms",
+        type=int,
+        default=200,
+        help="Delay between order submissions",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=5,
+        help="Orders to submit per batch before sleeping",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="List actions without placing orders (default behavior)",
+    )
+    parser.add_argument(
+        "--force-execute",
+        action="store_true",
+        help="Actually place close-all market orders",
+    )
+    return parser.parse_args(argv)
+
+
+def decrypt_keys(keys_file: str, passphrase: str) -> dict[str, Any]:
+    with tempfile.NamedTemporaryFile("w", delete=False) as pass_file:
+        pass_file.write(passphrase)
+        pass_file_path = pass_file.name
+
+    try:
+        result = subprocess.run(
+            [
+                "openssl",
+                "enc",
+                "-d",
+                "-aes-256-cbc",
+                "-pbkdf2",
+                "-in",
+                keys_file,
+                "-pass",
+                f"file:{pass_file_path}",
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError("Failed to decrypt keys.json.enc") from exc
+    finally:
+        os.remove(pass_file_path)
+
+    return json.loads(result.stdout)
+
+
+def build_exchange(credentials: dict[str, Any], market: str):
+    import ccxt  # Imported lazily so dry unit tests do not require exchange setup.
+
+    options = {
+        "apiKey": credentials["apiKey"],
+        "secret": credentials["secret"],
+        "enableRateLimit": True,
+    }
+
+    if credentials.get("password"):
+        options["password"] = credentials["password"]
+
+    if market == "futures":
+        options["options"] = {"defaultType": "future"}
+
+    exchange = ccxt.binance(options)
+    if credentials.get("testnet"):
+        exchange.set_sandbox_mode(True)
+    return exchange
+
+
+def fetch_all_positions(spot_exchange: Any, futures_exchange: Any) -> list[CloseAction]:
+    actions: list[CloseAction] = []
+
+    balances = spot_exchange.fetch_balance()
+    markets = spot_exchange.load_markets()
+    for asset, amount_info in balances.get("total", {}).items():
+        amount = float(amount_info or 0)
+        if amount <= 0:
+            continue
+        symbol = f"{asset}/USDT"
+        if symbol not in markets or asset == "USDT":
+            continue
+        actions.append(
+            CloseAction(market="spot", symbol=symbol, side="sell", amount=amount)
+        )
+
+    futures_positions = futures_exchange.fetch_positions()
+    for pos in futures_positions:
+        contracts = float(pos.get("contracts") or 0)
+        if contracts == 0:
+            continue
+        symbol = pos["symbol"]
+        side = "sell" if contracts > 0 else "buy"
+        actions.append(
+            CloseAction(
+                market="futures",
+                symbol=symbol,
+                side=side,
+                amount=abs(contracts),
+            )
+        )
+
+    return actions
+
+
+def market_close_all(
+    actions: list[CloseAction],
+    *,
+    spot_exchange: Any,
+    futures_exchange: Any,
+    dry_run: bool,
+    batch_size: int,
+    rate_limit_ms: int,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+
+    for idx, action in enumerate(actions, start=1):
+        exchange = spot_exchange if action.market == "spot" else futures_exchange
+
+        if dry_run:
+            results.append(
+                {
+                    "status": "dry_run",
+                    "market": action.market,
+                    "symbol": action.symbol,
+                    "side": action.side,
+                    "amount": action.amount,
+                }
+            )
+        else:
+            order = exchange.create_order(
+                action.symbol,
+                "market",
+                action.side,
+                action.amount,
+            )
+            results.append(
+                {
+                    "status": "executed",
+                    "market": action.market,
+                    "symbol": action.symbol,
+                    "side": action.side,
+                    "amount": action.amount,
+                    "order_id": order.get("id"),
+                }
+            )
+
+        if idx % max(batch_size, 1) == 0:
+            time.sleep(max(rate_limit_ms, 0) / 1000.0)
+
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    execute = args.force_execute
+    dry_run = not execute
+
+    passphrase = os.getenv(args.passphrase_env)
+    if not passphrase:
+        print(
+            f"Missing passphrase env var: {args.passphrase_env}",
+            file=sys.stderr,
+        )
+        return 2
+
+    credentials = decrypt_keys(args.keys_file, passphrase)
+    spot_exchange = build_exchange(credentials, market="spot")
+    futures_exchange = build_exchange(credentials, market="futures")
+
+    actions = fetch_all_positions(spot_exchange, futures_exchange)
+    print(f"Discovered {len(actions)} close actions")
+
+    results = market_close_all(
+        actions,
+        spot_exchange=spot_exchange,
+        futures_exchange=futures_exchange,
+        dry_run=dry_run,
+        batch_size=args.batch_size,
+        rate_limit_ms=args.rate_limit_ms,
+    )
+
+    print(json.dumps(results, indent=2))
+
+    if dry_run:
+        print("Dry-run mode completed. Use --force-execute to place orders.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/EMERGENCY_OPERATIONS.md
+++ b/docs/EMERGENCY_OPERATIONS.md
@@ -1,0 +1,45 @@
+# Emergency Operations: Nuclear Option
+
+## Purpose
+`canary/nuclear_option.py` is a standalone emergency script to close all spot and USD-M futures positions when CIO/K8s/NATS are unavailable.
+
+## Safety Model
+- Default behavior is **dry-run**.
+- Real execution requires explicit `--force-execute`.
+- Credentials are read from encrypted `keys.json.enc`.
+- Encryption/decryption uses OpenSSL AES-256-CBC (`openssl enc`).
+
+## 1. Encrypt Keys Locally
+```bash
+python canary/encrypt_keys.py \
+  --api-key "<BINANCE_API_KEY>" \
+  --secret "<BINANCE_SECRET>" \
+  --testnet \
+  --output keys.json.enc
+```
+
+## 2. Dry-Run (Mandatory First Step)
+```bash
+export NUCLEAR_PASSPHRASE='<your-passphrase>'
+python canary/nuclear_option.py --keys-file keys.json.enc
+```
+
+Expected behavior:
+- Lists all spot and futures close actions.
+- Does not submit orders.
+
+## 3. Force Execute (Emergency Only)
+```bash
+export NUCLEAR_PASSPHRASE='<your-passphrase>'
+python canary/nuclear_option.py \
+  --keys-file keys.json.enc \
+  --force-execute \
+  --batch-size 5 \
+  --rate-limit-ms 200
+```
+
+## Operational Notes
+- Script has no internal `petrosa-*` imports.
+- Exchange dependency: `ccxt` only.
+- System dependency: `openssl` binary (for encrypted vault operations).
+- Use Binance Testnet first before any production run.

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,6 @@ redis>=5.0.0
 structlog>=24.1.0
 
 # Utilities
+ccxt==4.5.40
 tenacity>=8.2.0
 uvicorn[standard]>=0.27.0

--- a/tests/test_nuclear_option.py
+++ b/tests/test_nuclear_option.py
@@ -1,0 +1,158 @@
+"""Tests for standalone nuclear option canary scripts."""
+
+import json
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+from canary.encrypt_keys import encrypt_payload
+from canary.nuclear_option import (
+    CloseAction,
+    decrypt_keys,
+    fetch_all_positions,
+    main,
+    market_close_all,
+)
+
+
+class FakeExchange:
+    def __init__(self, *, balances=None, markets=None, positions=None):
+        self._balances = balances or {}
+        self._markets = markets or {}
+        self._positions = positions or []
+        self.orders = []
+
+    def fetch_balance(self):
+        return {"total": self._balances}
+
+    def load_markets(self):
+        return self._markets
+
+    def fetch_positions(self):
+        return self._positions
+
+    def create_order(self, symbol, order_type, side, amount):
+        self.orders.append((symbol, order_type, side, amount))
+        return {"id": f"order-{len(self.orders)}"}
+
+
+def test_encrypt_decrypt_roundtrip_keys_file():
+    payload = {"apiKey": "k", "secret": "s", "password": "p", "testnet": True}
+    passphrase = "strong-passphrase"
+
+    with tempfile.NamedTemporaryFile("wb", delete=False) as tmp:
+        path = tmp.name
+
+    try:
+        encrypt_payload(payload, passphrase, path)
+        decrypted = decrypt_keys(path, passphrase)
+    finally:
+        os.remove(path)
+
+    assert decrypted == payload
+
+
+def test_decrypt_keys_raises_on_invalid_ciphertext():
+    with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+        tmp.write("not encrypted")
+        path = tmp.name
+
+    try:
+        with pytest.raises(ValueError):
+            decrypt_keys(path, "bad")
+    finally:
+        os.remove(path)
+
+
+def test_fetch_all_positions_collects_spot_and_futures_actions():
+    spot = FakeExchange(
+        balances={"BTC": 0.5, "USDT": 1200, "ETH": 0.0},
+        markets={"BTC/USDT": {}, "ETH/USDT": {}},
+    )
+    futures = FakeExchange(
+        positions=[
+            {"symbol": "BTC/USDT:USDT", "contracts": 2},
+            {"symbol": "ETH/USDT:USDT", "contracts": -3},
+            {"symbol": "SOL/USDT:USDT", "contracts": 0},
+        ]
+    )
+
+    actions = fetch_all_positions(spot, futures)
+
+    assert CloseAction("spot", "BTC/USDT", "sell", 0.5) in actions
+    assert CloseAction("futures", "BTC/USDT:USDT", "sell", 2.0) in actions
+    assert CloseAction("futures", "ETH/USDT:USDT", "buy", 3.0) in actions
+
+
+def test_market_close_all_dry_run_default_no_orders():
+    spot = FakeExchange()
+    futures = FakeExchange()
+    actions = [CloseAction("spot", "BTC/USDT", "sell", 1.0)]
+
+    result = market_close_all(
+        actions,
+        spot_exchange=spot,
+        futures_exchange=futures,
+        dry_run=True,
+        batch_size=1,
+        rate_limit_ms=0,
+    )
+
+    assert result[0]["status"] == "dry_run"
+    assert spot.orders == []
+
+
+def test_market_close_all_force_execute_places_orders():
+    spot = FakeExchange()
+    futures = FakeExchange()
+    actions = [
+        CloseAction("spot", "BTC/USDT", "sell", 1.0),
+        CloseAction("futures", "ETH/USDT:USDT", "buy", 2.0),
+    ]
+
+    result = market_close_all(
+        actions,
+        spot_exchange=spot,
+        futures_exchange=futures,
+        dry_run=False,
+        batch_size=10,
+        rate_limit_ms=0,
+    )
+
+    assert result[0]["status"] == "executed"
+    assert result[1]["status"] == "executed"
+    assert spot.orders == [("BTC/USDT", "market", "sell", 1.0)]
+    assert futures.orders == [("ETH/USDT:USDT", "market", "buy", 2.0)]
+
+
+def test_main_requires_passphrase_env(monkeypatch):
+    monkeypatch.delenv("NUCLEAR_PASSPHRASE", raising=False)
+
+    code = main(["--keys-file", "nonexistent.json.enc"])
+    assert code == 2
+
+
+def test_encrypt_payload_invokes_openssl(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, check, capture_output, text):
+        captured["cmd"] = cmd
+        assert check is True
+        assert capture_output is True
+        assert text is True
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    with tempfile.NamedTemporaryFile("wb", delete=False) as tmp:
+        out = tmp.name
+
+    try:
+        encrypt_payload({"apiKey": "k", "secret": "s"}, "pw", out)
+    finally:
+        os.remove(out)
+
+    assert captured["cmd"][0] == "openssl"
+    assert "-aes-256-cbc" in captured["cmd"]


### PR DESCRIPTION
## Summary
- add standalone emergency script `canary/nuclear_option.py` with zero internal petrosa imports
- implement encrypted vault decryption from local `keys.json.enc` using OpenSSL AES-256-CBC + passphrase env var
- implement position discovery for spot + USD-M futures (`fetch_all_positions`) and close action planning
- implement market close execution with batching/rate-limit controls
- enforce simulation-first behavior: dry-run default, execution only via `--force-execute`
- add key encryption utility `canary/encrypt_keys.py`
- add emergency runbook `docs/EMERGENCY_OPERATIONS.md`
- add tests for encryption/decryption roundtrip, position discovery, dry-run safety, force-execution paths, and passphrase guard
- pin `ccxt` to stable version in requirements

## Validation
- `.venv/bin/python -m ruff format canary/nuclear_option.py canary/encrypt_keys.py tests/test_nuclear_option.py`
- `.venv/bin/python -m ruff check canary/nuclear_option.py canary/encrypt_keys.py tests/test_nuclear_option.py`
- `.venv/bin/python -m pytest tests/test_nuclear_option.py tests/test_alerting.py tests/test_mcp_server.py tests/test_schema_parser.py tests/test_guard.py tests/test_interceptor.py tests/test_heartbeat.py tests/test_contracts.py tests/test_probe.py -q`

Closes #9
