### PR TITLE
fix: use GitHub App token for gitops checkout

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -260,12 +260,20 @@ jobs:
     needs: [build-and-push, prepare-release]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
+      - name: Generate GitOps Bot Token
+        uses: tibdex/github-app-token@v2
+        id: generate-token
+        with:
+          app_id: ${{ secrets.GITOPS_APP_ID }}
+          installation_id: ${{ secrets.GITOPS_APP_INSTALLATION_ID }}
+          private_key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+
       - name: Checkout petrosa_k8s
         uses: actions/checkout@v4
         with:
           repository: PetroSa2/petrosa_k8s
           ref: main
-          token: ${{ secrets.GITOPS_BOT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: petrosa_k8s
 
       - name: Rebase on main

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -77,12 +77,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Generate GitOps Bot Token
+        uses: tibdex/github-app-token@v2
+        id: generate-token
+        with:
+          app_id: ${{ secrets.GITOPS_APP_ID }}
+          installation_id: ${{ secrets.GITOPS_APP_INSTALLATION_ID }}
+          private_key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+
       - name: Checkout petrosa_k8s
         uses: actions/checkout@v4
         with:
           repository: PetroSa2/petrosa_k8s
           ref: main
-          token: ${{ secrets.GITOPS_BOT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: petrosa_k8s
 
       - name: Rebase on main


### PR DESCRIPTION
## Summary
- Add `tibdex/github-app-token@v2` step to generate token from GitHub App credentials
- Replace `GITOPS_BOT_TOKEN` secret reference with dynamically generated token
- Fixes the "Input required and not supplied: token" error in GitHub Actions

## Problem
The GitOps workflow was failing with:
```
Error: Input required and not supplied: token
```

## Solution
Use the GitHub App credentials to generate a fresh token on each run.