### PR TITLE
fix: handle 'No regime data available' in metadata

### DIFF
--- a/cio/core/context_builder.py
+++ b/cio/core/context_builder.py
@@ -149,14 +149,19 @@ class ContextBuilder:
             response.raise_for_status()
 
             data = response.json()
-            # Defensive check: Data Manager sometimes returns 200 OK with an error message body
-            if "message" in data and "No regime data" in data["message"]:
+            # Defensive check: Data Manager returns 200 OK with an error message in metadata
+            metadata = data.get("metadata", {})
+            if (
+                metadata
+                and "message" in metadata
+                and "No regime data" in metadata["message"]
+            ):
                 return RegimeResult(
                     regime="choppy",
                     regime_confidence="low",
                     volatility_level=VolatilityLevel.MEDIUM,
                     primary_signal="data_manager_empty",
-                    thought_trace=f"Data Manager reports: {data['message']}",
+                    thought_trace=f"Data Manager reports: {metadata['message']}",
                 )
 
             api_resp = RegimeAPIResponse.model_validate(data)

--- a/tests/unit/test_cold_path.py
+++ b/tests/unit/test_cold_path.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -83,5 +83,42 @@ async def test_context_builder_cold_path_retrieval():
 
     assert ctx_hot.historical_context is None
     mock_vector.query.assert_not_called()
+
+    await builder.close()
+
+
+@pytest.mark.asyncio
+async def test_context_builder_handles_no_regime_data_in_metadata():
+    """
+    Verifies that ContextBuilder handles 'No regime data available' message
+    when it's nested in the metadata block (not at top level).
+    """
+    # 1. Setup
+    builder = ContextBuilder(
+        data_manager_url="http://dm",
+        tradeengine_url="http://te",
+    )
+
+    # Mock HTTP response that returns 200 OK with error in metadata
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "pair": "BTCUSDT",
+        "metric": "regime",
+        "data": None,
+        "metadata": {"message": "No regime data available"},
+    }
+
+    builder.client.get = AsyncMock(return_value=mock_response)
+
+    # 2. Test the regime fetch
+    result = await builder._fetch_regime("BTCUSDT", "test-correlation")
+
+    # 3. Assertions - should return safe default, not raise validation error
+    assert result.regime == "choppy"
+    assert result.regime_confidence == "low"
+    assert result.volatility_level == VolatilityLevel.MEDIUM
+    assert result.primary_signal == "data_manager_empty"
+    assert "No regime data available" in result.thought_trace
 
     await builder.close()


### PR DESCRIPTION
Fixes Pydantic validation error when market regime is unavailable. Handles the nested message in metadata block.