### PR TITLE
feat(cio): #114 - strategy lifecycle authority + state machine (P1.2)

### DIFF
--- a/cio/apps/lifecycle_api.py
+++ b/cio/apps/lifecycle_api.py
@@ -1,0 +1,225 @@
+"""FastAPI router for strategy lifecycle endpoints (P1.2, #114).
+
+Exposes:
+  POST /strategies/register        — register a new strategy definition (FR1, FR5)
+  GET  /strategies/{sid}/lifecycle — operator view of the full transition
+                                     history for one strategy (feeds FR9)
+  GET  /strategies                 — list all registered strategy ids
+
+The router is mounted by `cio.main` and reads/writes through a
+`StrategyLifecycleStore` instance held on `app.state.lifecycle_store`. The
+store is in-memory; persistence is intentionally pluggable so a future
+Mongo- or Qdrant-backed implementation can drop in without changing the
+endpoint contracts.
+
+Per the P0.1 cross-service identifier contract, every transition (including
+the genesis registration event) carries a `decision_id`. The registration
+endpoint accepts an optional `decision_id` in the request body; if omitted
+a new hex id is minted on the server side.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from cio.core.lifecycle import (
+    InvalidTransition,
+    LifecycleEvent,
+    LifecycleState,
+    StrategyAlreadyRegistered,
+    StrategyLifecycleStore,
+    StrategyNotRegistered,
+)
+
+router = APIRouter(prefix="/strategies", tags=["lifecycle"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class RegisterStrategyRequest(BaseModel):
+    """Request body for `POST /strategies/register`.
+
+    `definition` is intentionally an open dict — strategy definitions are
+    owned by the publishing service (`petrosa-bot-ta-analysis` /
+    `petrosa-realtime-strategies`). The CIO records them verbatim for
+    audit and replay; field-level validation is the publisher's
+    responsibility.
+    """
+
+    strategy_id: str = Field(..., min_length=1)
+    definition: dict[str, Any] = Field(default_factory=dict)
+    decision_id: str | None = Field(default=None)
+    reasoning: dict[str, Any] = Field(default_factory=dict)
+
+
+class LifecycleEventResponse(BaseModel):
+    strategy_id: str
+    from_state: LifecycleState | None
+    to_state: LifecycleState
+    action: str | None
+    decision_id: str
+    reasoning: dict[str, Any]
+    at: datetime
+
+    @classmethod
+    def from_event(cls, event: LifecycleEvent) -> LifecycleEventResponse:
+        return cls(
+            strategy_id=event.strategy_id,
+            from_state=event.from_state,
+            to_state=event.to_state,
+            action=event.action.value if event.action else None,
+            decision_id=event.decision_id,
+            reasoning=event.reasoning,
+            at=event.at,
+        )
+
+
+class RegisterStrategyResponse(BaseModel):
+    strategy_id: str
+    current_state: LifecycleState
+    event: LifecycleEventResponse
+
+
+class LifecycleHistoryResponse(BaseModel):
+    strategy_id: str
+    current_state: LifecycleState
+    history: list[LifecycleEventResponse]
+
+
+class StrategyListResponse(BaseModel):
+    strategy_ids: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Store access
+# ---------------------------------------------------------------------------
+
+
+def _store(request: Request) -> StrategyLifecycleStore:
+    """Resolve the lifecycle store from app state.
+
+    `cio.main` is expected to attach an instance on
+    `app.state.lifecycle_store` during startup. Tests can override via
+    the FastAPI dependency-override mechanism by mounting their own
+    `app.state.lifecycle_store` before sending requests.
+    """
+    store = getattr(request.app.state, "lifecycle_store", None)
+    if store is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="lifecycle store not initialized",
+        )
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/register",
+    response_model=RegisterStrategyResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def register_strategy(
+    payload: RegisterStrategyRequest, request: Request
+) -> RegisterStrategyResponse:
+    store = _store(request)
+    try:
+        event = store.register(
+            payload.strategy_id,
+            payload.definition,
+            decision_id=payload.decision_id,
+            reasoning=payload.reasoning,
+        )
+    except StrategyAlreadyRegistered as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"strategy_id {payload.strategy_id} already registered",
+        ) from exc
+    return RegisterStrategyResponse(
+        strategy_id=event.strategy_id,
+        current_state=store.get_state(event.strategy_id),
+        event=LifecycleEventResponse.from_event(event),
+    )
+
+
+@router.get(
+    "/{strategy_id}/lifecycle",
+    response_model=LifecycleHistoryResponse,
+)
+def get_lifecycle_history(
+    strategy_id: str, request: Request
+) -> LifecycleHistoryResponse:
+    store = _store(request)
+    try:
+        history = store.get_history(strategy_id)
+        current = store.get_state(strategy_id)
+    except StrategyNotRegistered as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"strategy_id {strategy_id} not registered",
+        ) from exc
+    return LifecycleHistoryResponse(
+        strategy_id=strategy_id,
+        current_state=current,
+        history=[LifecycleEventResponse.from_event(e) for e in history],
+    )
+
+
+@router.get(
+    "",
+    response_model=StrategyListResponse,
+)
+def list_strategies(request: Request) -> StrategyListResponse:
+    store = _store(request)
+    return StrategyListResponse(strategy_ids=list(store.list_strategies()))
+
+
+# ---------------------------------------------------------------------------
+# Internal: transition surface for in-process callers
+# ---------------------------------------------------------------------------
+#
+# The CIO's arbitration loop (`cio.core.orchestrator`, `cio.core.arbiter`)
+# calls into the lifecycle store directly — *not* through this HTTP router —
+# to drive transitions and emit ActionType events. The HTTP surface above is
+# intentionally read + register only. Wiring the in-process transition path
+# is owned by the orchestrator/arbiter integration that follows this ticket
+# (P1.3, sibling `petrosa-cio#115`).
+
+
+def install_invalid_transition_handler(app: Any) -> None:  # pragma: no cover
+    """Convert InvalidTransition into a 409 when the HTTP surface is extended."""
+
+    from fastapi import FastAPI
+
+    if not isinstance(app, FastAPI):
+        return
+
+    @app.exception_handler(InvalidTransition)
+    async def _handle(_request: Request, exc: InvalidTransition):  # noqa: ANN001
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content={"detail": str(exc)},
+        )
+
+
+__all__ = [
+    "LifecycleEventResponse",
+    "LifecycleHistoryResponse",
+    "RegisterStrategyRequest",
+    "RegisterStrategyResponse",
+    "StrategyListResponse",
+    "install_invalid_transition_handler",
+    "router",
+]

--- a/cio/core/lifecycle.py
+++ b/cio/core/lifecycle.py
@@ -1,0 +1,400 @@
+"""Strategy lifecycle authority + state machine (P1.2, #114).
+
+Owns the live-state of every strategy the CIO governs. Transitions emit
+`ActionType` events that the existing `OutputRouter` publishes on
+`cio.lifecycle.<kind>.<strategy_id>`, so downstream consumers (data-manager
+audit-trail, dashboard, FR9 history reader) see standing-state changes
+without touching the per-intent signal path.
+
+States and transitions:
+
+    Registered (definition received)
+        └── characterize() ──► Characterized (backtest complete)
+                                 ├── admit()       ──► Admitted   [emits ADMIT]
+                                 ├── admit_small() ──► OnTrial    [emits ADMIT_SMALL]
+                                 └── reject()      ──► Rejected   [emits REJECT, terminal]
+                          OnTrial
+                                 ├── promote()     ──► Graduated  [emits PROMOTE]
+                                 └── demote()      ──► Demoted    [emits DEMOTE]
+                          Graduated
+                                 ├── demote()      ──► Demoted    [emits DEMOTE]
+                                 └── retire()      ──► Retired    [emits RETIRE, terminal]
+                          Demoted
+                                 ├── promote()     ──► Graduated  [emits PROMOTE]
+                                 └── retire()      ──► Retired    [emits RETIRE, terminal]
+
+Every transition carries a `decision_id` (P0.1 contract). The transition
+helper raises `InvalidTransition` for any move not in the table above so
+guards are explicit and testable.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime
+from threading import Lock
+from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - py310 fallback
+    from enum import Enum
+
+    class StrEnum(str, Enum):  # type: ignore[no-redef]  # noqa: UP042
+        pass
+
+
+from cio.models.enums import ActionType
+
+
+class LifecycleState(StrEnum):
+    """Strategy lifecycle states owned by the CIO."""
+
+    REGISTERED = "registered"
+    CHARACTERIZED = "characterized"
+    ADMITTED = "admitted"
+    ON_TRIAL = "on_trial"
+    GRADUATED = "graduated"
+    DEMOTED = "demoted"
+    RETIRED = "retired"
+    REJECTED = "rejected"
+
+
+# Transitions allowed by the state machine. Key = (from_state, action),
+# value = to_state. Any (from_state, action) tuple not present in this map
+# results in `InvalidTransition`. The terminal states `RETIRED` and
+# `REJECTED` have no outgoing transitions.
+_ALLOWED: dict[tuple[LifecycleState, ActionType], LifecycleState] = {
+    # Characterized branches
+    (LifecycleState.CHARACTERIZED, ActionType.ADMIT): LifecycleState.ADMITTED,
+    (LifecycleState.CHARACTERIZED, ActionType.ADMIT_SMALL): LifecycleState.ON_TRIAL,
+    (LifecycleState.CHARACTERIZED, ActionType.REJECT): LifecycleState.REJECTED,
+    # On-trial branches
+    (LifecycleState.ON_TRIAL, ActionType.PROMOTE): LifecycleState.GRADUATED,
+    (LifecycleState.ON_TRIAL, ActionType.DEMOTE): LifecycleState.DEMOTED,
+    # Graduated branches
+    (LifecycleState.GRADUATED, ActionType.DEMOTE): LifecycleState.DEMOTED,
+    (LifecycleState.GRADUATED, ActionType.RETIRE): LifecycleState.RETIRED,
+    # Demoted branches
+    (LifecycleState.DEMOTED, ActionType.PROMOTE): LifecycleState.GRADUATED,
+    (LifecycleState.DEMOTED, ActionType.RETIRE): LifecycleState.RETIRED,
+    # Admitted branches (post-trial direct admission to full weight; may still retire)
+    (LifecycleState.ADMITTED, ActionType.RETIRE): LifecycleState.RETIRED,
+    (LifecycleState.ADMITTED, ActionType.DEMOTE): LifecycleState.DEMOTED,
+}
+
+
+class InvalidTransition(ValueError):
+    """Raised when an unsupported (state, action) pair is attempted."""
+
+
+class StrategyNotRegistered(KeyError):
+    """Raised when an operation references an unknown strategy_id."""
+
+
+class StrategyAlreadyRegistered(ValueError):
+    """Raised when `register()` is called twice for the same strategy_id."""
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """A single transition recorded in the lifecycle history.
+
+    Each event carries the cross-service `decision_id` so audit-trail consumers
+    can join lifecycle events with intent / decision / execution records.
+    """
+
+    strategy_id: str
+    from_state: LifecycleState | None
+    to_state: LifecycleState
+    action: ActionType | None
+    decision_id: str
+    reasoning: dict[str, Any]
+    at: datetime
+
+
+@dataclass
+class StrategyLifecycle:
+    """In-memory lifecycle record for a single strategy."""
+
+    strategy_id: str
+    definition: dict[str, Any]
+    current_state: LifecycleState
+    history: list[LifecycleEvent] = field(default_factory=list)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _new_decision_id() -> str:
+    return uuid.uuid4().hex
+
+
+class StrategyLifecycleStore:
+    """In-memory authority for strategy lifecycles.
+
+    Thread-safe via a single mutex (lifecycle transitions are low-throughput).
+    Persistence is intentionally pluggable: the public API exposes only what
+    a future Mongo- or Qdrant-backed store would need to satisfy. The audit-
+    trail itself (the durable record of state changes) is owned by
+    `petrosa-data-manager` via the `cio.lifecycle.<kind>.<sid>` NATS subjects.
+
+    Per FR9: `get_history(strategy_id)` returns the full sequence of
+    transitions for an operator view; per the P0.1 contract, every event
+    in the history carries a `decision_id`.
+    """
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._strategies: dict[str, StrategyLifecycle] = {}
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register(
+        self,
+        strategy_id: str,
+        definition: dict[str, Any],
+        *,
+        decision_id: str | None = None,
+        reasoning: dict[str, Any] | None = None,
+    ) -> LifecycleEvent:
+        """Register a new strategy in `REGISTERED` state.
+
+        Raises `StrategyAlreadyRegistered` if the strategy_id already exists.
+        Returns the genesis `LifecycleEvent` (no `from_state`, no `action`).
+        """
+        decision_id = decision_id or _new_decision_id()
+        with self._lock:
+            if strategy_id in self._strategies:
+                raise StrategyAlreadyRegistered(strategy_id)
+            event = LifecycleEvent(
+                strategy_id=strategy_id,
+                from_state=None,
+                to_state=LifecycleState.REGISTERED,
+                action=None,
+                decision_id=decision_id,
+                reasoning=dict(reasoning or {}),
+                at=_now(),
+            )
+            self._strategies[strategy_id] = StrategyLifecycle(
+                strategy_id=strategy_id,
+                definition=dict(definition),
+                current_state=LifecycleState.REGISTERED,
+                history=[event],
+            )
+        return event
+
+    # ------------------------------------------------------------------
+    # Internal transition primitive
+    # ------------------------------------------------------------------
+
+    def _transition(
+        self,
+        strategy_id: str,
+        action: ActionType,
+        *,
+        decision_id: str | None,
+        reasoning: dict[str, Any] | None,
+    ) -> LifecycleEvent:
+        decision_id = decision_id or _new_decision_id()
+        with self._lock:
+            record = self._strategies.get(strategy_id)
+            if record is None:
+                raise StrategyNotRegistered(strategy_id)
+            from_state = record.current_state
+            try:
+                to_state = _ALLOWED[(from_state, action)]
+            except KeyError as exc:
+                raise InvalidTransition(
+                    f"strategy={strategy_id} cannot {action.value} "
+                    f"from state {from_state.value}"
+                ) from exc
+            event = LifecycleEvent(
+                strategy_id=strategy_id,
+                from_state=from_state,
+                to_state=to_state,
+                action=action,
+                decision_id=decision_id,
+                reasoning=dict(reasoning or {}),
+                at=_now(),
+            )
+            record.current_state = to_state
+            record.history.append(event)
+        return event
+
+    # ------------------------------------------------------------------
+    # Public transition helpers
+    # ------------------------------------------------------------------
+
+    def characterize(
+        self,
+        strategy_id: str,
+        *,
+        decision_id: str | None = None,
+        reasoning: dict[str, Any] | None = None,
+    ) -> LifecycleEvent:
+        """Move REGISTERED → CHARACTERIZED. Internal transition, no ActionType emitted.
+
+        Characterization is a backtest-complete signal; downstream consumers
+        do not need a NATS event for it, so this transition does not produce
+        an `ActionType`. Caller passes the resulting `LifecycleEvent` to the
+        history; nothing is published.
+        """
+        decision_id = decision_id or _new_decision_id()
+        with self._lock:
+            record = self._strategies.get(strategy_id)
+            if record is None:
+                raise StrategyNotRegistered(strategy_id)
+            if record.current_state is not LifecycleState.REGISTERED:
+                raise InvalidTransition(
+                    f"strategy={strategy_id} cannot characterize from state "
+                    f"{record.current_state.value}"
+                )
+            event = LifecycleEvent(
+                strategy_id=strategy_id,
+                from_state=LifecycleState.REGISTERED,
+                to_state=LifecycleState.CHARACTERIZED,
+                action=None,
+                decision_id=decision_id,
+                reasoning=dict(reasoning or {}),
+                at=_now(),
+            )
+            record.current_state = LifecycleState.CHARACTERIZED
+            record.history.append(event)
+        return event
+
+    def admit(
+        self,
+        strategy_id: str,
+        *,
+        decision_id: str | None = None,
+        reasoning: dict[str, Any] | None = None,
+    ) -> LifecycleEvent:
+        return self._transition(
+            strategy_id,
+            ActionType.ADMIT,
+            decision_id=decision_id,
+            reasoning=reasoning,
+        )
+
+    def admit_small(
+        self,
+        strategy_id: str,
+        *,
+        decision_id: str | None = None,
+        reasoning: dict[str, Any] | None = None,
+    ) -> LifecycleEvent:
+        return self._transition(
+            strategy_id,
+            ActionType.ADMIT_SMALL,
+            decision_id=decision_id,
+            reasoning=reasoning,
+        )
+
+    def reject(
+        self,
+        strategy_id: str,
+        *,
+        decision_id: str | None = None,
+        reasoning: dict[str, Any] | None = None,
+    ) -> LifecycleEvent:
+        return self._transition(
+            strategy_id,
+            ActionType.REJECT,
+            decision_id=decision_id,
+            reasoning=reasoning,
+        )
+
+    def promote(
+        self,
+        strategy_id: str,
+        *,
+        decision_id: str | None = None,
+        reasoning: dict[str, Any] | None = None,
+    ) -> LifecycleEvent:
+        return self._transition(
+            strategy_id,
+            ActionType.PROMOTE,
+            decision_id=decision_id,
+            reasoning=reasoning,
+        )
+
+    def demote(
+        self,
+        strategy_id: str,
+        *,
+        decision_id: str | None = None,
+        reasoning: dict[str, Any] | None = None,
+    ) -> LifecycleEvent:
+        return self._transition(
+            strategy_id,
+            ActionType.DEMOTE,
+            decision_id=decision_id,
+            reasoning=reasoning,
+        )
+
+    def retire(
+        self,
+        strategy_id: str,
+        *,
+        decision_id: str | None = None,
+        reasoning: dict[str, Any] | None = None,
+    ) -> LifecycleEvent:
+        return self._transition(
+            strategy_id,
+            ActionType.RETIRE,
+            decision_id=decision_id,
+            reasoning=reasoning,
+        )
+
+    # ------------------------------------------------------------------
+    # Read API (feeds FR9)
+    # ------------------------------------------------------------------
+
+    def get_state(self, strategy_id: str) -> LifecycleState:
+        with self._lock:
+            record = self._strategies.get(strategy_id)
+            if record is None:
+                raise StrategyNotRegistered(strategy_id)
+            return record.current_state
+
+    def get_history(self, strategy_id: str) -> list[LifecycleEvent]:
+        with self._lock:
+            record = self._strategies.get(strategy_id)
+            if record is None:
+                raise StrategyNotRegistered(strategy_id)
+            return list(record.history)
+
+    def get_definition(self, strategy_id: str) -> dict[str, Any]:
+        with self._lock:
+            record = self._strategies.get(strategy_id)
+            if record is None:
+                raise StrategyNotRegistered(strategy_id)
+            return dict(record.definition)
+
+    def list_strategies(self) -> Iterable[str]:
+        with self._lock:
+            return list(self._strategies.keys())
+
+
+__all__ = [
+    "InvalidTransition",
+    "LifecycleEvent",
+    "LifecycleState",
+    "StrategyAlreadyRegistered",
+    "StrategyLifecycle",
+    "StrategyLifecycleStore",
+    "StrategyNotRegistered",
+]

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -15,6 +15,20 @@ from cio.output.translator import TradeEngineTranslator
 logger = logging.getLogger(__name__)
 
 
+# Lifecycle ActionType values (per #114 P1.2). Kept as a module-level set so the
+# router's elif chain can use a single membership check instead of six branches.
+_LIFECYCLE_ACTIONS = frozenset(
+    {
+        ActionType.ADMIT,
+        ActionType.ADMIT_SMALL,
+        ActionType.REJECT,
+        ActionType.PROMOTE,
+        ActionType.DEMOTE,
+        ActionType.RETIRE,
+    }
+)
+
+
 class NATSClientProtocol(Protocol):
     """Structural protocol for NATS client to ensure testability."""
 
@@ -332,6 +346,18 @@ class OutputRouter:
             # notified (audit/dashboard) instead of silently dropping the intent.
             dispatch_tasks_data.append(
                 (f"cio.veto.{strategy_id}", decision.model_dump_json().encode())
+            )
+        elif action in _LIFECYCLE_ACTIONS:
+            # Lifecycle (per #114 P1.2): every transition emitted by the strategy
+            # lifecycle state machine publishes on `cio.lifecycle.<kind>.<sid>`.
+            # Subscribers (data-manager audit-trail, dashboard, lifecycle reader)
+            # observe the standing-state changes without touching the per-intent
+            # signal path.
+            dispatch_tasks_data.append(
+                (
+                    f"cio.lifecycle.{action.value}.{strategy_id}",
+                    decision.model_dump_json().encode(),
+                )
             )
         elif action == ActionType.FAIL_SAFE:
             # 1. NATS Failure Signal

--- a/cio/main.py
+++ b/cio/main.py
@@ -8,12 +8,14 @@ import uvicorn
 from fastapi import FastAPI
 from nats.aio.client import Client as NATS
 
+from cio.apps.lifecycle_api import router as lifecycle_router
 from cio.apps.nurse.enforcer import NurseEnforcer
 from cio.clients.factory import ClientFactory
 from cio.core.arbiter import SignalArbiter
 from cio.core.cache import AsyncRedisCache
 from cio.core.context_builder import ContextBuilder
 from cio.core.heartbeat import HeartbeatPublisher, HeartbeatResponder
+from cio.core.lifecycle import StrategyLifecycleStore
 from cio.core.listener import NATSListener
 from cio.core.orchestrator import Orchestrator
 from cio.core.router import OutputRouter
@@ -53,6 +55,12 @@ logger = logging.getLogger("cio-strategist")
 
 # Initialize FastAPI for health checks
 app = FastAPI(title="Petrosa CIO Health")
+
+# Strategy lifecycle store (P1.2, #114) is shared between the HTTP surface and
+# the in-process arbitration loop. The store is in-memory today; persistence
+# is pluggable behind the StrategyLifecycleStore API.
+app.state.lifecycle_store = StrategyLifecycleStore()
+app.include_router(lifecycle_router)
 
 
 @app.get("/health/liveness")

--- a/cio/models/enums.py
+++ b/cio/models/enums.py
@@ -97,6 +97,15 @@ class ActionType(StrEnum):
     DOWN_WEIGHT = "down_weight"
     THROTTLE = "throttle"
     VETO = "veto"
+    # Lifecycle actions (per #114 P1.2). Emitted by the strategy lifecycle state
+    # machine when a registered strategy transitions between states. Each maps
+    # to a `cio.lifecycle.<kind>.<strategy_id>` subject — see cio/core/router.py.
+    ADMIT = "admit"
+    ADMIT_SMALL = "admit_small"
+    REJECT = "reject"
+    PROMOTE = "promote"
+    DEMOTE = "demote"
+    RETIRE = "retire"
 
 
 class TriggerType(StrEnum):

--- a/tests/unit/test_lifecycle_api.py
+++ b/tests/unit/test_lifecycle_api.py
@@ -1,0 +1,134 @@
+"""Tests for the strategy lifecycle FastAPI router (P1.2, #114).
+
+Covers:
+  * POST /strategies/register — happy path + duplicate (409) + minted decision_id
+  * GET  /strategies/{sid}/lifecycle — returns history with current state
+  * GET  /strategies — lists registered ids
+  * 404 when the lifecycle store has no record of the strategy
+  * 503 when the lifecycle store is missing from app.state
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cio.apps.lifecycle_api import router as lifecycle_router
+from cio.core.lifecycle import StrategyLifecycleStore
+
+
+@pytest.fixture
+def app_with_store() -> FastAPI:
+    app = FastAPI()
+    app.state.lifecycle_store = StrategyLifecycleStore()
+    app.include_router(lifecycle_router)
+    return app
+
+
+@pytest.fixture
+def client(app_with_store) -> TestClient:
+    return TestClient(app_with_store)
+
+
+# ---------------------------------------------------------------------------
+# Registration endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_register_strategy_returns_genesis_event(client):
+    resp = client.post(
+        "/strategies/register",
+        json={
+            "strategy_id": "strat_alpha",
+            "definition": {"family": "mean_rev", "version": "1.0.0"},
+            "decision_id": "dec-alpha",
+            "reasoning": {"why": "operator_request"},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["strategy_id"] == "strat_alpha"
+    assert body["current_state"] == "registered"
+    assert body["event"]["from_state"] is None
+    assert body["event"]["to_state"] == "registered"
+    assert body["event"]["action"] is None
+    assert body["event"]["decision_id"] == "dec-alpha"
+
+
+def test_register_mints_decision_id_when_omitted(client):
+    resp = client.post(
+        "/strategies/register",
+        json={"strategy_id": "strat_alpha", "definition": {}},
+    )
+    assert resp.status_code == 201
+    minted = resp.json()["event"]["decision_id"]
+    assert minted and len(minted) >= 16
+
+
+def test_register_duplicate_returns_409(client):
+    payload = {"strategy_id": "strat_alpha", "definition": {}}
+    assert client.post("/strategies/register", json=payload).status_code == 201
+    resp = client.post("/strategies/register", json=payload)
+    assert resp.status_code == 409
+    assert "already registered" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# History endpoint (feeds FR9)
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_history_returns_current_and_history(app_with_store):
+    # Mutate the store directly to seed a multi-event history.
+    store: StrategyLifecycleStore = app_with_store.state.lifecycle_store
+    store.register("strat_alpha", {"family": "mean_rev"})
+    store.characterize("strat_alpha", reasoning={"backtest": "passed"})
+    store.admit("strat_alpha", reasoning={"size": "full"})
+
+    client = TestClient(app_with_store)
+    resp = client.get("/strategies/strat_alpha/lifecycle")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["strategy_id"] == "strat_alpha"
+    assert body["current_state"] == "admitted"
+    actions = [e["action"] for e in body["history"]]
+    assert actions == [None, None, "admit"]
+    # Every event in the history carries a decision_id (P0.1 contract).
+    assert all(e["decision_id"] for e in body["history"])
+
+
+def test_lifecycle_history_unknown_strategy_404(client):
+    resp = client.get("/strategies/ghost/lifecycle")
+    assert resp.status_code == 404
+    assert "not registered" in resp.json()["detail"]
+
+
+def test_list_strategies(client):
+    client.post(
+        "/strategies/register",
+        json={"strategy_id": "a", "definition": {}},
+    )
+    client.post(
+        "/strategies/register",
+        json={"strategy_id": "b", "definition": {}},
+    )
+    resp = client.get("/strategies")
+    assert resp.status_code == 200
+    assert set(resp.json()["strategy_ids"]) == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# Store missing from app.state (defensive)
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_returns_503_when_store_missing():
+    app = FastAPI()
+    app.include_router(lifecycle_router)
+    client = TestClient(app)
+    resp = client.post(
+        "/strategies/register",
+        json={"strategy_id": "x", "definition": {}},
+    )
+    assert resp.status_code == 503

--- a/tests/unit/test_lifecycle_state_machine.py
+++ b/tests/unit/test_lifecycle_state_machine.py
@@ -1,0 +1,199 @@
+"""Tests for the strategy lifecycle state machine (P1.2, #114).
+
+Covers the happy-path traversal of every documented transition and the
+per-transition guard rails (invalid (from_state, action) pairs raise).
+Every transition is verified to carry a `decision_id` per the P0.1
+cross-service identifier contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cio.core.lifecycle import (
+    InvalidTransition,
+    LifecycleState,
+    StrategyAlreadyRegistered,
+    StrategyLifecycleStore,
+    StrategyNotRegistered,
+)
+from cio.models.enums import ActionType
+
+SID = "strat_test"
+DEF = {"family": "momentum", "version": "1.0.0"}
+
+
+@pytest.fixture
+def store() -> StrategyLifecycleStore:
+    return StrategyLifecycleStore()
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_creates_registered_state_with_genesis_event(store):
+    event = store.register(SID, DEF, decision_id="dec-1", reasoning={"why": "new"})
+
+    assert store.get_state(SID) is LifecycleState.REGISTERED
+    assert event.from_state is None
+    assert event.action is None  # genesis event has no action
+    assert event.to_state is LifecycleState.REGISTERED
+    assert event.decision_id == "dec-1"
+    assert event.reasoning == {"why": "new"}
+
+    history = store.get_history(SID)
+    assert history == [event]
+
+
+def test_register_mints_decision_id_when_omitted(store):
+    event = store.register(SID, DEF)
+    assert event.decision_id
+    assert len(event.decision_id) >= 16  # uuid4 hex
+
+
+def test_register_duplicates_rejected(store):
+    store.register(SID, DEF)
+    with pytest.raises(StrategyAlreadyRegistered) as exc_info:
+        store.register(SID, DEF)
+    assert SID in str(exc_info.value)
+
+
+def test_transition_on_unknown_strategy_raises(store):
+    with pytest.raises(StrategyNotRegistered) as exc_info:
+        store.admit("ghost")
+    assert "ghost" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — full traversal through PROMOTE → DEMOTE → RETIRE
+# ---------------------------------------------------------------------------
+
+
+def test_full_happy_path_registered_through_retired(store):
+    store.register(SID, DEF)
+    store.characterize(SID)
+    store.admit_small(SID, reasoning={"size": "small"})
+    store.promote(SID, reasoning={"perf": "exceeds_target"})
+    store.demote(SID, reasoning={"perf": "drift"})
+    store.promote(SID, reasoning={"perf": "recovered"})  # demoted → graduated
+    final = store.retire(SID, reasoning={"reason": "operator_request"})
+
+    assert final.to_state is LifecycleState.RETIRED
+    assert store.get_state(SID) is LifecycleState.RETIRED
+
+    history = store.get_history(SID)
+    actions = [e.action.value if e.action else None for e in history]
+    assert actions == [
+        None,  # genesis (REGISTERED)
+        None,  # characterize (internal transition)
+        ActionType.ADMIT_SMALL.value,
+        ActionType.PROMOTE.value,
+        ActionType.DEMOTE.value,
+        ActionType.PROMOTE.value,
+        ActionType.RETIRE.value,
+    ]
+    # Every event carries a decision_id (P0.1 contract).
+    assert all(e.decision_id for e in history)
+
+
+def test_characterize_to_admit_full_weight(store):
+    store.register(SID, DEF)
+    store.characterize(SID)
+    event = store.admit(SID, reasoning={"size": "full"})
+    assert event.to_state is LifecycleState.ADMITTED
+    assert event.action is ActionType.ADMIT
+
+
+def test_characterize_to_reject_terminal(store):
+    store.register(SID, DEF)
+    store.characterize(SID)
+    event = store.reject(SID, reasoning={"why": "backtest_fail"})
+    assert event.to_state is LifecycleState.REJECTED
+    # Rejected is terminal — any further transition fails.
+    with pytest.raises(InvalidTransition):
+        store.promote(SID)
+    with pytest.raises(InvalidTransition):
+        store.retire(SID)
+
+
+# ---------------------------------------------------------------------------
+# Transition guards — invalid (from_state, action) raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "premature_action_name",
+    ["admit", "admit_small", "reject", "promote", "demote", "retire"],
+)
+def test_transitions_from_registered_are_blocked_before_characterize(
+    store, premature_action_name
+):
+    store.register(SID, DEF)
+    method = getattr(store, premature_action_name)
+    with pytest.raises(InvalidTransition) as exc_info:
+        method(SID)
+    assert "registered" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "invalid_after_admit_small",
+    ["admit", "admit_small", "reject"],
+)
+def test_on_trial_blocks_pre_trial_transitions(store, invalid_after_admit_small):
+    store.register(SID, DEF)
+    store.characterize(SID)
+    store.admit_small(SID)
+    # From ON_TRIAL only promote / demote are valid.
+    method = getattr(store, invalid_after_admit_small)
+    with pytest.raises(InvalidTransition) as exc_info:
+        method(SID)
+    assert "on_trial" in str(exc_info.value)
+
+
+def test_admitted_can_retire_or_demote_but_not_promote(store):
+    store.register(SID, DEF)
+    store.characterize(SID)
+    store.admit(SID)
+    # Promote is not valid from Admitted (full weight already).
+    with pytest.raises(InvalidTransition):
+        store.promote(SID)
+    # Demote and retire are valid from Admitted.
+    store.demote(SID)
+    assert store.get_state(SID) is LifecycleState.DEMOTED
+
+
+def test_retired_is_terminal(store):
+    store.register(SID, DEF)
+    store.characterize(SID)
+    store.admit_small(SID)
+    store.promote(SID)
+    store.retire(SID)
+    blocked_methods = ("admit", "admit_small", "promote", "demote", "retire")
+    for method_name in blocked_methods:
+        method = getattr(store, method_name)
+        with pytest.raises(InvalidTransition) as exc_info:
+            method(SID)
+        assert "retired" in str(exc_info.value)
+    assert store.get_state(SID) is LifecycleState.RETIRED
+
+
+# ---------------------------------------------------------------------------
+# Read API surface
+# ---------------------------------------------------------------------------
+
+
+def test_list_strategies_and_definition_access(store):
+    store.register("a", {"family": "mean_rev"})
+    store.register("b", {"family": "momentum"})
+    assert set(store.list_strategies()) == {"a", "b"}
+    assert store.get_definition("a") == {"family": "mean_rev"}
+
+
+def test_history_is_defensive_copy(store):
+    store.register(SID, DEF)
+    history = store.get_history(SID)
+    history.clear()
+    # The store's internal history must be untouched.
+    assert len(store.get_history(SID)) == 1

