### PR TITLE
[BUG][P0] Fix CIO LLM validation: response_format, schema fallback, and validation counter (#79)

### DIFF
--- a/cio/clients/llm_client.py
+++ b/cio/clients/llm_client.py
@@ -42,6 +42,15 @@ class CIO_LLM_Client(ABC):
         """
         pass
 
+    async def _schema_fallback(
+        self, prompt_id: str, system_prompt: str, user_context: dict[str, Any]
+    ) -> "RawLLMResponse | None":
+        """
+        Override in subclass to provide a fallback LLM call on schema validation failure.
+        Returns None if no fallback is available.
+        """
+        return None
+
     async def complete_with_schema(
         self,
         prompt_id: str,
@@ -78,13 +87,46 @@ class CIO_LLM_Client(ABC):
 
             return response_model.model_validate_json(content)
         except (ValidationError, json.JSONDecodeError) as e:
+            # Record metric
+            try:
+                from cio.core.metrics import LLM_VALIDATION_FAILURES
+
+                LLM_VALIDATION_FAILURES.labels(
+                    prompt_id=prompt_id, model=raw.model
+                ).inc()
+            except ImportError:
+                pass
+
             logger.warning(
-                "LLM response validation failed — returning safe default",
+                "LLM response validation failed — attempting schema fallback",
                 extra={
                     "prompt_id": prompt_id,
                     "error": str(e),
                     "content_preview": raw.content[:200],
                 },
+            )
+
+            # 4. Schema-failure fallback: retry with fallback model
+            fallback_raw = await self._schema_fallback(
+                prompt_id, system_prompt, user_context
+            )
+            if fallback_raw and not fallback_raw.error:
+                try:
+                    fb_content = fallback_raw.content.strip()
+                    if fb_content.startswith("```"):
+                        lines = fb_content.splitlines()
+                        if len(lines) >= 2:
+                            fb_content = "\n".join(lines[1:-1])
+                    return response_model.model_validate_json(fb_content)
+                except (ValidationError, json.JSONDecodeError) as fb_e:
+                    logger.warning(
+                        "LLM schema fallback also failed — returning safe default",
+                        extra={"prompt_id": prompt_id, "error": str(fb_e)},
+                    )
+
+            logger.warning(
+                "LLM response validation failed — returning safe default",
+                extra={"prompt_id": prompt_id},
             )
             return SAFE_DEFAULTS[prompt_id]
 
@@ -206,8 +248,9 @@ class LiteLLMClient(CIO_LLM_Client):
                         ],
                         response_format=(
                             {"type": "json_object"}
-                            if "json_object"
-                            in litellm.get_supported_openai_params(primary_model)
+                            if api_base
+                            or "json_object"
+                            in litellm.get_supported_openai_params(routing_primary)
                             else None
                         ),
                     )
@@ -235,8 +278,9 @@ class LiteLLMClient(CIO_LLM_Client):
                     ],
                     response_format=(
                         {"type": "json_object"}
-                        if "json_object"
-                        in litellm.get_supported_openai_params(fallback_model)
+                        if api_base
+                        or "json_object"
+                        in litellm.get_supported_openai_params(routing_fallback)
                         else None
                     ),
                 )
@@ -267,6 +311,51 @@ class LiteLLMClient(CIO_LLM_Client):
                     latency_ms=latency_ms,
                     timestamp=datetime.now(UTC),
                 )
+
+    async def _schema_fallback(
+        self, prompt_id: str, system_prompt: str, user_context: dict[str, Any]
+    ) -> "RawLLMResponse | None":
+        """
+        Retries with the fallback model when the primary model returns invalid JSON.
+        Called by complete_with_schema on ValidationError / JSONDecodeError.
+        """
+        import litellm
+
+        fallback_model = os.getenv("LLM_FALLBACK_MODEL", DEFAULT_FALLBACK_MODEL)
+        api_base = os.getenv("LLM_API_BASE")
+        routing_fallback = f"openai/{fallback_model}" if api_base else fallback_model
+
+        logger.info(
+            "Schema fallback: retrying with fallback model",
+            extra={"prompt_id": prompt_id, "model": fallback_model},
+        )
+
+        try:
+            start_time = time.perf_counter()
+            response = await litellm.acompletion(
+                model=routing_fallback,
+                api_base=api_base,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": json.dumps(user_context)},
+                ],
+                response_format=(
+                    {"type": "json_object"}
+                    if api_base
+                    or "json_object"
+                    in litellm.get_supported_openai_params(routing_fallback)
+                    else None
+                ),
+            )
+            return self._process_response(
+                prompt_id, response, int((time.perf_counter() - start_time) * 1000)
+            )
+        except Exception as e:
+            logger.warning(
+                "Schema fallback call failed",
+                extra={"prompt_id": prompt_id, "error": str(e)},
+            )
+            return None
 
     async def embed(self, text: str) -> list[float]:
         """Generates real embeddings via litellm.embedding."""

--- a/cio/clients/llm_client.py
+++ b/cio/clients/llm_client.py
@@ -78,12 +78,12 @@ class CIO_LLM_Client(ABC):
             content = raw.content.strip()
             # Handle potential markdown wrapping
             if content.startswith("```"):
-                # Find first and last newline to extract content between markers
                 lines = content.splitlines()
-                if len(lines) >= 2:
-                    # Remove first line (```json or ```) and last line (```)
-                    # Join middle lines
-                    content = "\n".join(lines[1:-1])
+                # Drop opening fence line, then closing fence only if present
+                inner = lines[1:]
+                if inner and inner[-1].strip() == "```":
+                    inner = inner[:-1]
+                content = "\n".join(inner)
 
             return response_model.model_validate_json(content)
         except (ValidationError, json.JSONDecodeError) as e:
@@ -115,10 +115,21 @@ class CIO_LLM_Client(ABC):
                     fb_content = fallback_raw.content.strip()
                     if fb_content.startswith("```"):
                         lines = fb_content.splitlines()
-                        if len(lines) >= 2:
-                            fb_content = "\n".join(lines[1:-1])
+                        # Drop opening fence line, then closing fence only if present
+                        inner = lines[1:]
+                        if inner and inner[-1].strip() == "```":
+                            inner = inner[:-1]
+                        fb_content = "\n".join(inner)
                     return response_model.model_validate_json(fb_content)
                 except (ValidationError, json.JSONDecodeError) as fb_e:
+                    try:
+                        from cio.core.metrics import LLM_VALIDATION_FAILURES
+
+                        LLM_VALIDATION_FAILURES.labels(
+                            prompt_id=prompt_id, model=fallback_raw.model
+                        ).inc()
+                    except ImportError:
+                        pass
                     logger.warning(
                         "LLM schema fallback also failed — returning safe default",
                         extra={"prompt_id": prompt_id, "error": str(fb_e)},

--- a/cio/core/metrics.py
+++ b/cio/core/metrics.py
@@ -17,3 +17,10 @@ DECISION_ACTIONS = Counter(
     "Total number of final decisions by action type",
     ["action_type", "strategy_id"],
 )
+
+# LLM Validation Failures
+LLM_VALIDATION_FAILURES = Counter(
+    "cio_llm_validation_failures_total",
+    "Total number of LLM response schema validation failures",
+    ["prompt_id", "model"],
+)

--- a/tests/unit/test_llm_client.py
+++ b/tests/unit/test_llm_client.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for LiteLLMClient fixes:
+  - AC2: fallback model fires on schema/validation failure
+  - AC1: response_format=json_object set when api_base is present
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from cio.clients.llm_client import LiteLLMClient
+from cio.models import RawLLMResponse
+
+# ---------------------------------------------------------------------------
+# Minimal response model for testing
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse(BaseModel):
+    value: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build RawLLMResponse fixtures
+# ---------------------------------------------------------------------------
+
+
+def _raw(content: str, model: str = "test-model", error: str | None = None):
+    return RawLLMResponse(
+        prompt_id="PETROSA_PROMPT_ACTION_CLASSIFIER",
+        content=content,
+        error=error,
+        model=model,
+        input_tokens=10,
+        output_tokens=10,
+        latency_ms=50,
+        timestamp=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC2: schema fallback fires when primary returns invalid JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schema_fallback_called_on_validation_failure():
+    """
+    When complete() returns non-JSON content, _schema_fallback() must be called
+    and its valid response must be returned instead of SAFE_DEFAULTS.
+    """
+    client = LiteLLMClient()
+
+    valid_json = '{"value": "ok"}'
+
+    # Primary: returns malformed JSON → triggers ValidationError / JSONDecodeError
+    client.complete = AsyncMock(return_value=_raw("NOT_JSON"))
+    # Fallback: returns valid JSON
+    client._schema_fallback = AsyncMock(
+        return_value=_raw(valid_json, model="fallback-model")
+    )
+
+    result = await client.complete_with_schema(
+        prompt_id="PETROSA_PROMPT_ACTION_CLASSIFIER",
+        system_prompt="sys",
+        user_context={},
+        response_model=_FakeResponse,
+    )
+
+    client._schema_fallback.assert_awaited_once()
+    assert isinstance(result, _FakeResponse)
+    assert result.value == "ok"
+
+
+@pytest.mark.asyncio
+async def test_safe_defaults_returned_when_both_models_fail():
+    """
+    When primary AND fallback both produce invalid JSON, SAFE_DEFAULTS is returned.
+    """
+    from cio.models import SAFE_DEFAULTS
+
+    client = LiteLLMClient()
+
+    client.complete = AsyncMock(return_value=_raw("BAD_PRIMARY"))
+    client._schema_fallback = AsyncMock(
+        return_value=_raw("BAD_FALLBACK", model="fallback-model")
+    )
+
+    result = await client.complete_with_schema(
+        prompt_id="PETROSA_PROMPT_ACTION_CLASSIFIER",
+        system_prompt="sys",
+        user_context={},
+        response_model=_FakeResponse,
+    )
+
+    assert result == SAFE_DEFAULTS["PETROSA_PROMPT_ACTION_CLASSIFIER"]
+
+
+@pytest.mark.asyncio
+async def test_safe_defaults_returned_when_fallback_not_available():
+    """
+    When _schema_fallback returns None (e.g. MockLLMClient), SAFE_DEFAULTS is returned.
+    """
+    from cio.models import SAFE_DEFAULTS
+
+    client = LiteLLMClient()
+
+    client.complete = AsyncMock(return_value=_raw("NOT_JSON"))
+    client._schema_fallback = AsyncMock(return_value=None)
+
+    result = await client.complete_with_schema(
+        prompt_id="PETROSA_PROMPT_ACTION_CLASSIFIER",
+        system_prompt="sys",
+        user_context={},
+        response_model=_FakeResponse,
+    )
+
+    assert result == SAFE_DEFAULTS["PETROSA_PROMPT_ACTION_CLASSIFIER"]
+
+
+# ---------------------------------------------------------------------------
+# AC1: response_format set unconditionally when api_base is present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_response_format_json_set_when_api_base_present():
+    """
+    When LLM_API_BASE is set (Requesty proxy), response_format=json_object must be
+    passed to litellm.acompletion regardless of litellm.get_supported_openai_params().
+    """
+    client = LiteLLMClient()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = '{"value": "proxy_ok"}'
+    mock_response.model = "openai/novita/llama-3.1-8b"
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 10
+    mock_response.usage.prompt_tokens_details = None
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "LLM_API_BASE": "https://router.requesty.ai/v1",
+                "LLM_MODEL": "novita/llama-3.1-8b",
+            },
+        ),
+        patch(
+            "litellm.acompletion", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_acompletion,
+    ):
+        await client.complete(
+            prompt_id="test",
+            system_prompt="sys",
+            user_context={},
+        )
+
+    call_kwargs = mock_acompletion.call_args.kwargs
+    assert call_kwargs.get("response_format") == {"type": "json_object"}, (
+        f"Expected json_object response_format, got: {call_kwargs.get('response_format')}"
+    )

--- a/tests/unit/test_llm_client.py
+++ b/tests/unit/test_llm_client.py
@@ -163,3 +163,113 @@ async def test_response_format_json_set_when_api_base_present():
     assert call_kwargs.get("response_format") == {"type": "json_object"}, (
         f"Expected json_object response_format, got: {call_kwargs.get('response_format')}"
     )
+
+
+# ---------------------------------------------------------------------------
+# LiteLLMClient._schema_fallback: direct implementation coverage
+# ---------------------------------------------------------------------------
+
+
+def _mock_litellm_response(content: str, model: str = "openai/fallback"):
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = content
+    resp.model = model
+    resp.usage.prompt_tokens = 10
+    resp.usage.completion_tokens = 10
+    resp.usage.prompt_tokens_details = None
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_schema_fallback_returns_raw_response_via_litellm():
+    """
+    LiteLLMClient._schema_fallback calls litellm.acompletion with the
+    fallback model and returns a RawLLMResponse with the content.
+    """
+    client = LiteLLMClient()
+    mock_resp = _mock_litellm_response('{"value": "fallback_ok"}')
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "LLM_API_BASE": "https://router.requesty.ai/v1",
+                "LLM_FALLBACK_MODEL": "novita/llama-3.1-8b",
+            },
+        ),
+        patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_resp),
+    ):
+        result = await client._schema_fallback(
+            prompt_id="PETROSA_PROMPT_ACTION_CLASSIFIER",
+            system_prompt="sys",
+            user_context={},
+        )
+
+    assert result is not None
+    assert result.error is None
+    assert '{"value": "fallback_ok"}' in result.content
+
+
+@pytest.mark.asyncio
+async def test_schema_fallback_returns_none_on_litellm_exception():
+    """
+    If litellm raises during _schema_fallback, the method returns None
+    rather than propagating the exception.
+    """
+    client = LiteLLMClient()
+
+    with patch(
+        "litellm.acompletion", new_callable=AsyncMock, side_effect=RuntimeError("boom")
+    ):
+        result = await client._schema_fallback(
+            prompt_id="PETROSA_PROMPT_ACTION_CLASSIFIER",
+            system_prompt="sys",
+            user_context={},
+        )
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Fence stripping: with and without closing fence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fence_stripping_with_closing_fence():
+    """Content wrapped in ```json ... ``` is correctly unwrapped."""
+    client = LiteLLMClient()
+    fenced = '```json\n{"value": "fenced"}\n```'
+    client.complete = AsyncMock(return_value=_raw(fenced))
+    client._schema_fallback = AsyncMock(return_value=None)
+
+    result = await client.complete_with_schema(
+        prompt_id="PETROSA_PROMPT_ACTION_CLASSIFIER",
+        system_prompt="sys",
+        user_context={},
+        response_model=_FakeResponse,
+    )
+
+    assert isinstance(result, _FakeResponse)
+    assert result.value == "fenced"
+
+
+@pytest.mark.asyncio
+async def test_fence_stripping_without_closing_fence():
+    """Content with opening ``` but no closing fence still parses correctly."""
+    client = LiteLLMClient()
+    # No closing fence — last line is part of JSON, must NOT be stripped
+    fenced = '```json\n{"value": "no_close"}'
+    client.complete = AsyncMock(return_value=_raw(fenced))
+    client._schema_fallback = AsyncMock(return_value=None)
+
+    result = await client.complete_with_schema(
+        prompt_id="PETROSA_PROMPT_ACTION_CLASSIFIER",
+        system_prompt="sys",
+        user_context={},
+        response_model=_FakeResponse,
+    )
+
+    assert isinstance(result, _FakeResponse)
+    assert result.value == "no_close"


### PR DESCRIPTION
## Summary

Fixes three compounding bugs that caused ~75% of CIO LLM calls to silently return SAFE_DEFAULTS, resulting in `final decision: skip` dominating.

- **Fix response_format detection**: When `LLM_API_BASE` is set (Requesty proxy), `response_format={"type": "json_object"}` is now set unconditionally. Previously `get_supported_openai_params()` was called with the bare model name instead of the `openai/`-prefixed routing name, so JSON mode was never activated.
- **Schema-failure fallback**: `complete_with_schema()` now retries with `LLM_FALLBACK_MODEL` on `ValidationError`/`JSONDecodeError` before returning `SAFE_DEFAULTS`. Previously the 8B fallback was dead code for this failure path.
- **Observability**: Prometheus counter `cio_llm_validation_failures_total{prompt_id, model}` added and incremented on every schema validation failure.

**k8s config change tracked in separate PR on petrosa_k8s:** upgrades `LLM_MODEL` from `llama-3.2-1b-instruct` (too small for structured output) to `llama-3.1-8b-instruct`.

## Test plan

- [x] AC1: unit test `test_response_format_json_set_when_api_base_present` verifies `response_format=json_object` is passed to litellm when `LLM_API_BASE` is set
- [x] AC2: unit test `test_schema_fallback_called_on_validation_failure` verifies fallback model is called on invalid JSON response and SAFE_DEFAULTS is NOT returned when fallback succeeds
- [x] `test_safe_defaults_returned_when_both_models_fail` — SAFE_DEFAULTS returned only when both primary and fallback fail
- [x] All 28 unit tests pass
- [ ] AC3/AC4: deploy and monitor skip rate over 30 min (requires k8s model upgrade PR to merge first)
- [ ] AC5: `curl .../metrics | grep cio_llm_validation_failures_total` returns counter after deploy

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)