### PR TITLE
fix: #334 - CIO bypass mode now routes EXECUTE despite CHOPPY/CAPITULATION regime

### DIFF
--- a/cio/core/context_builder.py
+++ b/cio/core/context_builder.py
@@ -202,7 +202,7 @@ class ContextBuilder:
             # Safe conservative defaults (trigger blocks)
             return (
                 PortfolioSummary(
-                    net_directional_exposure=1.0,
+                    gross_exposure=1.0,
                     same_asset_pct=1.0,
                     open_positions_count=999,
                 ),

--- a/cio/core/orchestrator.py
+++ b/cio/core/orchestrator.py
@@ -66,9 +66,6 @@ class Orchestrator:
         )
 
         try:
-            # 1. CODE ENGINE: Hard Limits (S2)
-            code_result = CodeEngine.run(context)
-
             # Placeholder results for deterministic bypass (Ticket #334/337)
             # Use explicit "bypass" placeholders instead of SAFE_DEFAULTS to avoid "PARSE_FAILURE" trace
             bypass_regime = RegimeResult(
@@ -88,6 +85,23 @@ class Orchestrator:
                 confidence=1.0,
                 thought_trace="DETERMINISTIC_BYPASS",
             )
+
+            # 1. CODE ENGINE: Hard Limits (S2)
+            # In bypass mode, substitute bypass_regime so that policy-based regime hard
+            # blocks (CHOPPY / CAPITULATION) do not fire. Risk-gate hard limits (drawdown,
+            # open orders) still apply because they are derived from env_stats/risk_limits,
+            # not from the regime field.
+            if not self.use_llm_reasoning:
+                engine_context = context.model_copy(
+                    update={
+                        "regime": bypass_regime,
+                        "volatility_level": bypass_regime.volatility_level,
+                    }
+                )
+            else:
+                engine_context = context
+
+            code_result = CodeEngine.run(engine_context)
 
             if code_result.hard_blocked:
                 # Bypassing persona analysis for hard blocks
@@ -117,8 +131,7 @@ class Orchestrator:
                     "Deterministic bypass active. Skipping LLM personas.",
                     extra={"correlation_id": context.correlation_id},
                 )
