### PR TITLE
[BUG] Fix copilot-review-gate: restore cancel-in-progress=false, 15s grace period, and HEAD SHA check (#370)

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -23,7 +23,7 @@ on:
 
 concurrency:
   group: copilot-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   copilot-review:
@@ -70,6 +70,14 @@ jobs:
               return null;
             }
 
+            // Grace period: after pull_request_review events, GitHub's API may take
+            // 10-20s to propagate the review. Wait 15s before first poll to avoid
+            // a false-fail on the initial check.
+            if (context.eventName === 'pull_request_review') {
+              core.info('pull_request_review trigger: waiting 15s for GitHub API propagation...');
+              await new Promise((r) => setTimeout(r, 15000));
+            }
+
             const pr = await resolvePullRequest();
             if (!pr) {
               return;
@@ -100,11 +108,11 @@ jobs:
                 per_page: 100,
               });
 
-              // RELAXED: Any submitted review from Copilot is sufficient to start thread check.
               return reviews.some(
                 (r) =>
                   r.user &&
                   isCopilotPrReviewer(r.user.login) &&
+                  r.commit_id === headSha &&
                   r.state !== 'DISMISSED' &&
                   r.state !== 'PENDING'
               );


### PR DESCRIPTION
## Summary

Fixes three regressions introduced in PR #92 (commit `f3f1db3`) into `copilot-review-gate.yml`.

## Changes

### 1. Restore `cancel-in-progress: false`
PR #92 reverted this to `true`, reintroducing a race condition:
- Gate triggers on `pull_request.synchronize`, starts polling
- Copilot submits review → fires `pull_request_review` event
- `cancel-in-progress: true` **cancels the polling run before it succeeds**
- New run starts; GitHub API hasn't propagated the review yet → false fail

### 2. Re-add 15s grace period after `pull_request_review` trigger
GitHub API takes 10-20s to propagate a newly submitted review. The 15s wait before first poll prevents a false-fail on the initial check.

### 3. Restore `r.commit_id === headSha` in `hasCopilotReview()`
The relaxed check accepted any non-dismissed Copilot review, meaning a review on a stale SHA could satisfy the gate. Restoring strict SHA matching ensures only a review on the current HEAD passes.

## References
- Closes PetroSa2/petrosa_k8s#370
- Original fix: commit `7378a92`
- Regression: commit `f3f1db3` (PR #92)