### PR TITLE
infra: add k8s manifests for petrosa-cio

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: petrosa-cio-config
+  namespace: petrosa-apps
+  labels:
+    app: cio
+    component: governance
+data:
+  ENVIRONMENT: "production"
+  LOG_LEVEL: "INFO"
+  API_PORT: "8000"
+  ENABLE_OTEL: "true"
+  OTEL_SERVICE_VERSION: "1.0.0"
+  NATS_URL: "nats://petrosa-nats:4222"
+  REDIS_URL: "redis://petrosa-redis:6379"
+  MONGO_URL: "mongodb://petrosa-mongo:27017"
+  LLM_PROVIDER: "openai"
+  LLM_USE_MOCK: "false"
+  NURSE_USE_LLM_REASONING: "false"
+  MCP_USE_LLM: "false"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: petrosa-cio
+  namespace: petrosa-apps
+  labels:
+    app: cio
+    component: governance
+    version: VERSION_PLACEHOLDER
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: cio
+  template:
+    metadata:
+      labels:
+        app: cio
+        component: governance
+        version: VERSION_PLACEHOLDER
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "2026-02-28T00:00:00Z"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: default
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+      - name: cio
+        image: yurisa2/petrosa-cio:VERSION_PLACEHOLDER
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+        - name: metrics
+          containerPort: 9090
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: petrosa-common-config
+        - configMapRef:
+            name: petrosa-cio-config
+        env:
+        - name: ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-cio-config
+              key: ENVIRONMENT
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-cio-config
+              key: LOG_LEVEL
+
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "150m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+
+        livenessProbe:
+          httpGet:
+            path: /health/liveness
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /health/readiness
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: petrosa-cio
+  namespace: petrosa-apps
+  labels:
+    app: cio
+    component: governance
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8000
+    protocol: TCP
+  - name: metrics
+    port: 9090
+    targetPort: 9090
+    protocol: TCP
+  selector:
+    app: cio


### PR DESCRIPTION
## Summary
- Add k8s manifests for petrosa-cio service (deployment, service, configmap)
- Follows standard petrosa-k8s pattern used by other services

## Changes
- `k8s/deployment.yaml` - Kubernetes deployment with standard configuration
- `k8s/service.yaml` - ClusterIP service for internal access
- `k8s/configmap.yaml` - Environment configuration

## Acceptance Criteria
- [x] k8s manifests created in local repo
- [ ] Sync manifests to petrosa_k8s hub (separate PR)
- [ ] Verify deployment via centralized hub

Refs: #29