### PR TITLE
feat(cio): #115 - per-action authority + operator-approval queue (P1.3)

### DIFF
--- a/cio/apps/authority_api.py
+++ b/cio/apps/authority_api.py
@@ -1,0 +1,266 @@
+"""FastAPI router for per-action authority + pending-approval queue (P1.3, #115).
+
+Exposes:
+  GET    /authority                       — current state of every ActionType
+  GET    /authority/{action}              — state of a single action
+  PUT    /authority/{action}              — operator mutates the state
+  GET    /authority/audit                 — change history (operator id + reason)
+  GET    /authority/pending               — list decisions awaiting approval
+  POST   /authority/pending/{queue_id}/approve  — operator approves; payload dispatches
+  POST   /authority/pending/{queue_id}/reject   — operator rejects; payload discarded
+
+The router is mounted by `cio.main`. It reads/writes through an
+`AuthorityStore` instance attached to `app.state.authority_store`.
+
+Operator identity (`operator_id`) is passed in the request body for mutating
+calls and recorded on every audit-log entry. Single-operator deployment
+today; the field is captured so the audit trail is intact when SSO lands.
+
+`POST /authority/pending/{queue_id}/approve` does NOT re-dispatch the
+decision from this HTTP path — the approval result is returned to the
+caller, which is expected to feed the payload back into `OutputRouter` (or
+the calling test). The router is intentionally pure REST over the store;
+dispatching from a request handler would introduce a circular import.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from cio.core.authority import (
+    ActionAuthority,
+    AuthorityChange,
+    AuthorityStore,
+    PendingDecision,
+    PendingResolution,
+)
+from cio.models.enums import ActionType
+
+router = APIRouter(prefix="/authority", tags=["authority"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class AuthorityStateResponse(BaseModel):
+    action: ActionType
+    state: ActionAuthority
+
+
+class AuthorityListResponse(BaseModel):
+    states: list[AuthorityStateResponse]
+
+
+class AuthorityUpdateRequest(BaseModel):
+    state: ActionAuthority
+    operator_id: str = Field(..., min_length=1)
+    reason: str = Field(default="")
+
+
+class AuthorityChangeResponse(BaseModel):
+    action: ActionType
+    from_state: ActionAuthority
+    to_state: ActionAuthority
+    operator_id: str
+    reason: str
+    at: datetime
+
+    @classmethod
+    def from_change(cls, change: AuthorityChange) -> AuthorityChangeResponse:
+        return cls(
+            action=change.action,
+            from_state=change.from_state,
+            to_state=change.to_state,
+            operator_id=change.operator_id,
+            reason=change.reason,
+            at=change.at,
+        )
+
+
+class AuthorityAuditResponse(BaseModel):
+    changes: list[AuthorityChangeResponse]
+
+
+class PendingDecisionResponse(BaseModel):
+    queue_id: str
+    action: ActionType
+    strategy_id: str
+    decision_id: str
+    correlation_id: str
+    context_payload: dict[str, Any]
+    decision_payload: dict[str, Any]
+    at: datetime
+
+    @classmethod
+    def from_pending(cls, pending: PendingDecision) -> PendingDecisionResponse:
+        return cls(
+            queue_id=pending.queue_id,
+            action=pending.action,
+            strategy_id=pending.strategy_id,
+            decision_id=pending.decision_id,
+            correlation_id=pending.correlation_id,
+            context_payload=pending.context_payload,
+            decision_payload=pending.decision_payload,
+            at=pending.at,
+        )
+
+
+class PendingListResponse(BaseModel):
+    pending: list[PendingDecisionResponse]
+
+
+class ResolvePendingRequest(BaseModel):
+    operator_id: str = Field(..., min_length=1)
+    reason: str = Field(default="")
+
+
+class ResolvePendingResponse(BaseModel):
+    queue_id: str
+    approved: bool
+    operator_id: str
+    reason: str
+    at: datetime
+    pending: PendingDecisionResponse
+
+    @classmethod
+    def from_resolution(cls, resolution: PendingResolution) -> ResolvePendingResponse:
+        return cls(
+            queue_id=resolution.queue_id,
+            approved=resolution.approved,
+            operator_id=resolution.operator_id,
+            reason=resolution.reason,
+            at=resolution.at,
+            pending=PendingDecisionResponse.from_pending(resolution.pending),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Store access
+# ---------------------------------------------------------------------------
+
+
+def _store(request: Request) -> AuthorityStore:
+    store = getattr(request.app.state, "authority_store", None)
+    if store is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="authority store not initialized",
+        )
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Authority CRUD endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=AuthorityListResponse)
+def list_authority(request: Request) -> AuthorityListResponse:
+    store = _store(request)
+    states = store.get_all()
+    return AuthorityListResponse(
+        states=[
+            AuthorityStateResponse(action=action, state=state)
+            for action, state in sorted(states.items(), key=lambda kv: kv[0].value)
+        ]
+    )
+
+
+@router.get("/audit", response_model=AuthorityAuditResponse)
+def get_authority_audit(request: Request) -> AuthorityAuditResponse:
+    store = _store(request)
+    return AuthorityAuditResponse(
+        changes=[AuthorityChangeResponse.from_change(c) for c in store.get_audit()]
+    )
+
+
+@router.get("/pending", response_model=PendingListResponse)
+def list_pending(request: Request) -> PendingListResponse:
+    store = _store(request)
+    return PendingListResponse(
+        pending=[PendingDecisionResponse.from_pending(p) for p in store.list_pending()]
+    )
+
+
+@router.post(
+    "/pending/{queue_id}/approve",
+    response_model=ResolvePendingResponse,
+)
+def approve_pending(
+    queue_id: str, payload: ResolvePendingRequest, request: Request
+) -> ResolvePendingResponse:
+    store = _store(request)
+    try:
+        resolution = store.approve_pending(
+            queue_id,
+            operator_id=payload.operator_id,
+            reason=payload.reason,
+        )
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"pending queue_id {queue_id} not found",
+        ) from exc
+    return ResolvePendingResponse.from_resolution(resolution)
+
+
+@router.post(
+    "/pending/{queue_id}/reject",
+    response_model=ResolvePendingResponse,
+)
+def reject_pending(
+    queue_id: str, payload: ResolvePendingRequest, request: Request
+) -> ResolvePendingResponse:
+    store = _store(request)
+    try:
+        resolution = store.reject_pending(
+            queue_id,
+            operator_id=payload.operator_id,
+            reason=payload.reason,
+        )
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"pending queue_id {queue_id} not found",
+        ) from exc
+    return ResolvePendingResponse.from_resolution(resolution)
+
+
+@router.get("/{action}", response_model=AuthorityStateResponse)
+def get_authority(action: ActionType, request: Request) -> AuthorityStateResponse:
+    store = _store(request)
+    return AuthorityStateResponse(action=action, state=store.get_state(action))
+
+
+@router.put("/{action}", response_model=AuthorityChangeResponse)
+def set_authority(
+    action: ActionType, payload: AuthorityUpdateRequest, request: Request
+) -> AuthorityChangeResponse:
+    store = _store(request)
+    change = store.set_state(
+        action,
+        payload.state,
+        operator_id=payload.operator_id,
+        reason=payload.reason,
+    )
+    return AuthorityChangeResponse.from_change(change)
+
+
+__all__ = [
+    "AuthorityAuditResponse",
+    "AuthorityChangeResponse",
+    "AuthorityListResponse",
+    "AuthorityStateResponse",
+    "AuthorityUpdateRequest",
+    "PendingDecisionResponse",
+    "PendingListResponse",
+    "ResolvePendingRequest",
+    "ResolvePendingResponse",
+    "router",
+]

--- a/cio/core/authority.py
+++ b/cio/core/authority.py
@@ -1,0 +1,383 @@
+"""Per-ActionType authority configuration + pending-approval queue (P1.3, #115).
+
+Runtime-mutable governance layer that sits in front of `OutputRouter.route()`.
+Each `ActionType` has one of three authority states:
+
+  ENABLED                       — current behavior; the action is dispatched as-is
+  OPERATOR_APPROVAL_REQUIRED    — the decision is diverted to a pending queue
+                                   surfaced to the operator dashboard; nothing
+                                   is dispatched until `approve_pending()` fires
+  DISABLED                      — the action is replaced with a next-best safe
+                                   fallback; the substituted action proceeds
+                                   through the normal dispatch path
+
+Defaults are all `ENABLED` so existing behavior is preserved until an operator
+mutates the store. Every authority change is appended to an audit log with the
+operator identity supplied by the caller (single-operator deployment today;
+the field is recorded so the audit-trail is intact when SSO lands).
+
+This module is intentionally self-contained — no NATS, no HTTP. The HTTP
+surface lives in `cio.apps.authority_api`; the router consults this store via
+`cio.core.router`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from threading import Lock
+from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - py310 fallback
+    from enum import Enum
+
+    class StrEnum(str, Enum):  # type: ignore[no-redef]  # noqa: UP042
+        pass
+
+
+from cio.models.enums import ActionType
+
+
+class ActionAuthority(StrEnum):
+    """Per-ActionType authority state."""
+
+    ENABLED = "enabled"
+    OPERATOR_APPROVAL_REQUIRED = "operator_approval_required"
+    DISABLED = "disabled"
+
+
+# Next-best safe fallback when an action is DISABLED. The fallback action is
+# dispatched in place of the original; it is NOT itself subject to a recursive
+# authority check (to keep the substitution deterministic and avoid loops).
+#
+# Design rule: the fallback must be a strictly *safer* action — never expand
+# scope, never start a trade that the original would not have started.
+DEFAULT_FALLBACKS: dict[ActionType, ActionType] = {
+    ActionType.EXECUTE: ActionType.SKIP,
+    ActionType.MODIFY_PARAMS: ActionType.SKIP,
+    ActionType.PAUSE_STRATEGY: ActionType.BLOCK,
+    ActionType.ESCALATE: ActionType.BLOCK,
+    ActionType.RETRY_SAFE: ActionType.SKIP,
+    ActionType.FAIL_SAFE: ActionType.BLOCK,
+    ActionType.DOWN_WEIGHT: ActionType.SKIP,
+    ActionType.THROTTLE: ActionType.SKIP,
+    ActionType.VETO: ActionType.BLOCK,
+    # Lifecycle actions (P1.2): admit/admit_small/promote downgrade to reject;
+    # demote/retire downgrade to skip (no-op rather than action).
+    ActionType.ADMIT: ActionType.REJECT,
+    ActionType.ADMIT_SMALL: ActionType.REJECT,
+    ActionType.PROMOTE: ActionType.SKIP,
+    ActionType.DEMOTE: ActionType.SKIP,
+    ActionType.RETIRE: ActionType.SKIP,
+    # SKIP, BLOCK, REJECT are already terminal-safe; they cannot be "disabled"
+    # meaningfully. The store still records the state for completeness and
+    # `apply_authority` simply returns SKIP for any disabled action whose
+    # mapping is missing here (see `_resolve_fallback`).
+}
+
+
+class _Sentinel:
+    """Marker for pending-queue diversion vs disabled-fallback substitution."""
+
+
+@dataclass(frozen=True)
+class AuthorityChange:
+    """An audit-log entry: who changed what, when, and why."""
+
+    action: ActionType
+    from_state: ActionAuthority
+    to_state: ActionAuthority
+    operator_id: str
+    reason: str
+    at: datetime
+
+
+@dataclass(frozen=True)
+class PendingDecision:
+    """A decision held in the operator-approval queue.
+
+    The decision and trigger context are stored verbatim (`dict` form) so the
+    operator's approve/reject path can reconstruct the dispatch without
+    re-running the reasoning loop.
+    """
+
+    queue_id: str
+    action: ActionType
+    strategy_id: str
+    decision_id: str
+    correlation_id: str
+    context_payload: dict[str, Any]
+    decision_payload: dict[str, Any]
+    at: datetime
+
+
+@dataclass(frozen=True)
+class PendingResolution:
+    """Outcome of approve_pending / reject_pending."""
+
+    queue_id: str
+    approved: bool
+    operator_id: str
+    reason: str
+    at: datetime
+    pending: PendingDecision
+
+
+class AuthorityStore:
+    """Thread-safe in-memory authority configuration + pending-decision queue.
+
+    Public surface mirrors the FastAPI router's needs:
+        - `get_state(action) -> ActionAuthority`
+        - `set_state(action, new_state, *, operator_id, reason) -> AuthorityChange`
+        - `get_all() -> dict[ActionType, ActionAuthority]`
+        - `get_audit() -> list[AuthorityChange]`
+        - `enqueue_pending(...)` / `list_pending()`
+        - `approve_pending(queue_id, *, operator_id, reason)`
+        - `reject_pending(queue_id, *, operator_id, reason)`
+
+    Persistence is intentionally pluggable — a future Mongo- or Qdrant-backed
+    implementation can drop in behind this API without changing callers.
+    """
+
+    def __init__(
+        self,
+        defaults: dict[ActionType, ActionAuthority] | None = None,
+        fallbacks: dict[ActionType, ActionType] | None = None,
+    ) -> None:
+        self._lock = Lock()
+        self._state: dict[ActionType, ActionAuthority] = {
+            a: ActionAuthority.ENABLED for a in ActionType
+        }
+        if defaults:
+            self._state.update(defaults)
+        self._audit: list[AuthorityChange] = []
+        self._pending: dict[str, PendingDecision] = {}
+        self._fallbacks: dict[ActionType, ActionType] = dict(
+            fallbacks if fallbacks is not None else DEFAULT_FALLBACKS
+        )
+
+    # ------------------------------------------------------------------
+    # Authority CRUD
+    # ------------------------------------------------------------------
+
+    def get_state(self, action: ActionType) -> ActionAuthority:
+        with self._lock:
+            return self._state[action]
+
+    def get_all(self) -> dict[ActionType, ActionAuthority]:
+        with self._lock:
+            return dict(self._state)
+
+    def set_state(
+        self,
+        action: ActionType,
+        new_state: ActionAuthority,
+        *,
+        operator_id: str,
+        reason: str,
+    ) -> AuthorityChange:
+        if not operator_id:
+            raise ValueError("operator_id is required for authority change")
+        with self._lock:
+            previous = self._state[action]
+            self._state[action] = new_state
+            change = AuthorityChange(
+                action=action,
+                from_state=previous,
+                to_state=new_state,
+                operator_id=operator_id,
+                reason=reason,
+                at=datetime.now(UTC),
+            )
+            self._audit.append(change)
+        return change
+
+    def get_audit(self) -> list[AuthorityChange]:
+        with self._lock:
+            return list(self._audit)
+
+    # ------------------------------------------------------------------
+    # Fallback resolution (DISABLED)
+    # ------------------------------------------------------------------
+
+    def get_fallback(self, action: ActionType) -> ActionType:
+        """Resolve the next-best safe action for a DISABLED `action`.
+
+        Missing entries default to `SKIP` (the safest no-op). `SKIP`, `BLOCK`,
+        and `REJECT` are themselves terminal-safe — disabling them is a
+        configuration mistake the caller should treat as a no-op rather than
+        an error.
+        """
+        with self._lock:
+            return self._fallbacks.get(action, ActionType.SKIP)
+
+    # ------------------------------------------------------------------
+    # Pending-approval queue
+    # ------------------------------------------------------------------
+
+    def enqueue_pending(
+        self,
+        *,
+        action: ActionType,
+        strategy_id: str,
+        decision_id: str,
+        correlation_id: str,
+        context_payload: dict[str, Any],
+        decision_payload: dict[str, Any],
+    ) -> PendingDecision:
+        queue_id = uuid.uuid4().hex
+        pending = PendingDecision(
+            queue_id=queue_id,
+            action=action,
+            strategy_id=strategy_id,
+            decision_id=decision_id,
+            correlation_id=correlation_id,
+            context_payload=dict(context_payload),
+            decision_payload=dict(decision_payload),
+            at=datetime.now(UTC),
+        )
+        with self._lock:
+            self._pending[queue_id] = pending
+        return pending
+
+    def list_pending(self) -> list[PendingDecision]:
+        with self._lock:
+            return list(self._pending.values())
+
+    def get_pending(self, queue_id: str) -> PendingDecision:
+        with self._lock:
+            if queue_id not in self._pending:
+                raise KeyError(queue_id)
+            return self._pending[queue_id]
+
+    def approve_pending(
+        self,
+        queue_id: str,
+        *,
+        operator_id: str,
+        reason: str = "",
+    ) -> PendingResolution:
+        return self._resolve_pending(
+            queue_id, approved=True, operator_id=operator_id, reason=reason
+        )
+
+    def reject_pending(
+        self,
+        queue_id: str,
+        *,
+        operator_id: str,
+        reason: str = "",
+    ) -> PendingResolution:
+        return self._resolve_pending(
+            queue_id, approved=False, operator_id=operator_id, reason=reason
+        )
+
+    def _resolve_pending(
+        self,
+        queue_id: str,
+        *,
+        approved: bool,
+        operator_id: str,
+        reason: str,
+    ) -> PendingResolution:
+        if not operator_id:
+            raise ValueError("operator_id is required for pending resolution")
+        with self._lock:
+            pending = self._pending.pop(queue_id, None)
+            if pending is None:
+                raise KeyError(queue_id)
+        return PendingResolution(
+            queue_id=queue_id,
+            approved=approved,
+            operator_id=operator_id,
+            reason=reason,
+            at=datetime.now(UTC),
+            pending=pending,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Decision-time helpers (used by OutputRouter)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AuthorityDecision:
+    """Resolution of an authority check at dispatch time.
+
+    One of three outcomes:
+        - dispatch the original action (`action == original`)
+        - dispatch a fallback action (`action != original`, `was_disabled=True`)
+        - hold for operator approval (`pending` is not None, no dispatch)
+    """
+
+    action: ActionType
+    pending: PendingDecision | None
+    was_disabled: bool
+    original: ActionType
+
+
+def apply_authority(
+    store: AuthorityStore,
+    *,
+    action: ActionType,
+    strategy_id: str,
+    decision_id: str,
+    correlation_id: str,
+    context_payload: dict[str, Any],
+    decision_payload: dict[str, Any],
+) -> AuthorityDecision:
+    """Apply the authority store's per-action policy at dispatch time.
+
+    Caller (`OutputRouter`) consults the returned `AuthorityDecision`:
+        - `pending is not None` → divert to the pending queue, return early
+        - `was_disabled` → dispatch `action` (the fallback) instead of `original`
+        - otherwise → dispatch `action` as normal
+
+    Authority lookup, fallback resolution, and pending enqueue are all
+    serialized by the store's internal lock, so concurrent dispatch is safe.
+    """
+    state = store.get_state(action)
+    if state is ActionAuthority.ENABLED:
+        return AuthorityDecision(
+            action=action, pending=None, was_disabled=False, original=action
+        )
+    if state is ActionAuthority.OPERATOR_APPROVAL_REQUIRED:
+        pending = store.enqueue_pending(
+            action=action,
+            strategy_id=strategy_id,
+            decision_id=decision_id,
+            correlation_id=correlation_id,
+            context_payload=context_payload,
+            decision_payload=decision_payload,
+        )
+        return AuthorityDecision(
+            action=action, pending=pending, was_disabled=False, original=action
+        )
+    # DISABLED
+    fallback = store.get_fallback(action)
+    return AuthorityDecision(
+        action=fallback, pending=None, was_disabled=True, original=action
+    )
+
+
+__all__ = [
+    "DEFAULT_FALLBACKS",
+    "ActionAuthority",
+    "AuthorityChange",
+    "AuthorityDecision",
+    "AuthorityStore",
+    "PendingDecision",
+    "PendingResolution",
+    "apply_authority",
+]

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import Protocol
+from typing import Any, Protocol
 
 import httpx
 
@@ -48,9 +48,14 @@ class OutputRouter:
         ta_bot_url: str | None = None,
         realtime_strategies_url: str | None = None,
         cache: AsyncRedisCache | None = None,
+        authority_store: Any = None,
     ):
         self.nats_client = nats_client
         self.vector_client = vector_client
+        # Per-action authority (P1.3, #115). When None, the router behaves as
+        # if every action were ENABLED — preserving pre-P1.3 behavior and
+        # keeping the construction surface backwards-compatible.
+        self.authority_store = authority_store
         # Allow explicit arguments to override environment-based configuration.
         self.ta_bot_url = ta_bot_url or os.getenv("TA_BOT_URL", "")
         self.realtime_strategies_url = realtime_strategies_url or os.getenv(
@@ -126,18 +131,78 @@ class OutputRouter:
         except Exception as _otel_exc:
             logger.debug("set_decision_context failed: %s", _otel_exc)
 
+        # 0b. Apply per-action authority (P1.3, #115). When configured, may:
+        #     * divert to the pending-approval queue (returns early, no dispatch)
+        #     * substitute the action with a next-best safe fallback
+        original_action = action
+        authority_pending = None
+        authority_was_disabled = False
+        if self.authority_store is not None:
+            from cio.core.authority import apply_authority
+
+            authority_decision = apply_authority(
+                self.authority_store,
+                action=action,
+                strategy_id=strategy_id,
+                decision_id=decision_id,
+                correlation_id=correlation_id,
+                context_payload=context.trigger_payload,
+                decision_payload=decision.model_dump(),
+            )
+            if authority_decision.pending is not None:
+                # Divert: record the diversion in the audit trail and stop.
+                authority_pending = authority_decision.pending
+                await self.vector_client.upsert(
+                    strategy_id=strategy_id,
+                    payload={
+                        "event_type": "decision_pending_approval",
+                        "action": original_action.value,
+                        "correlation_id": correlation_id,
+                        "decision_id": decision_id,
+                        "queue_id": authority_pending.queue_id,
+                        "summary": decision.justification,
+                        "thought_trace": decision.thought_trace,
+                        "decision_data": decision.model_dump(),
+                    },
+                )
+                logger.info(
+                    "Decision diverted to operator-approval queue",
+                    extra={
+                        "correlation_id": correlation_id,
+                        "action": original_action.value,
+                        "strategy_id": strategy_id,
+                        "queue_id": authority_pending.queue_id,
+                    },
+                )
+                return
+            if authority_decision.was_disabled:
+                action = authority_decision.action
+                authority_was_disabled = True
+                logger.info(
+                    "Action substituted by authority fallback",
+                    extra={
+                        "correlation_id": correlation_id,
+                        "original_action": original_action.value,
+                        "fallback_action": action.value,
+                        "strategy_id": strategy_id,
+                    },
+                )
+
         # 1. Prepare Audit Path (Memory storage - Always executed)
+        audit_payload: dict[str, Any] = {
+            "event_type": "decision",
+            "action": action.value,
+            "correlation_id": correlation_id,
+            "decision_id": decision_id,
+            "summary": decision.justification,
+            "thought_trace": decision.thought_trace,
+            "decision_data": decision.model_dump(),
+        }
+        if authority_was_disabled:
+            audit_payload["authority_fallback_from"] = original_action.value
         audit_task = self.vector_client.upsert(
             strategy_id=strategy_id,
-            payload={
-                "event_type": "decision",
-                "action": action.value,
-                "correlation_id": correlation_id,
-                "decision_id": decision_id,
-                "summary": decision.justification,
-                "thought_trace": decision.thought_trace,
-                "decision_data": decision.model_dump(),
-            },
+            payload=audit_payload,
         )
 
         # 2. Prepare NATS Dispatch Path (T-Junction)

--- a/cio/main.py
+++ b/cio/main.py
@@ -8,10 +8,12 @@ import uvicorn
 from fastapi import FastAPI
 from nats.aio.client import Client as NATS
 
+from cio.apps.authority_api import router as authority_router
 from cio.apps.lifecycle_api import router as lifecycle_router
 from cio.apps.nurse.enforcer import NurseEnforcer
 from cio.clients.factory import ClientFactory
 from cio.core.arbiter import SignalArbiter
+from cio.core.authority import AuthorityStore
 from cio.core.cache import AsyncRedisCache
 from cio.core.context_builder import ContextBuilder
 from cio.core.heartbeat import HeartbeatPublisher, HeartbeatResponder
@@ -61,6 +63,12 @@ app = FastAPI(title="Petrosa CIO Health")
 # is pluggable behind the StrategyLifecycleStore API.
 app.state.lifecycle_store = StrategyLifecycleStore()
 app.include_router(lifecycle_router)
+
+# Per-action authority + pending-approval queue (P1.3, #115). The OutputRouter
+# consults `app.state.authority_store` at dispatch time; the HTTP surface
+# (operator-only) mutates it via the authority_router endpoints.
+app.state.authority_store = AuthorityStore()
+app.include_router(authority_router)
 
 
 @app.get("/health/liveness")

--- a/tests/unit/test_authority_api.py
+++ b/tests/unit/test_authority_api.py
@@ -1,0 +1,185 @@
+"""Tests for the per-action authority FastAPI router (P1.3, #115).
+
+Covers GET/PUT authority state, audit endpoint, pending-queue listing,
+approve / reject endpoints, and the 503/404/422 paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cio.apps.authority_api import router as authority_router
+from cio.core.authority import AuthorityStore
+from cio.models.enums import ActionType
+
+
+@pytest.fixture
+def app_with_store() -> FastAPI:
+    app = FastAPI()
+    app.state.authority_store = AuthorityStore()
+    app.include_router(authority_router)
+    return app
+
+
+@pytest.fixture
+def client(app_with_store) -> TestClient:
+    return TestClient(app_with_store)
+
+
+# ---------------------------------------------------------------------------
+# State CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_list_authority_returns_default_enabled_for_every_action(client):
+    resp = client.get("/authority")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    states = {e["action"]: e["state"] for e in body["states"]}
+    # Every ActionType is present and ENABLED by default.
+    assert states[ActionType.EXECUTE.value] == "enabled"
+    assert states[ActionType.ADMIT.value] == "enabled"
+    assert len(states) == len(list(ActionType))
+
+
+def test_get_authority_for_single_action(client):
+    resp = client.get(f"/authority/{ActionType.EXECUTE.value}")
+    assert resp.status_code == 200
+    assert resp.json() == {"action": "execute", "state": "enabled"}
+
+
+def test_put_authority_records_change_and_updates_state(client):
+    resp = client.put(
+        f"/authority/{ActionType.EXECUTE.value}",
+        json={
+            "state": "operator_approval_required",
+            "operator_id": "op-yuri",
+            "reason": "manual review week",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["action"] == "execute"
+    assert body["from_state"] == "enabled"
+    assert body["to_state"] == "operator_approval_required"
+    assert body["operator_id"] == "op-yuri"
+    assert body["reason"] == "manual review week"
+
+    # Confirm the change propagates.
+    follow_up = client.get(f"/authority/{ActionType.EXECUTE.value}")
+    assert follow_up.json()["state"] == "operator_approval_required"
+
+
+def test_put_authority_missing_operator_returns_422(client):
+    resp = client.put(
+        f"/authority/{ActionType.EXECUTE.value}",
+        json={"state": "disabled", "operator_id": "", "reason": "r"},
+    )
+    assert resp.status_code == 422
+
+
+def test_audit_endpoint_returns_change_history(client):
+    client.put(
+        f"/authority/{ActionType.EXECUTE.value}",
+        json={
+            "state": "disabled",
+            "operator_id": "op-a",
+            "reason": "step 1",
+        },
+    )
+    client.put(
+        f"/authority/{ActionType.EXECUTE.value}",
+        json={
+            "state": "enabled",
+            "operator_id": "op-b",
+            "reason": "step 2",
+        },
+    )
+    resp = client.get("/authority/audit")
+    assert resp.status_code == 200
+    changes = resp.json()["changes"]
+    assert len(changes) == 2
+    assert changes[0]["operator_id"] == "op-a"
+    assert changes[1]["operator_id"] == "op-b"
+
+
+# ---------------------------------------------------------------------------
+# Pending queue
+# ---------------------------------------------------------------------------
+
+
+def _seed_pending(app: FastAPI) -> str:
+    store: AuthorityStore = app.state.authority_store
+    pending = store.enqueue_pending(
+        action=ActionType.EXECUTE,
+        strategy_id="strat_alpha",
+        decision_id="dec-115",
+        correlation_id="corr-115",
+        context_payload={"symbol": "BTCUSDT"},
+        decision_payload={"action": "execute", "justification": "j"},
+    )
+    return pending.queue_id
+
+
+def test_list_pending_returns_diverted_decisions(app_with_store):
+    queue_id = _seed_pending(app_with_store)
+    client = TestClient(app_with_store)
+    resp = client.get("/authority/pending")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["pending"]) == 1
+    assert body["pending"][0]["queue_id"] == queue_id
+    assert body["pending"][0]["action"] == "execute"
+    assert body["pending"][0]["decision_id"] == "dec-115"
+
+
+def test_approve_pending_returns_resolution_and_clears_queue(app_with_store):
+    queue_id = _seed_pending(app_with_store)
+    client = TestClient(app_with_store)
+    resp = client.post(
+        f"/authority/pending/{queue_id}/approve",
+        json={"operator_id": "op-yuri", "reason": "looks fine"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["queue_id"] == queue_id
+    assert body["approved"] is True
+    assert body["operator_id"] == "op-yuri"
+    assert body["pending"]["action"] == "execute"
+    # Queue is now empty.
+    assert client.get("/authority/pending").json()["pending"] == []
+
+
+def test_reject_pending_returns_resolution_and_clears_queue(app_with_store):
+    queue_id = _seed_pending(app_with_store)
+    client = TestClient(app_with_store)
+    resp = client.post(
+        f"/authority/pending/{queue_id}/reject",
+        json={"operator_id": "op-yuri", "reason": "too risky"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["approved"] is False
+    assert client.get("/authority/pending").json()["pending"] == []
+
+
+def test_resolve_unknown_queue_returns_404(client):
+    resp = client.post(
+        "/authority/pending/ghost/approve",
+        json={"operator_id": "op-yuri", "reason": ""},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Defensive: missing store
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_returns_503_when_store_missing():
+    app = FastAPI()
+    app.include_router(authority_router)
+    client = TestClient(app)
+    resp = client.get("/authority")
+    assert resp.status_code == 503

--- a/tests/unit/test_authority_store.py
+++ b/tests/unit/test_authority_store.py
@@ -1,0 +1,282 @@
+"""Tests for the per-action authority store (P1.3, #115).
+
+Covers the three authority states (ENABLED / OPERATOR_APPROVAL_REQUIRED /
+DISABLED), the audit log with operator identity, the pending-approval
+queue, and the default-fallback table.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cio.core.authority import (
+    DEFAULT_FALLBACKS,
+    ActionAuthority,
+    AuthorityStore,
+    apply_authority,
+)
+from cio.models.enums import ActionType
+
+
+@pytest.fixture
+def store() -> AuthorityStore:
+    return AuthorityStore()
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_state_is_enabled_for_every_action_type(store):
+    states = store.get_all()
+    assert all(s is ActionAuthority.ENABLED for s in states.values())
+    assert set(states.keys()) == set(ActionType)
+
+
+def test_default_fallback_table_covers_dispatch_actions():
+    """Every action that produces a NATS dispatch has a safer fallback."""
+    dispatch_actions = {
+        ActionType.EXECUTE,
+        ActionType.MODIFY_PARAMS,
+        ActionType.PAUSE_STRATEGY,
+        ActionType.ESCALATE,
+        ActionType.RETRY_SAFE,
+        ActionType.FAIL_SAFE,
+        ActionType.DOWN_WEIGHT,
+        ActionType.THROTTLE,
+        ActionType.VETO,
+        ActionType.ADMIT,
+        ActionType.ADMIT_SMALL,
+        ActionType.PROMOTE,
+        ActionType.DEMOTE,
+        ActionType.RETIRE,
+    }
+    safe_terminals = {ActionType.SKIP, ActionType.BLOCK, ActionType.REJECT}
+    for action in dispatch_actions:
+        assert action in DEFAULT_FALLBACKS, action
+        assert DEFAULT_FALLBACKS[action] in safe_terminals, (
+            action,
+            DEFAULT_FALLBACKS[action],
+        )
+
+
+# ---------------------------------------------------------------------------
+# CRUD + audit
+# ---------------------------------------------------------------------------
+
+
+def test_set_state_records_audit_change(store):
+    change = store.set_state(
+        ActionType.EXECUTE,
+        ActionAuthority.OPERATOR_APPROVAL_REQUIRED,
+        operator_id="op-yuri",
+        reason="manual review week",
+    )
+    assert change.from_state is ActionAuthority.ENABLED
+    assert change.to_state is ActionAuthority.OPERATOR_APPROVAL_REQUIRED
+    assert change.operator_id == "op-yuri"
+    assert change.reason == "manual review week"
+
+    audit = store.get_audit()
+    assert audit == [change]
+    assert (
+        store.get_state(ActionType.EXECUTE)
+        is ActionAuthority.OPERATOR_APPROVAL_REQUIRED
+    )
+
+
+def test_set_state_rejects_empty_operator(store):
+    with pytest.raises(ValueError) as exc_info:
+        store.set_state(
+            ActionType.EXECUTE,
+            ActionAuthority.DISABLED,
+            operator_id="",
+            reason="who cares",
+        )
+    assert "operator_id" in str(exc_info.value)
+
+
+def test_audit_log_preserves_full_history(store):
+    store.set_state(
+        ActionType.EXECUTE,
+        ActionAuthority.OPERATOR_APPROVAL_REQUIRED,
+        operator_id="op-a",
+        reason="step 1",
+    )
+    store.set_state(
+        ActionType.EXECUTE,
+        ActionAuthority.ENABLED,
+        operator_id="op-b",
+        reason="step 2",
+    )
+    audit = store.get_audit()
+    assert len(audit) == 2
+    assert audit[0].operator_id == "op-a"
+    assert audit[1].operator_id == "op-b"
+    assert audit[0].to_state is ActionAuthority.OPERATOR_APPROVAL_REQUIRED
+    assert audit[1].to_state is ActionAuthority.ENABLED
+
+
+def test_audit_is_defensive_copy(store):
+    store.set_state(
+        ActionType.EXECUTE,
+        ActionAuthority.DISABLED,
+        operator_id="op-a",
+        reason="r",
+    )
+    audit = store.get_audit()
+    audit.clear()
+    assert len(store.get_audit()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Pending-approval queue
+# ---------------------------------------------------------------------------
+
+
+def _enqueue(store: AuthorityStore):
+    return store.enqueue_pending(
+        action=ActionType.EXECUTE,
+        strategy_id="strat_alpha",
+        decision_id="dec-115-1",
+        correlation_id="corr-115-1",
+        context_payload={"symbol": "BTCUSDT", "trigger": "intent"},
+        decision_payload={"action": "execute", "justification": "j"},
+    )
+
+
+def test_enqueue_pending_returns_queue_entry(store):
+    pending = _enqueue(store)
+    assert pending.queue_id
+    assert pending.action is ActionType.EXECUTE
+    assert pending.decision_id == "dec-115-1"
+    assert pending.context_payload["symbol"] == "BTCUSDT"
+
+    listing = store.list_pending()
+    assert listing == [pending]
+
+
+def test_approve_pending_removes_from_queue(store):
+    pending = _enqueue(store)
+    resolution = store.approve_pending(
+        pending.queue_id, operator_id="op-yuri", reason="trade looks fine"
+    )
+    assert resolution.approved is True
+    assert resolution.pending == pending
+    assert resolution.operator_id == "op-yuri"
+    assert store.list_pending() == []
+
+
+def test_reject_pending_removes_from_queue(store):
+    pending = _enqueue(store)
+    resolution = store.reject_pending(
+        pending.queue_id, operator_id="op-yuri", reason="too risky"
+    )
+    assert resolution.approved is False
+    assert resolution.pending == pending
+    assert store.list_pending() == []
+
+
+def test_approve_unknown_queue_id_raises(store):
+    with pytest.raises(KeyError) as exc_info:
+        store.approve_pending("ghost-id", operator_id="op-a")
+    assert "ghost-id" in str(exc_info.value)
+
+
+def test_resolve_pending_requires_operator(store):
+    pending = _enqueue(store)
+    with pytest.raises(ValueError) as exc_info:
+        store.approve_pending(pending.queue_id, operator_id="")
+    assert "operator_id" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# apply_authority decision helper
+# ---------------------------------------------------------------------------
+
+
+def _apply(store, action: ActionType):
+    return apply_authority(
+        store,
+        action=action,
+        strategy_id="strat_alpha",
+        decision_id="dec-115-x",
+        correlation_id="corr-115-x",
+        context_payload={"symbol": "BTCUSDT"},
+        decision_payload={"action": action.value},
+    )
+
+
+def test_apply_authority_enabled_passes_through(store):
+    decision = _apply(store, ActionType.EXECUTE)
+    assert decision.pending is None
+    assert decision.was_disabled is False
+    assert decision.action is ActionType.EXECUTE
+    assert decision.original is ActionType.EXECUTE
+
+
+def test_apply_authority_approval_required_enqueues(store):
+    store.set_state(
+        ActionType.EXECUTE,
+        ActionAuthority.OPERATOR_APPROVAL_REQUIRED,
+        operator_id="op-a",
+        reason="review week",
+    )
+    decision = _apply(store, ActionType.EXECUTE)
+    assert decision.pending is not None
+    assert decision.pending.action is ActionType.EXECUTE
+    assert decision.was_disabled is False
+    assert decision.original is ActionType.EXECUTE
+    assert store.list_pending() == [decision.pending]
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_fallback"),
+    [
+        (ActionType.EXECUTE, ActionType.SKIP),
+        (ActionType.MODIFY_PARAMS, ActionType.SKIP),
+        (ActionType.PAUSE_STRATEGY, ActionType.BLOCK),
+        (ActionType.ADMIT, ActionType.REJECT),
+        (ActionType.PROMOTE, ActionType.SKIP),
+        (ActionType.RETIRE, ActionType.SKIP),
+        (ActionType.VETO, ActionType.BLOCK),
+    ],
+)
+def test_apply_authority_disabled_substitutes_fallback(
+    store, action, expected_fallback
+):
+    store.set_state(
+        action,
+        ActionAuthority.DISABLED,
+        operator_id="op-a",
+        reason="off-policy",
+    )
+    decision = _apply(store, action)
+    assert decision.pending is None
+    assert decision.was_disabled is True
+    assert decision.action is expected_fallback
+    assert decision.original is action
+
+
+def test_disabled_unknown_action_falls_back_to_skip(store):
+    # Override DEFAULT_FALLBACKS to simulate an action without a mapping —
+    # the store should still produce a safe SKIP.
+    custom = AuthorityStore(fallbacks={})
+    custom.set_state(
+        ActionType.EXECUTE,
+        ActionAuthority.DISABLED,
+        operator_id="op-a",
+        reason="r",
+    )
+    decision = apply_authority(
+        custom,
+        action=ActionType.EXECUTE,
+        strategy_id="s",
+        decision_id="d",
+        correlation_id="c",
+        context_payload={},
+        decision_payload={"action": "execute"},
+    )
+    assert decision.was_disabled is True
+    assert decision.action is ActionType.SKIP

--- a/tests/unit/test_router_authority.py
+++ b/tests/unit/test_router_authority.py
@@ -1,0 +1,287 @@
+"""Tests for OutputRouter ↔ AuthorityStore integration (P1.3, #115).
+
+Covers the three runtime outcomes a configured authority store can produce
+at dispatch time:
+
+  * ENABLED                       → original behavior, action dispatched as-is
+  * OPERATOR_APPROVAL_REQUIRED    → decision diverted to pending queue, no
+                                    NATS publish, audit-trail records the
+                                    diversion with the queue_id
+  * DISABLED                      → action substituted with the fallback,
+                                    fallback is dispatched normally (or
+                                    SKIP-style no-publish), audit-trail
+                                    records the original action
+
+`decision_id` propagation is verified end-to-end (P0.1 contract).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cio.core.authority import ActionAuthority, AuthorityStore
+from cio.core.router import OutputRouter
+from cio.models import (
+    ActionType,
+    ActivationRecommendation,
+    ConfidenceLevel,
+    DecisionResult,
+    HealthStatus,
+    RegimeFit,
+    TriggerContext,
+)
+
+
+def _make_decision(action: ActionType) -> DecisionResult:
+    return DecisionResult(
+        hard_blocked=False,
+        ev_passes=True,
+        cost_viable=True,
+        regime_confidence=ConfidenceLevel.HIGH,
+        regime_fit=RegimeFit.GOOD,
+        strategy_health=HealthStatus.HEALTHY,
+        activation_recommendation=ActivationRecommendation.RUN,
+        action=action,
+        justification="authority test",
+        thought_trace="audit trace",
+    )
+
+
+def _make_context(strategy_id: str = "strat_a") -> TriggerContext:
+    ctx = MagicMock(spec=TriggerContext)
+    ctx.strategy_id = strategy_id
+    ctx.decision_id = "decision-115"
+    ctx.correlation_id = "corr-115"
+    ctx.trigger_payload = {"symbol": "BTCUSDT"}
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# ENABLED (default) — passes through unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enabled_action_dispatches_normally_via_authority_store():
+    store = AuthorityStore()  # everything ENABLED by default
+    router = OutputRouter(
+        nats_client=AsyncMock(),
+        vector_client=AsyncMock(),
+        ta_bot_url="http://ta-bot",
+        authority_store=store,
+    )
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(_make_context(), _make_decision(ActionType.ADMIT))
+
+    # ADMIT (a lifecycle action) publishes on cio.lifecycle.admit.<sid>.
+    router.nats_client.publish.assert_called_once()
+    subject, _payload = router.nats_client.publish.call_args.args
+    assert subject == "cio.lifecycle.admit.strat_a"
+    # No pending-approval entries because action was ENABLED.
+    assert store.list_pending() == []
+
+
+# ---------------------------------------------------------------------------
+# OPERATOR_APPROVAL_REQUIRED — divert to pending queue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approval_required_diverts_and_skips_dispatch():
+    store = AuthorityStore()
+    store.set_state(
+        ActionType.EXECUTE,
+        ActionAuthority.OPERATOR_APPROVAL_REQUIRED,
+        operator_id="op-yuri",
+        reason="review week",
+    )
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+        authority_store=store,
+    )
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(_make_context(), _make_decision(ActionType.EXECUTE))
+
+    # NATS dispatch must NOT have happened.
+    mock_nc.publish.assert_not_called()
+
+    # Pending queue should hold exactly one entry for this decision.
+    pending = store.list_pending()
+    assert len(pending) == 1
+    assert pending[0].action is ActionType.EXECUTE
+    assert pending[0].decision_id == "decision-115"
+    assert pending[0].strategy_id == "strat_a"
+
+    # Audit trail records the diversion (event_type=decision_pending_approval).
+    audit_calls = [c for c in mock_vc.upsert.call_args_list]
+    assert len(audit_calls) == 1
+    audit_payload = audit_calls[0].kwargs["payload"]
+    assert audit_payload["event_type"] == "decision_pending_approval"
+    assert audit_payload["action"] == "execute"
+    assert audit_payload["decision_id"] == "decision-115"
+    assert audit_payload["queue_id"] == pending[0].queue_id
+
+
+# ---------------------------------------------------------------------------
+# DISABLED — substitute with next-best safe action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_action_substitutes_fallback_and_records_original():
+    """EXECUTE → SKIP fallback when EXECUTE is DISABLED.
+
+    SKIP is a no-publish action, so the router must not call publish for the
+    substituted action. The audit trail records the SKIP plus the
+    `authority_fallback_from` field pointing at the original EXECUTE.
+    """
+    store = AuthorityStore()
+    store.set_state(
+        ActionType.EXECUTE,
+        ActionAuthority.DISABLED,
+        operator_id="op-yuri",
+        reason="off-policy",
+    )
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+        authority_store=store,
+    )
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(_make_context(), _make_decision(ActionType.EXECUTE))
+
+    # EXECUTE → SKIP fallback. SKIP does not publish.
+    mock_nc.publish.assert_not_called()
+
+    mock_vc.upsert.assert_called_once()
+    payload = mock_vc.upsert.call_args.kwargs["payload"]
+    assert payload["action"] == "skip"
+    assert payload["authority_fallback_from"] == "execute"
+    assert payload["decision_id"] == "decision-115"
+
+
+@pytest.mark.asyncio
+async def test_disabled_lifecycle_action_dispatches_safe_fallback():
+    """ADMIT → REJECT fallback when ADMIT is DISABLED.
+
+    REJECT is itself a lifecycle action that publishes — the router must
+    dispatch the fallback, not the original.
+    """
+    store = AuthorityStore()
+    store.set_state(
+        ActionType.ADMIT,
+        ActionAuthority.DISABLED,
+        operator_id="op-yuri",
+        reason="freeze admissions",
+    )
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+        authority_store=store,
+    )
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(_make_context(), _make_decision(ActionType.ADMIT))
+
+    # Fallback publishes on cio.lifecycle.reject.<sid>, NOT cio.lifecycle.admit.<sid>.
+    mock_nc.publish.assert_called_once()
+    subject, payload_bytes = mock_nc.publish.call_args.args
+    assert subject == "cio.lifecycle.reject.strat_a"
+
+    payload = json.loads(payload_bytes.decode())
+    # The decision payload's `action` field is the original — we do not mutate
+    # the DecisionResult on the wire; only the dispatch subject reflects the
+    # fallback. (Audit-trail captures the swap via authority_fallback_from.)
+    assert payload["action"] == "admit"
+
+    audit_payload = mock_vc.upsert.call_args.kwargs["payload"]
+    assert audit_payload["action"] == "reject"
+    assert audit_payload["authority_fallback_from"] == "admit"
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility — no authority_store wired
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_router_without_authority_store_preserves_behavior():
+    """authority_store=None → no behavioral change from pre-P1.3 routing."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(_make_context(), _make_decision(ActionType.ADMIT))
+
+    mock_nc.publish.assert_called_once()
+    subject, _payload = mock_nc.publish.call_args.args
+    assert subject == "cio.lifecycle.admit.strat_a"
+
+
+# ---------------------------------------------------------------------------
+# decision_id propagation across all three outcomes (P0.1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "expect_publish", "expect_pending"),
+    [
+        (ActionAuthority.ENABLED, True, False),
+        (ActionAuthority.OPERATOR_APPROVAL_REQUIRED, False, True),
+        (ActionAuthority.DISABLED, False, False),  # EXECUTE → SKIP no-publish
+    ],
+)
+async def test_decision_id_propagates_in_every_outcome(
+    state, expect_publish, expect_pending
+):
+    store = AuthorityStore()
+    if state is not ActionAuthority.ENABLED:
+        store.set_state(ActionType.EXECUTE, state, operator_id="op-yuri", reason="r")
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+        authority_store=store,
+    )
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(_make_context(), _make_decision(ActionType.EXECUTE))
+
+    if expect_publish:
+        assert mock_nc.publish.called
+    else:
+        mock_nc.publish.assert_not_called()
+
+    if expect_pending:
+        pending = store.list_pending()
+        assert pending and pending[0].decision_id == "decision-115"
+
+    # Audit trail always carries decision_id.
+    mock_vc.upsert.assert_called_once()
+    audit = mock_vc.upsert.call_args.kwargs["payload"]
+    assert audit["decision_id"] == "decision-115"


### PR DESCRIPTION
## Summary

Implements [PetroSa2/petrosa-cio#115](https://github.com/PetroSa2/petrosa-cio/issues/115) (P1.3, FR16). Builds on the freshly-merged P1.2 (#116) — every ActionType (including the lifecycle six) can now be gated at runtime via per-action authority.

## Authority states

| State | Behavior |
|---|---|
| `ENABLED` | Current behavior; action dispatched as-is (default). |
| `OPERATOR_APPROVAL_REQUIRED` | Decision diverted to the pending-approval queue. No NATS publish until approved. |
| `DISABLED` | Action substituted with a next-best safe fallback. Fallback dispatches through normal path. |

### Default fallback table

| Disabled action | Fallback |
|---|---|
| EXECUTE / MODIFY_PARAMS / RETRY_SAFE / DOWN_WEIGHT / THROTTLE | SKIP |
| PAUSE_STRATEGY / ESCALATE / FAIL_SAFE / VETO | BLOCK |
| ADMIT / ADMIT_SMALL | REJECT |
| PROMOTE / DEMOTE / RETIRE | SKIP |

Fallbacks are strictly safer than the original — never expand scope, never start a trade the original would not have started.

## Changes

| Layer | File | What |
|---|---|---|
| Store | [cio/core/authority.py](cio/core/authority.py) | `AuthorityStore` (thread-safe, in-memory, pluggable persistence) + `apply_authority()` decision helper + dataclasses (`AuthorityChange`, `PendingDecision`, `PendingResolution`, `AuthorityDecision`). |
| Router | [cio/core/router.py](cio/core/router.py) | New optional `authority_store` ctor kwarg. At dispatch time, `apply_authority()` may divert to pending queue (audit-only, no publish), substitute fallback, or pass through. `decision_id` carried across all three outcomes. |
| HTTP | [cio/apps/authority_api.py](cio/apps/authority_api.py) + [cio/main.py](cio/main.py) | 7 endpoints under `/authority` — list/get/put state, audit, pending list, approve, reject. Mounted on the existing FastAPI app alongside P1.2's lifecycle router. |

## Acceptance Criteria

- [x] **Configuration mutable via REST endpoint on CIO (operator-only)** — `PUT /authority/{action}` requires `operator_id` (422 otherwise) and records the change in the audit log.
- [x] **Pending-approval queue visible (P5 dashboard dependency — CLI/curl-readable JSON acceptable)** — `GET /authority/pending` returns the full queue as JSON (`PendingListResponse`).
- [x] **All authority changes persisted to audit trail with operator identity** — `AuthorityStore.get_audit()` + `GET /authority/audit` return the full change history with `operator_id`, `reason`, `at`. Single-operator today; field captured for SSO future.
- [x] **Falling back to next-best safe action when DISABLED is unit-tested** — `test_apply_authority_disabled_substitutes_fallback` parametrizes 7 representative actions; `test_disabled_action_substitutes_fallback_and_records_original` and `test_disabled_lifecycle_action_dispatches_safe_fallback` exercise the router end-to-end.
- [x] **All emitted decisions carry `decision_id` per P0.1** — `test_decision_id_propagates_in_every_outcome` verifies the field is present in audit-trail upserts for all three outcomes (ENABLED / APPROVAL_REQUIRED / DISABLED).

## Notes for reviewers

- The approve endpoint deliberately does NOT re-dispatch from the HTTP path — it returns the `PendingResolution` payload so the caller (or the orchestrator in a follow-up) can feed it back into `OutputRouter`. Dispatching from the HTTP handler would introduce a circular import between `cio.apps.authority_api` and `cio.core.router`.
- The `authority_store` ctor kwarg defaults to `None` so existing constructions (including the 19 + 19 + 13 router tests on `main`) continue to work unchanged.
- The audit-trail upsert payload now carries an `authority_fallback_from` field when a fallback was substituted, so data-manager subscribers can identify governance-driven substitutions in retrospect.

## Test plan

- [x] `venv/bin/python -m pytest tests/unit/ -v` — 39 new + 142 existing = 181 PASS (full unit suite)
- [x] `venv/bin/python -m pytest tests/ -v` — 185/185 PASS (incl. existing integration tests)
- [x] `venv/bin/ruff check cio/ tests/unit/` — clean
- [x] `venv/bin/ruff format` — clean
- [x] Pre-commit hooks pass (ruff, gitleaks, bandit, yaml, test-assertions)

## References

- Issue: [PetroSa2/petrosa-cio#115](https://github.com/PetroSa2/petrosa-cio/issues/115)
- Sibling P1.2 (just merged): [petrosa-cio#116](https://github.com/PetroSa2/petrosa-cio/pull/116)
- Predecessor (ActionType extension): [petrosa-cio#113](https://github.com/PetroSa2/petrosa-cio/pull/113) (#589 P1.1)
- decision_id contract: P0.1 (approved 2026-05-16)
- MemPalace pre-flight comment: [#115 comment 4498719316](https://github.com/PetroSa2/petrosa-cio/issues/115#issuecomment-4498719316)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>