-                # In bypass mode, we "blindly" trust the intent IF code engine passes.
-                # The ActionClassifier still handles the final assembly into DecisionResult.
+                # In bypass mode we "blindly" trust the intent when risk gates pass.
                 return await self.action_classifier.classify(
                     context,
                     code_result,

--- a/tests/unit/test_deterministic_bypass.py
+++ b/tests/unit/test_deterministic_bypass.py
@@ -5,11 +5,15 @@ import pytest
 
 from cio.core.orchestrator import Orchestrator
 from cio.models import (
+    ActionType,
+    ActivationRecommendation,
     ConfidenceLevel,
+    HealthStatus,
     MarketSignals,
     PnlTrend,
     PortfolioSummary,
     RegimeEnum,
+    RegimeFit,
     RegimeResult,
     RiskLimits,
     StrategyDefaults,
@@ -18,6 +22,7 @@ from cio.models import (
     TriggerType,
     VolatilityLevel,
 )
+from cio.models.decision import DecisionResult
 
 
 @pytest.mark.asyncio
@@ -169,3 +174,90 @@ async def test_orchestrator_hard_block_with_bypass():
             mock_classifier.classify.assert_called_once()
             _, kwargs = mock_classifier.classify.call_args
             assert kwargs["bypass_mode"] is True
+
+
+def _make_bypass_context(regime_enum):
+    """Helper: build a TriggerContext with the given regime for bypass tests."""
+    return TriggerContext(
+        correlation_id="test-regime-bypass",
+        trigger_type=TriggerType.TRADE_INTENT,
+        strategy_id="test_strat",
+        symbol="BTCUSDT",
+        source_subject="cio.intent.trading.test_strat",
+        trigger_payload={"symbol": "BTCUSDT"},
+        regime=RegimeResult(
+            regime=regime_enum,
+            regime_confidence=ConfidenceLevel.HIGH,
+            volatility_level=VolatilityLevel.MEDIUM,
+            primary_signal="test",
+            confidence=1.0,
+            fit="good",
+            thought_trace="test",
+        ),
+        volatility_level=VolatilityLevel.MEDIUM,
+        market_signals=MarketSignals(
+            signal_summary="bullish",
+            current_price=50000.0,
+            volatility_percentile=0.5,
+            trend_strength=0.7,
+            price_action_character="stable",
+        ),
+        strategy_stats=StrategyStats(recent_pnl_trend=PnlTrend.NEUTRAL),
+        strategy_defaults=StrategyDefaults(
+            stop_loss_pct=0.02, take_profit_pct=0.04, max_hold_hours=24
+        ),
+        global_drawdown_pct=0.0,
+        open_orders_global=0,
+        open_orders_symbol=0,
+        available_capital_usd=1000.0,
+        portfolio=PortfolioSummary(
+            gross_exposure=0.0, same_asset_pct=0.0, open_positions_count=0
+        ),
+        risk_limits=RiskLimits(
+            max_drawdown_pct=0.1,
+            max_orders_global=50,
+            max_orders_per_symbol=5,
+            max_position_size_usd=1000.0,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "blocking_regime", [RegimeEnum.CHOPPY, RegimeEnum.CAPITULATION]
+)
+async def test_bypass_mode_skips_regime_hard_block(blocking_regime):
+    """
+    Verifies that bypass mode (NURSE_USE_LLM_REASONING=false) does NOT hard-block
+    on CHOPPY or CAPITULATION regimes.  Risk-gate blocks (drawdown / orders) still
+    apply; only policy-based regime blocks are skipped.
+    """
+    with patch.dict(os.environ, {"NURSE_USE_LLM_REASONING": "false"}):
+        with patch("cio.core.orchestrator.ActionClassifier") as MockClassifier:
+            mock_result = DecisionResult(
+                hard_blocked=False,
+                ev_passes=True,
+                cost_viable=True,
+                regime_confidence=ConfidenceLevel.HIGH,
+                regime_fit=RegimeFit.GOOD,
+                strategy_health=HealthStatus.HEALTHY,
+                activation_recommendation=ActivationRecommendation.RUN,
+                action=ActionType.EXECUTE,
+                justification="bypass test",
+                thought_trace="bypass",
+            )
+            MockClassifier.return_value.classify = AsyncMock(return_value=mock_result)
+
+            orchestrator = Orchestrator()
+            context = _make_bypass_context(blocking_regime)
+
+            decision = await orchestrator.run(context)
+
+            # Must NOT be blocked — bypass mode overrides regime policy blocks
+            assert decision.action == ActionType.EXECUTE, (
+                f"Expected EXECUTE in bypass mode with {blocking_regime} regime, "
+                f"got {decision.action}"
+            )
+            # Classifier must be called with bypass_mode=True
+            call_kwargs = MockClassifier.return_value.classify.call_args[1]
+            assert call_kwargs["bypass_mode"] is True


### PR DESCRIPTION
## Summary

Fixes [petrosa_k8s#334](https://github.com/PetroSa2/petrosa_k8s/issues/334) — organic TA signals were silently swallowed by CIO and never published to `signals.trading.*`, causing zero execution from the TA-driven path.

**Three root causes fixed:**

- **`orchestrator.py`**: In bypass mode (`NURSE_USE_LLM_REASONING=false`), `CodeEngine` ran on the real `context.regime`. If the data manager reported `CHOPPY` or `CAPITULATION` with non-low confidence (common on the testnet), every intent was hard-blocked before reaching the NATS publish path. Fix: build `engine_context` with `bypass_regime` (RANGING) before running `CodeEngine`, so policy-based regime blocks are skipped. Risk-gate hard limits (drawdown %, open order counts) are **still enforced** — they derive from `env_stats`/`risk_limits`, not from regime.
- **`context_builder.py`**: The error-path fallback `PortfolioSummary(net_directional_exposure=1.0, ...)` used the wrong field name (`gross_exposure` is required). This caused a Pydantic `ValidationError` inside the `except` block, which propagated out of `asyncio.gather`, dropping intents silently via the "Failed to build context" path.
- **`tests/unit/test_deterministic_bypass.py`**: Added a parametrized test for `CHOPPY` and `CAPITULATION` regimes in bypass mode to prevent regression.

## Test plan

- [x] `python3.11 -m pytest tests/unit/test_deterministic_bypass.py -v` — 4 passed (includes 2 new parametrized cases)
- [x] `python3.11 -m pytest tests/ --ignore=tests/integration` — 80 passed, 0 failed
- [x] `ruff check` — all checks passed
- [ ] Cluster validation: deploy and verify `signals.trading.*` receives messages from TA bot intents

🤖 Generated with [Claude Code](https://claude.com/claude-code)