### PR TITLE
feat(cio): assign decision_id on intent consumption, persist in Qdrant, propagate to signals (P0.1a / #578)

### DIFF
--- a/cio/core/context_builder.py
+++ b/cio/core/context_builder.py
@@ -67,6 +67,7 @@ class ContextBuilder:
         source_subject: str,
         trigger_type: TriggerType,
         payload: dict[str, Any],
+        decision_id: str = "",
     ) -> TriggerContext:
         """
         Assembles a full TriggerContext.
@@ -113,8 +114,11 @@ class ContextBuilder:
         historical_context = results[3] if vector_task else None
 
         # Assemble TriggerContext
+        import uuid as _uuid
+
         return TriggerContext(
             correlation_id=correlation_id,
+            decision_id=decision_id or _uuid.uuid4().hex,
             source_subject=source_subject,
             trigger_type=trigger_type,
             trigger_payload=payload,

--- a/cio/core/context_builder.py
+++ b/cio/core/context_builder.py
@@ -67,7 +67,7 @@ class ContextBuilder:
         source_subject: str,
         trigger_type: TriggerType,
         payload: dict[str, Any],
-        decision_id: str = "",
+        decision_id: str | None = None,
     ) -> TriggerContext:
         """
         Assembles a full TriggerContext.
@@ -114,12 +114,12 @@ class ContextBuilder:
         historical_context = results[3] if vector_task else None
 
         # Assemble TriggerContext
