### PR TITLE
chore: upgrade petrosa-otel to >=1.0.6 for set_decision_context

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ opentelemetry-instrumentation-logging>=0.41b0
 opentelemetry-sdk>=1.22.0
 
 # Unified OpenTelemetry package for Petrosa services
-petrosa-otel[all]>=1.0.4
+petrosa-otel[all]>=1.0.6
 prometheus-client>=0.19.0
 
 # Logging and observability


### PR DESCRIPTION
## Summary
- Bumps `petrosa-otel[all]>=1.0.4` to `>=1.0.6`
- v1.0.6 includes `set_decision_context()` and `extract_decision_context_from_nats()` from petrosa_k8s#581
- Required so the decision_id OTel span attributes in router.py (added in petrosa_k8s#578, merged via PR #110) work correctly in production

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)