### PR TITLE
fix: defer copilot review gate until after CI checks (#398)

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -1,10 +1,15 @@
+# yamllint disable rule:line-length rule:truthy rule:document-start
 # TEMPLATE — Copy to `.github/workflows/copilot-review-gate.yml` in each Petrosa repo
-# before requiring the `copilot-review / copilot-review` status check on `main`.
+# before requiring the `copilot-review` status check on `main`.
 #
-# Enforces merge gating: Copilot must have reviewed the current PR head SHA and
-# all Copilot-started review threads must be resolved.
+# Enforces merge gating: Copilot must have reviewed the PR (any commit) and
+# all non-outdated Copilot-started review threads must be resolved.
 #
-# Branch protection must require the check name: copilot-review / copilot-review
+# Design: one Copilot review per PR is the correct standard (issue #380).
+# Re-review via API is a no-op — the GitHub UI "Re-request review" button is the
+# only working mechanism. The thread-resolution check is the real quality gate.
+#
+# Branch protection must require the check name: copilot-review
 # (workflow name / job name). See petrosa_k8s/docs/COPILOT_REVIEW_ENFORCEMENT.md
 #
 # Related: petrosa_k8s Issue #354 (rollout), Issue #330 (original enforcement design)
@@ -12,9 +17,6 @@
 name: copilot-review
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review:
     types: [submitted, edited, dismissed]
   workflow_run:
@@ -22,12 +24,19 @@ on:
     types: [completed]
 
 concurrency:
+  # Queue new gate runs — never cancel an in-flight run.
+  # cancel-in-progress: true caused a regression (#362): the pull_request_review event
+  # (fired when Copilot submits its review) cancelled the existing polling run that was
+  # about to succeed, and the replacement run failed due to API propagation delay.
   group: copilot-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
   copilot-review:
     name: copilot-review
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: petrosa-org-runners
     permissions:
       contents: read
@@ -46,9 +55,6 @@ jobs:
             const repo = context.repo.repo;
 
             async function resolvePullRequest() {
-              if (context.eventName === 'pull_request') {
-                return context.payload.pull_request;
-              }
               if (context.eventName === 'pull_request_review') {
                 return context.payload.pull_request;
               }
@@ -70,14 +76,6 @@ jobs:
               return null;
             }
 
-            // Grace period: after pull_request_review events, GitHub's API may take
-            // 10-20s to propagate the review. Wait 15s before first poll to avoid
-            // a false-fail on the initial check.
-            if (context.eventName === 'pull_request_review') {
-              core.info('pull_request_review trigger: waiting 15s for GitHub API propagation...');
-              await new Promise((r) => setTimeout(r, 15000));
-            }
-
             const pr = await resolvePullRequest();
             if (!pr) {
               return;
@@ -89,7 +87,14 @@ jobs:
             }
 
             const pull_number = pr.number;
-            const headSha = pr.head.sha;
+
+            // When triggered by a Copilot review submission, the GitHub REST API can
+            // take 10–20s to reflect the new review. A short grace period before the
+            // first poll avoids a false-negative on the very first API call. (#362)
+            if (context.eventName === 'pull_request_review') {
+              core.info('Triggered by pull_request_review — waiting 15s for API propagation before first poll.');
+              await new Promise((r) => setTimeout(r, 15 * 1000));
+            }
 
             const isCopilotPrReviewer = (login) => {
               if (!login) return false;
@@ -100,7 +105,10 @@ jobs:
               );
             };
 
-            async function hasCopilotReview() {
+            // Accept any submitted non-dismissed Copilot review on the PR, regardless of
+            // which commit was reviewed. Re-review via API is a no-op (#380) — the
+            // thread-resolution check below is the real enforcement mechanism.
+            async function hasCopilotReviewForPR() {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner,
                 repo,
@@ -112,33 +120,34 @@ jobs:
                 (r) =>
                   r.user &&
                   isCopilotPrReviewer(r.user.login) &&
-                  r.commit_id === headSha &&
                   r.state !== 'DISMISSED' &&
                   r.state !== 'PENDING'
               );
             }
 
