### PR TITLE
fix: 493 - replace hardcoded BASE_VERSION with VERSION-file pattern

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,8 +44,9 @@ jobs:
     - name: Set version
       id: version
       run: |
-        # Default version for CIO
-        BASE_VERSION="v0.1.0"
+        # Sourced from VERSION file (unified per #154); preserves leading 'v'
+        RAW=$(cat VERSION | tr -d '[:space:]')
+        BASE_VERSION="v${RAW#v}"
         SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
         VERSION="${BASE_VERSION}-r${{ github.run_number }}-${SHORT_SHA}"
         echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "petrosa-cio"
-version = "1.0.0"
+version = "1.0.7"
 description = "Autonomous trading intelligence and strategy controller"
 authors = [{name = "Petrosa Systems"}]
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Closes PetroSa2/petrosa_k8s#493.

`petrosa-cio` was publishing every Docker image as `v0.1.0-r{N}-{SHA}` because `deploy.yml` hardcoded `BASE_VERSION="v0.1.0"`, ignoring the existing `VERSION` file (`1.0.7`). This made the SemVer component meaningless and broke parity with the unified versioning strategy adopted across the ecosystem in #154.

## Changes

- **`.github/workflows/deploy.yml`** (line 47–49): Source `BASE_VERSION` from the `VERSION` file using the AC-specified pattern. The `v${RAW#v}` form is idempotent — works whether the VERSION file starts with `v` or not.
- **`pyproject.toml`** (line 3): Align package version `1.0.0` → `1.0.7` to match the `VERSION` file.

Diff is 4 insertions, 3 deletions across 2 files. No code or test files modified.

## Verification

| Input | Computed VERSION |
|---|---|
| VERSION=`1.0.7`  | `v1.0.7-r{N}-<sha>` |
| VERSION=`v1.0.7` | `v1.0.7-r{N}-<sha>` |

- `ruff check` passes
- YAML/TOML parse cleanly
- First release after merge will produce `v1.0.7-r89-<sha>` (or higher run number)

## Test plan

- [ ] CI Pipeline (`CI Pipeline / Pipeline`) green
- [ ] copilot-review green
- [ ] After merge, watch `deploy.yml` on `main` push and confirm the new tag matches `v1.0.7-r{N}-<sha>`
- [ ] Confirm `petrosa_k8s/k8s/cio/deployment.yaml` image tag updates via the GitOps sed (separate concern from #494's OTEL drift)

## Regression risk

**Low** — tags are opaque strings; k8s rollout uses exact-match; `imagePullPolicy: Always`. No code paths touched.

## Related

- Parent: PetroSa2/petrosa_k8s#154 (Unify versioning strategy — closed 2026-05-16)
- Sibling: PetroSa2/petrosa_k8s#494 (OTEL service.version sed bug — separate fix)
- Reference: `petrosa-data-manager/.github/workflows/deploy.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)