### PR TITLE
feat: add CIO governance ActionTypes DOWN_WEIGHT/THROTTLE/VETO (#589)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,10 @@ repos:
     hooks:
       - id: bandit
         name: 🔐 Bandit (Python Security)
-        args: [-ll, -r, ., -x, ".venv,venv,htmlcov"]
+        # Scope the scan to project source under cio/ — the previous root-level
+        # scan with -x globs did not actually skip venv contents and produced
+        # thousands of findings in third-party packages.
+        args: [-ll, -r, cio]
         exclude: ^tests/
         pass_filenames: false
 

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -314,6 +314,25 @@ class OutputRouter:
             dispatch_tasks_data.append(
                 (f"cio.retry.{strategy_id}", decision.model_dump_json().encode())
             )
+        elif action == ActionType.DOWN_WEIGHT:
+            # Governance: reduce strategy's per-decision allocation. Subscribers
+            # (lifecycle authority, dashboard) consume cio.weight.{strategy_id}
+            # to adjust per-decision sizing without halting signal flow.
+            dispatch_tasks_data.append(
+                (f"cio.weight.{strategy_id}", decision.model_dump_json().encode())
+            )
+        elif action == ActionType.THROTTLE:
+            # Governance: rate-limit a strategy's signals over a window.
+            dispatch_tasks_data.append(
+                (f"cio.throttle.{strategy_id}", decision.model_dump_json().encode())
+            )
+        elif action == ActionType.VETO:
+            # Governance: reject this specific intent without changing the strategy's
+            # standing weight. Distinct from SKIP in that downstream subscribers are
+            # notified (audit/dashboard) instead of silently dropping the intent.
+            dispatch_tasks_data.append(
+                (f"cio.veto.{strategy_id}", decision.model_dump_json().encode())
+            )
         elif action == ActionType.FAIL_SAFE:
             # 1. NATS Failure Signal
             dispatch_tasks_data.append(

--- a/cio/models/enums.py
+++ b/cio/models/enums.py
@@ -91,6 +91,12 @@ class ActionType(StrEnum):
     ESCALATE = "escalate"
     RETRY_SAFE = "retry_safe"
     FAIL_SAFE = "fail_safe"
+    # Governance actions (per #589 P1.1). Arbitration logic (when to emit) is owned
+    # by P1.2 (lifecycle authority) and P2.6 (verdict-driven pause); this layer
+    # only defines the vocabulary and emission paths.
+    DOWN_WEIGHT = "down_weight"
+    THROTTLE = "throttle"
+    VETO = "veto"
 
 
 class TriggerType(StrEnum):

--- a/tests/unit/test_router_governance_actions.py
+++ b/tests/unit/test_router_governance_actions.py
@@ -1,0 +1,147 @@
+"""Per #589 P1.1: governance action types (DOWN_WEIGHT, THROTTLE, VETO).
+
+Verifies the router emits each governance action on its dedicated NATS subject
+and that the audit path persists the new actions through the existing pattern
+(no new persistence code path required).
+"""
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cio.core.router import OutputRouter
+from cio.models import (
+    ActionType,
+    ActivationRecommendation,
+    ConfidenceLevel,
+    DecisionResult,
+    HealthStatus,
+    RegimeFit,
+    TriggerContext,
+)
+
+
+def _make_decision(action: ActionType) -> DecisionResult:
+    return DecisionResult(
+        hard_blocked=False,
+        ev_passes=True,
+        cost_viable=True,
+        regime_confidence=ConfidenceLevel.HIGH,
+        regime_fit=RegimeFit.GOOD,
+        strategy_health=HealthStatus.HEALTHY,
+        activation_recommendation=ActivationRecommendation.RUN,
+        action=action,
+        justification="governance reasoning",
+        thought_trace="audit trace",
+    )
+
+
+def _make_context(strategy_id: str) -> TriggerContext:
+    ctx = MagicMock(spec=TriggerContext)
+    ctx.strategy_id = strategy_id
+    ctx.decision_id = "decision-589"
+    ctx.correlation_id = "corr-589"
+    ctx.trigger_payload = {"symbol": "BTCUSDT"}
+    return ctx
+
+
+def test_governance_action_types_exposed():
+    """Enum carries the three governance values added by P1.1."""
+    assert ActionType.DOWN_WEIGHT.value == "down_weight"
+    assert ActionType.THROTTLE.value == "throttle"
+    assert ActionType.VETO.value == "veto"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("action", "expected_subject_prefix"),
+    [
+        (ActionType.DOWN_WEIGHT, "cio.weight"),
+        (ActionType.THROTTLE, "cio.throttle"),
+        (ActionType.VETO, "cio.veto"),
+    ],
+)
+async def test_governance_action_publishes_on_dedicated_subject(
+    action: ActionType, expected_subject_prefix: str
+):
+    """Each governance action publishes to cio.<kind>.<strategy_id> with the decision JSON."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    strategy_id = "momentum_pulse"
+    context = _make_context(strategy_id)
+    decision = _make_decision(action)
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(context, decision)
+
+    mock_nc.publish.assert_called_once()
+    subject, payload_bytes = mock_nc.publish.call_args.args
+    assert subject == f"{expected_subject_prefix}.{strategy_id}"
+
+    payload = json.loads(payload_bytes.decode())
+    assert payload["action"] == action.value
+    assert payload["justification"] == "governance reasoning"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action",
+    [ActionType.DOWN_WEIGHT, ActionType.THROTTLE, ActionType.VETO],
+)
+async def test_governance_action_persists_audit_with_decision_id(action: ActionType):
+    """Audit upsert is called for each governance action and carries decision_id."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    context = _make_context("strat_a")
+    decision = _make_decision(action)
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(context, decision)
+
+    mock_vc.upsert.assert_called_once()
+    kwargs = mock_vc.upsert.call_args.kwargs
+    assert kwargs["strategy_id"] == "strat_a"
+    payload = kwargs["payload"]
+    assert payload["action"] == action.value
+    assert payload["decision_id"] == "decision-589"
+    assert payload["summary"] == "governance reasoning"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action",
+    [ActionType.DOWN_WEIGHT, ActionType.THROTTLE, ActionType.VETO],
+)
+async def test_governance_action_skips_publish_in_dry_run(action: ActionType):
+    """DRY_RUN suppresses NATS publish but still persists audit."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    context = _make_context("strat_dry")
+    decision = _make_decision(action)
+
+    with patch.dict(os.environ, {"DRY_RUN": "true"}):
+        await router.route(context, decision)
+
+    mock_nc.publish.assert_not_called()
+    mock_vc.upsert.assert_called_once()
+    assert mock_vc.upsert.call_args.kwargs["payload"]["action"] == action.value


### PR DESCRIPTION
## Summary

Implements **PetroSa2/petrosa_k8s#589 (P1.1)** — extends `ActionType` with three governance actions and wires each to a dedicated NATS subject via the existing T-junction router.

| Action | NATS subject | Semantics |
|---|---|---|
| `DOWN_WEIGHT` | `cio.weight.{strategy_id}` | Reduce per-decision allocation (signal still flows; smaller size) |
| `THROTTLE` | `cio.throttle.{strategy_id}` | Rate-limit signals over a window |
| `VETO` | `cio.veto.{strategy_id}` | Reject this specific intent without changing standing weight |

- Audit persistence and `decision_id` propagation flow through the existing router pattern (`router.py:115-127`) — **no new persistence path**.
- Reasoning context (`justification`, `thought_trace`) already part of `DecisionResult`.
- Arbitration logic for *when* to emit each is out of scope (owned by P1.2 lifecycle authority and P2.6 verdict-driven pause). This change adds vocabulary + emission paths only.

### Acceptance criteria
- [x] `DOWN_WEIGHT`, `THROTTLE`, `VETO` added to `ActionType` enum (`cio/models/enums.py`)
- [x] Each persists to Qdrant via existing audit_task path (verified by unit test asserting `decision_id` + `action` value in the upsert payload)
- [x] Each carries reasoning context (`justification`) — verified by test
- [x] Each carries `decision_id` per P0.1 contract — verified by test
- [x] No regression on existing 100 unit tests; coverage 78.68% (threshold 40%)

### Pre-commit Bandit fix (bundled)

The bandit hook was scanning `venv/` (its `-x` globs didn't actually exclude it), producing 70 High findings in third-party deps that blocked every PR. Switched the hook to `-r cio` so only project source is scanned — 0 Medium / 0 High findings.

## Test plan
- [x] `make pipeline` passes locally (lint + format + 100 tests + bandit)
- [x] New tests: `tests/unit/test_router_governance_actions.py` covers enum membership, per-action NATS subject, audit persistence, and DRY_RUN suppression
- [ ] CI green on PR
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)