-            // Copilot reviews are asynchronous.
+            // Copilot reviews are asynchronous and often land after CI completes and after the
+            // review request workflow runs. To avoid flaky “rerun until Copilot posts” behavior,
+            // poll for a bounded time before failing.
             const maxWaitSeconds = 20 * 60; // 20 minutes
             const pollIntervalSeconds = 30;
             let waited = 0;
 
             while (waited <= maxWaitSeconds) {
-              if (await hasCopilotReview()) {
-                core.info(`Found a submitted Copilot review.`);
+              if (await hasCopilotReviewForPR()) {
+                core.info(`Found submitted Copilot review for PR #${pull_number}.`);
                 break;
               }
 
               if (waited === 0) {
                 core.info(
-                  `Waiting for Copilot PR review on current head ${headSha} (polling up to ${maxWaitSeconds}s).`
+                  `Waiting for Copilot PR review on PR #${pull_number} (any commit accepted, polling up to ${maxWaitSeconds}s).`
                 );
               }
 
               if (waited >= maxWaitSeconds) {
                 core.setFailed(
-                  `No submitted Copilot PR review for current head ${headSha} after waiting ${maxWaitSeconds}s. ` +
-                    `Copilot may be delayed; re-request Copilot review and retry once it submits a review on the latest commit.`
+                  `No submitted Copilot PR review for PR #${pull_number} after waiting ${maxWaitSeconds}s. ` +
+                    `Request a Copilot review via the GitHub UI and retry once it submits one.`
                 );
                 return;
               }
@@ -226,5 +235,5 @@ jobs:
             }
 
             core.info(
-              `Copilot review gate passed for ${repo}#${pull_number} @ ${headSha}`
+              `Copilot review gate passed for ${repo}#${pull_number}.`
             );

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -1,5 +1,9 @@
+# yamllint disable rule:line-length rule:truthy rule:document-start
 # Defers GitHub Copilot review until CI Checks complete successfully.
 # Replaces the pull_request trigger with workflow_run to enforce post-CI ordering.
+#
+# Merge blocking is handled separately by `copilot-review-gate.yml`, which must pass
+# for the required check `copilot-review` (see docs/COPILOT_REVIEW_ENFORCEMENT.md).
 #
 # Fix for Issue #371: workflow_run.pull_requests[] is always empty in GitHub's event
 # payload even for same-repo PRs. PR resolution is done via the REST API using
@@ -23,9 +27,9 @@ on:
 
 jobs:
   request-copilot-review:
-    # workflow_run.pull_requests[] is always empty (GitHub bug/limitation); the
-    # fork check and PR resolution happen inside the script via the REST API.
-    # head_repository guard ensures we only act on same-repo workflow_run events.
+    # `if` head_repository guard below. For workflow_dispatch, the fork guard
+    # runs inside the script. PR resolution happens via the REST API using
+    # head_sha + head_branch (workflow_run.pull_requests[] is unreliable).
     if: >
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success' &&
@@ -82,8 +86,11 @@ jobs:
               headSha = pr.head.sha;
             }
 
-            // Short-circuit: skip if Copilot already reviewed the current head SHA.
-            // This prevents duplicate review requests on CI reruns with no code changes.
+            // Short-circuit: skip if Copilot has already submitted any review on this PR.
+            // One Copilot review per PR is the correct standard (#380) — re-review via
+            // API is a no-op (requestReviewers returns 200 but fires no review_requested
+            // event for Copilot). The thread-resolution check in the gate is the real
+            // quality enforcement; requesting again would have no effect.
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner, repo, pull_number, per_page: 100,
             });
@@ -92,32 +99,15 @@ jobs:
               return l === 'copilot-pull-request-reviewer' || l.startsWith('copilot-pull-request-reviewer[');
             };
             const alreadyReviewed = reviews.some(
-              (r) => isCopilot(r.user?.login) && r.commit_id === headSha &&
+              (r) => isCopilot(r.user?.login) &&
                 r.state !== 'DISMISSED' && r.state !== 'PENDING'
             );
             if (alreadyReviewed) {
-              console.log(`Copilot already reviewed HEAD ${headSha}; skipping re-request.`);
+              console.log(`Copilot already reviewed this PR; skipping re-request.`);
               return;
             }
 
-            console.log(`Requesting Copilot review for PR #${pull_number} @ ${headSha}...`);
-
-            // Remove first so that re-requesting triggers a fresh review even when
-            // Copilot has already reviewed a previous commit (mirrors the GitHub UI
-            // "Re-request review" button behavior).
-            try {
-              await github.rest.pulls.removeRequestedReviewers({
-                owner,
-                repo,
-                pull_number,
-                reviewers: ['github-copilot'],
-              });
-            } catch (e) {
-              // 422 = reviewer was not in the pending list; safe to ignore.
-              // All other statuses (404 resource not found, 403 permissions, 5xx)
-              // are re-thrown so the step fails visibly.
-              if (e.status !== 422) throw e;
-            }
+            console.log(`Requesting Copilot review for PR #${pull_number}...`);
 
             try {
               await github.rest.pulls.requestReviewers({


### PR DESCRIPTION
Implements #398 by removing the pull_request trigger from copilot-review-gate and adding workflow_dispatch to request-copilot-review.