### PR TITLE
chore: comment out broken pyupio/safety pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,15 +52,15 @@ repos:
         exclude: ^tests/
 
   # ==================================================================
-  # SECURITY - Dependency Check (Safety)
+  # SECURITY - Dependency Check (Safety) — optional; see petrosa_k8s template
   # ==================================================================
-  - repo: https://github.com/pyupio/safety
-    rev: v3.0.1
-    hooks:
-      - id: safety
-        name: 🔐 Safety (Dependency Scan)
-        args: [check, --full-report]
-        files: ^requirements\.txt$
+  # - repo: https://github.com/pyupio/safety
+  #   rev: 3.0.1
+  #   hooks:
+  #     - id: safety
+  #       name: 🔐 Safety (Dependency Scan)
+  #       args: [check, --full-report]
+  #       files: ^requirements\.txt$
 
   # ==================================================================
   # LINTING - YAML & TOML


### PR DESCRIPTION
Aligns with `petrosa_k8s` template: the `pyupio/safety` repo is not a valid pre-commit hook source at `rev: v3.0.1` (checkout fails locally and blocks push). Dependency scanning remains available via `requirements-dev.txt` / CI as elsewhere in Petrosa.

Made with [Cursor](https://cursor.com)