--- a/tests/unit/test_router_lifecycle_actions.py
+++ b/tests/unit/test_router_lifecycle_actions.py
@@ -1,0 +1,158 @@
+"""Per #114 P1.2: lifecycle action types (ADMIT, ADMIT_SMALL, REJECT, PROMOTE,
+DEMOTE, RETIRE).
+
+Verifies the router emits each lifecycle action on its dedicated NATS subject
+(`cio.lifecycle.<kind>.<strategy_id>`) and that the audit path persists the
+new actions through the existing vector-client upsert (no new persistence
+code path required, mirroring the #589 governance pattern).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cio.core.router import OutputRouter
+from cio.models import (
+    ActionType,
+    ActivationRecommendation,
+    ConfidenceLevel,
+    DecisionResult,
+    HealthStatus,
+    RegimeFit,
+    TriggerContext,
+)
+
+LIFECYCLE_ACTIONS = [
+    ActionType.ADMIT,
+    ActionType.ADMIT_SMALL,
+    ActionType.REJECT,
+    ActionType.PROMOTE,
+    ActionType.DEMOTE,
+    ActionType.RETIRE,
+]
+
+
+def _make_decision(action: ActionType) -> DecisionResult:
+    return DecisionResult(
+        hard_blocked=False,
+        ev_passes=True,
+        cost_viable=True,
+        regime_confidence=ConfidenceLevel.HIGH,
+        regime_fit=RegimeFit.GOOD,
+        strategy_health=HealthStatus.HEALTHY,
+        activation_recommendation=ActivationRecommendation.RUN,
+        action=action,
+        justification="lifecycle reasoning",
+        thought_trace="audit trace",
+    )
+
+
+def _make_context(strategy_id: str) -> TriggerContext:
+    ctx = MagicMock(spec=TriggerContext)
+    ctx.strategy_id = strategy_id
+    ctx.decision_id = "decision-114"
+    ctx.correlation_id = "corr-114"
+    ctx.trigger_payload = {"symbol": "BTCUSDT"}
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Enum
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_action_types_exposed():
+    """Enum carries the six lifecycle values added by P1.2."""
+    assert ActionType.ADMIT.value == "admit"
+    assert ActionType.ADMIT_SMALL.value == "admit_small"
+    assert ActionType.REJECT.value == "reject"
+    assert ActionType.PROMOTE.value == "promote"
+    assert ActionType.DEMOTE.value == "demote"
+    assert ActionType.RETIRE.value == "retire"
+
+
+# ---------------------------------------------------------------------------
+# NATS dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", LIFECYCLE_ACTIONS)
+async def test_lifecycle_action_publishes_on_dedicated_subject(action: ActionType):
+    """Each lifecycle action publishes to cio.lifecycle.<kind>.<sid> with the decision JSON."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    strategy_id = "momentum_pulse"
+    context = _make_context(strategy_id)
+    decision = _make_decision(action)
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(context, decision)
+
+    mock_nc.publish.assert_called_once()
+    subject, payload_bytes = mock_nc.publish.call_args.args
+    assert subject == f"cio.lifecycle.{action.value}.{strategy_id}"
+
+    payload = json.loads(payload_bytes.decode())
+    assert payload["action"] == action.value
+    assert payload["justification"] == "lifecycle reasoning"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", LIFECYCLE_ACTIONS)
+async def test_lifecycle_action_persists_audit_with_decision_id(action: ActionType):
+    """Audit upsert is called for each lifecycle action and carries decision_id."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    strategy_id = "momentum_pulse"
+    context = _make_context(strategy_id)
+    decision = _make_decision(action)
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(context, decision)
+
+    mock_vc.upsert.assert_called_once()
+    upsert_kwargs = mock_vc.upsert.call_args.kwargs
+    assert upsert_kwargs["strategy_id"] == strategy_id
+    audit_payload = upsert_kwargs["payload"]
+    assert audit_payload["action"] == action.value
+    assert audit_payload["decision_id"] == "decision-114"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", LIFECYCLE_ACTIONS)
+async def test_lifecycle_action_dry_run_skips_publish(action: ActionType):
+    """In DRY_RUN, lifecycle actions log but do not publish (mirrors #589)."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    context = _make_context("momentum_pulse")
+    decision = _make_decision(action)
+
+    with patch.dict(os.environ, {"DRY_RUN": "true"}):
+        await router.route(context, decision)
+
+    mock_nc.publish.assert_not_called()
+    # Audit still happens in dry-run (it's the durable record of intent).
+    mock_vc.upsert.assert_called_once()


### PR DESCRIPTION
## Summary

Implements [PetroSa2/petrosa-cio#114](https://github.com/PetroSa2/petrosa-cio/issues/114) (P1.2). FRs covered: FR1, FR5, FR6, FR7, FR8 (moves FR8 from YELLOW to GREEN — graduated demote/promote now exists alongside binary pause).

Builds directly on [#113](https://github.com/PetroSa2/petrosa-cio/pull/113) (#589 governance action types). Same router shape, same audit-path contract.

## Changes

| Layer | File | What |
|---|---|---|
| Enum | [cio/models/enums.py](cio/models/enums.py) | +6 ActionType: `ADMIT`, `ADMIT_SMALL`, `REJECT`, `PROMOTE`, `DEMOTE`, `RETIRE` |
| Router | [cio/core/router.py](cio/core/router.py) | Single `elif action in _LIFECYCLE_ACTIONS` publishes to `cio.lifecycle.<kind>.<sid>` with full DecisionResult JSON. Audit path uses existing vector-client upsert (decision_id flows through). |
| State machine | [cio/core/lifecycle.py](cio/core/lifecycle.py) | New `StrategyLifecycleStore` — Registered → Characterized → Admitted \| OnTrial → Graduated ↔ Demoted → Retired. Thread-safe, in-memory, pluggable persistence. `InvalidTransition` for every guard. |
| HTTP | [cio/apps/lifecycle_api.py](cio/apps/lifecycle_api.py) + [cio/main.py](cio/main.py) | `POST /strategies/register`, `GET /strategies/{sid}/lifecycle`, `GET /strategies`. Mounted on the existing FastAPI health-check app. |

## Acceptance Criteria

- [x] **Strategy registration endpoint accepts a strategy definition (FR1, FR5)** — `POST /strategies/register` accepts `{strategy_id, definition, decision_id?, reasoning?}` and returns the genesis lifecycle event.
- [x] **State transitions emit ActionType events with reasoning context (FR12 path)** — `OutputRouter` publishes each lifecycle ActionType on `cio.lifecycle.<kind>.<sid>` with the full DecisionResult including `justification` and `thought_trace`.
- [x] **Lifecycle history is queryable per strategy (feeds FR9)** — `GET /strategies/{sid}/lifecycle` returns `{current_state, history: [LifecycleEvent...]}`. In-memory today; persistence pluggable.
- [x] **All transitions carry `decision_id` per the P0.1 contract** — `LifecycleEvent.decision_id` is required; the store mints a `uuid4().hex` when the caller omits one; tests assert presence on every event.
- [x] **Tests cover happy path + each transition guard** — 46 new unit tests (20 state-machine + 19 router + 7 HTTP). Full suite: **146/146 passing**.

## In-process vs HTTP transition surface

The HTTP surface is intentionally **read + register only**. The CIO's arbitration loop (`cio.core.orchestrator` / `cio.core.arbiter`) calls into `StrategyLifecycleStore` directly to drive transitions and emit ActionType events. Wiring the orchestrator/arbiter into the transition surface is owned by sibling ticket [#115](https://github.com/PetroSa2/petrosa-cio/issues/115) (P1.3 — per-decision-type CIO authority demote/revoke).

## Test plan

- [x] `venv/bin/python -m pytest tests/unit/ -v` — 142/142 PASS
- [x] `venv/bin/python -m pytest tests/ -v` — 146/146 PASS (incl. existing integration suite)
- [x] `venv/bin/ruff check cio/ tests/unit/` — clean
- [x] `venv/bin/ruff format` — clean
- [x] Pre-commit hooks pass on commit (ruff, gitleaks, bandit, yaml, test-assertions)

## References

- Issue: [PetroSa2/petrosa-cio#114](https://github.com/PetroSa2/petrosa-cio/issues/114)
- Parent epic: `petrosa_k8s` P1.x MVP epic
- Predecessor (ActionType extension): [petrosa-cio#113](https://github.com/PetroSa2/petrosa-cio/pull/113) (#589 P1.1)
- decision_id contract: P0.1 (approved 2026-05-16) — `petrosa_k8s/docs/cross-service-identifier-contract.md`
- Sibling ticket (next phase): [petrosa-cio#115](https://github.com/PetroSa2/petrosa-cio/issues/115) (P1.3)
- MemPalace pre-flight comment: [#114 comment 4498533184](https://github.com/PetroSa2/petrosa-cio/issues/114#issuecomment-4498533184)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>