-        import uuid as _uuid
-
+        # Pass decision_id only when provided; TriggerContext.default_factory generates one otherwise
+        extra = {"decision_id": decision_id} if decision_id is not None else {}
         return TriggerContext(
             correlation_id=correlation_id,
-            decision_id=decision_id or _uuid.uuid4().hex,
             source_subject=source_subject,
+            **extra,
             trigger_type=trigger_type,
             trigger_payload=payload,
             regime=regime,

--- a/cio/core/listener.py
+++ b/cio/core/listener.py
@@ -118,10 +118,12 @@ class NATSListener:
                 return
 
         # 4. Assemble Context
+        decision_id = uuid.uuid4().hex
         try:
             # For trade.intent.*, we assume TriggerType.TRADE_INTENT
             context = await self.context_builder.build(
                 correlation_id=correlation_id,
+                decision_id=decision_id,
                 source_subject=msg.subject,
                 trigger_type=TriggerType.TRADE_INTENT,
                 payload=payload,

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -107,8 +107,10 @@ class OutputRouter:
                 symbol=context.trigger_payload.get("symbol", ""),
                 correlation_id=correlation_id,
             )
-        except Exception:
+        except ImportError:
             pass
+        except Exception as _otel_exc:
+            logger.debug("set_decision_context failed: %s", _otel_exc)
 
         # 1. Prepare Audit Path (Memory storage - Always executed)
         audit_task = self.vector_client.upsert(

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -83,6 +83,7 @@ class OutputRouter:
         3. Audit Path -> DecisionResult + Context -> Vector DB (Always enabled for all actions)
         """
         correlation_id = context.correlation_id
+        decision_id = context.decision_id
         strategy_id = context.strategy_id
         action = decision.action or ActionType.SKIP
         is_dry_run = os.getenv("DRY_RUN", "false").lower() == "true"
@@ -92,6 +93,23 @@ class OutputRouter:
 
         DECISION_ACTIONS.labels(action_type=action.value, strategy_id=strategy_id).inc()
 
+        # Set OTel decision context attributes on the current span
+        try:
+            from opentelemetry import trace as _trace
+            from petrosa_otel import set_decision_context
+
+            _span = _trace.get_current_span()
+            set_decision_context(
+                _span,
+                decision_id=decision_id,
+                strategy_id=strategy_id,
+                action=action.value,
+                symbol=context.trigger_payload.get("symbol", ""),
+                correlation_id=correlation_id,
+            )
+        except Exception:
+            pass
+
         # 1. Prepare Audit Path (Memory storage - Always executed)
         audit_task = self.vector_client.upsert(
             strategy_id=strategy_id,
@@ -99,6 +117,7 @@ class OutputRouter:
                 "event_type": "decision",
                 "action": action.value,
                 "correlation_id": correlation_id,
+                "decision_id": decision_id,
                 "summary": decision.justification,
                 "thought_trace": decision.thought_trace,
                 "decision_data": decision.model_dump(),

--- a/cio/models/context.py
+++ b/cio/models/context.py
@@ -62,7 +62,7 @@ class TriggerContext(BaseModel):
     )
     decision_id: str = Field(
         default_factory=lambda: uuid.uuid4().hex,
-        description="UUID assigned by the CIO for this specific decision; propagated to signals and Qdrant audit trail",
+        description="uuid4 hex string (32 chars, no hyphens) assigned by the CIO per intent; propagated to signals and Qdrant audit trail",
     )
     source_subject: str = Field(
         ..., description="Original NATS subject the trigger was received on"

--- a/cio/models/context.py
+++ b/cio/models/context.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -58,6 +59,10 @@ class TriggerContext(BaseModel):
     # Orchestration and Routing (Winston's requirements)
     correlation_id: str = Field(
         ..., description="NATS message ID or unique GUID for this request flow"
+    )
+    decision_id: str = Field(
+        default_factory=lambda: uuid.uuid4().hex,
+        description="UUID assigned by the CIO for this specific decision; propagated to signals and Qdrant audit trail",
     )
     source_subject: str = Field(
         ..., description="Original NATS subject the trigger was received on"

--- a/cio/output/translator.py
+++ b/cio/output/translator.py
@@ -79,6 +79,7 @@ class TradeEngineTranslator:
                 "strength": "strong",
                 "strategy_mode": "llm_reasoning",
                 "timestamp": datetime.now(UTC).isoformat(),
+                "decision_id": context.decision_id,
                 # Map risk management parameters from decision (primary) or payload
                 "stop_loss": context.trigger_payload.get("stop_loss"),
                 "stop_loss_pct": decision.stop_loss_pct
@@ -88,6 +89,7 @@ class TradeEngineTranslator:
                 or context.trigger_payload.get("take_profit_pct"),
                 "metadata": {
                     "correlation_id": correlation_id,
+                    "decision_id": context.decision_id,
                     "cio_justification": decision.justification,
                     "thought_trace": decision.thought_trace,
                     "original_size_usd": quantity_usd,

--- a/tests/unit/test_decision_id_propagation.py
+++ b/tests/unit/test_decision_id_propagation.py
@@ -1,0 +1,129 @@
+"""Tests for decision_id propagation (P0.1a / petrosa_k8s#578)."""
+
+from __future__ import annotations
+
+from cio.models import (
+    ActivationRecommendation,
+    ConfidenceLevel,
+    DecisionResult,
+    HealthStatus,
+    MarketSignals,
+    PortfolioSummary,
+    RegimeEnum,
+    RegimeFit,
+    RegimeResult,
+    RiskLimits,
+    StrategyDefaults,
+    StrategyStats,
+    TriggerContext,
+    TriggerType,
+    VolatilityLevel,
+)
+from cio.output.translator import TradeEngineTranslator
+
+
+def _make_context(**overrides) -> TriggerContext:
+    regime = RegimeResult(
+        regime=RegimeEnum.RANGING,
+        regime_confidence=ConfidenceLevel.MEDIUM,
+        volatility_level=VolatilityLevel.MEDIUM,
+        primary_signal="test",
+        thought_trace="test",
+    )
+    defaults = dict(
+        correlation_id="test-corr",
+        source_subject="cio.intent.trading.s1",
+        trigger_type=TriggerType.TRADE_INTENT,
+        trigger_payload={"symbol": "BTCUSDT", "side": "long", "current_price": 50000.0},
+        regime=regime,
+        volatility_level=VolatilityLevel.MEDIUM,
+        market_signals=MarketSignals(
+            signal_summary="test",
+            current_price=50000.0,
+            volatility_percentile=0.5,
+            trend_strength=0.5,
+            price_action_character="Neutral",
+        ),
+        strategy_id="s1",
+        strategy_stats=StrategyStats(),
+        strategy_defaults=StrategyDefaults(
+            stop_loss_pct=0.02,
+            take_profit_pct=0.04,
+            leverage=1.0,
+            max_hold_hours=24.0,
+        ),
+        global_drawdown_pct=0.0,
+        open_orders_global=0,
+        open_orders_symbol=0,
+        available_capital_usd=1000.0,
+        portfolio=PortfolioSummary(
+            gross_exposure=0.0, same_asset_pct=0.0, open_positions_count=0
+        ),
+        risk_limits=RiskLimits(
+            max_single_position_pct=0.1,
+            max_global_drawdown_pct=0.1,
+            max_portfolio_exposure=0.5,
+            max_open_orders=10,
+            max_same_asset_concentration=0.25,
+        ),
+    )
+    defaults.update(overrides)
+    return TriggerContext(**defaults)
+
+
+def _make_decision(position_usd: float = 100.0) -> DecisionResult:
+    from cio.models import ActionType
+
+    return DecisionResult(
+        action=ActionType.EXECUTE,
+        justification="test",
+        thought_trace="test",
+        computed_position_size_usd=position_usd,
+        hard_blocked=False,
+        ev_passes=True,
+        cost_viable=True,
+        regime_confidence=ConfidenceLevel.HIGH,
+        regime_fit=RegimeFit.GOOD,
+        strategy_health=HealthStatus.HEALTHY,
+        activation_recommendation=ActivationRecommendation.RUN,
+    )
+
+
+class TestDecisionIdInContext:
+    def test_decision_id_auto_generated_when_not_provided(self):
+        ctx = _make_context()
+        assert ctx.decision_id
+        assert len(ctx.decision_id) == 32
+
+    def test_decision_id_uses_provided_value(self):
+        ctx = _make_context(decision_id="abc123")
+        assert ctx.decision_id == "abc123"
+
+    def test_two_contexts_get_different_decision_ids(self):
+        ctx1 = _make_context()
+        ctx2 = _make_context()
+        assert ctx1.decision_id != ctx2.decision_id
+
+
+class TestDecisionIdInTranslator:
+    def test_decision_id_in_top_level_signal(self):
+        ctx = _make_context(decision_id="d1d2d3")
+        decision = _make_decision()
+        result = TradeEngineTranslator.to_legacy_signal(ctx, decision)
+        assert result is not None
+        assert result["decision_id"] == "d1d2d3"
+
+    def test_decision_id_in_metadata(self):
+        ctx = _make_context(decision_id="meta-test")
+        decision = _make_decision()
+        result = TradeEngineTranslator.to_legacy_signal(ctx, decision)
+        assert result is not None
+        assert result["metadata"]["decision_id"] == "meta-test"
+
+    def test_decision_id_matches_context(self):
+        ctx = _make_context()
+        decision = _make_decision()
+        result = TradeEngineTranslator.to_legacy_signal(ctx, decision)
+        assert result is not None
+        assert result["decision_id"] == ctx.decision_id
+        assert result["metadata"]["decision_id"] == ctx.decision_id

--- a/tests/unit/test_router_rest.py
+++ b/tests/unit/test_router_rest.py
@@ -34,6 +34,7 @@ async def test_output_router_rest_modify_params_active():
 
     context = MagicMock(spec=TriggerContext)
     context.strategy_id = "momentum_pulse"  # TA_BOT
+    context.decision_id = "test-decision-id"
     context.correlation_id = "rest-active-id"
 
     decision = DecisionResult(
@@ -82,6 +83,7 @@ async def test_output_router_rest_429_handling():
 
     context = MagicMock(spec=TriggerContext)
     context.strategy_id = "test_strat"
+    context.decision_id = "test-decision-id"
     context.correlation_id = "rest-429-id"
 
     decision = DecisionResult(
@@ -130,6 +132,7 @@ async def test_output_router_rest_pause_strategy_freeze():
 
     context = MagicMock(spec=TriggerContext)
     context.strategy_id = "pause_strat"
+    context.decision_id = "test-decision-id"
     context.correlation_id = "rest-pause-id"
 
     decision = DecisionResult(
@@ -178,6 +181,7 @@ async def test_output_router_rest_429_fallback_ttl():
 
     context = MagicMock(spec=TriggerContext)
     context.strategy_id = "test_strat"
+    context.decision_id = "test-decision-id"
     context.correlation_id = "rest-429-fallback"
 
     decision = DecisionResult(
@@ -225,6 +229,7 @@ async def test_output_router_rest_cache_unavailable_warning(caplog):
 
     context = MagicMock(spec=TriggerContext)
     context.strategy_id = "no_cache_strat"
+    context.decision_id = "test-decision-id"
     context.correlation_id = "no-cache-id"
 
     decision = DecisionResult(
@@ -263,6 +268,7 @@ async def test_output_router_rest_fail_safe_identity():
 
     context = MagicMock(spec=TriggerContext)
     context.strategy_id = "fail_safe_strat"
+    context.decision_id = "test-decision-id"
     context.correlation_id = "fail-safe-id"
 
     decision = DecisionResult(
@@ -307,6 +313,7 @@ async def test_output_router_rest_429_clamping():
 
     context = MagicMock(spec=TriggerContext)
     context.strategy_id = "clamp_strat"
+    context.decision_id = "test-decision-id"
     context.correlation_id = "rest-429-clamp"
 
     decision = DecisionResult(
@@ -363,6 +370,7 @@ async def test_output_router_rest_dry_run():
 
     context = MagicMock(spec=TriggerContext)
     context.strategy_id = "orderbook_skew"  # REALTIME
+    context.decision_id = "test-decision-id"
     context.correlation_id = "rest-dryrun-id"
 
     decision = DecisionResult(


### PR DESCRIPTION
## Summary
- `TriggerContext.decision_id`: UUID auto-generated per intent via `default_factory`; listener generates it explicitly and passes to `context_builder.build()`
- `OutputRouter.route()`: adds `decision_id` to Qdrant audit payload; sets `decision.*` OTel span attributes via `set_decision_context()` from `petrosa-otel`
- `TradeEngineTranslator.to_legacy_signal()`: includes `decision_id` at top-level signal and in `metadata` so `petrosa-tradeengine` can read it downstream
- Tests: 86 unit tests pass; new `TestDecisionIdPropagation` class (6 tests) covers auto-generation, explicit override, and translator output

## Test plan
- [x] All 86 unit tests pass locally (Python 3.11)
- [x] All pre-commit hooks pass (ruff, bandit, gitleaks, check-test-assertions)
- [x] `decision_id` propagates from listener → context → router (Qdrant + OTel) → signal (tradeengine downstream)

Closes petrosa_k8s#578

🤖 Generated with [Claude Code](https://claude.com/claude-code)