### PR TITLE
feat(cio): #597 - pause arbitration on unhealthy upstream evaluator (P2.6)

### DIFF
--- a/cio/apps/state_api.py
+++ b/cio/apps/state_api.py
@@ -1,0 +1,59 @@
+"""CIO /state endpoint — operator view of evaluator-driven pauses (P2.6).
+
+GET  /state                       — full evaluator snapshot + paused list
+GET  /state/paused                — short paused-subsystems list
+POST /state/override/{subsystem}  — set or clear an operator pause override
+
+The store this reads from is the in-process EvaluatorSubscriber attached
+to ``app.state.evaluator_subscriber`` at startup. When the subscriber
+isn't wired (e.g. local dev without NATS), every read returns an empty
+snapshot and the override endpoint reports the missing dependency.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/state", tags=["state"])
+
+
+class OverrideBody(BaseModel):
+    """Body for the override POST. ``verdict=null`` clears the override."""
+
+    verdict: str | None = None
+
+
+def _subscriber(request: Request):
+    sub = getattr(request.app.state, "evaluator_subscriber", None)
+    if sub is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "evaluator subscriber is not wired — CIO is running without "
+                "the P2.6 pause gate"
+            ),
+        )
+    return sub
+
+
+@router.get("")
+async def get_state(request: Request) -> dict:
+    sub = _subscriber(request)
+    return sub.snapshot()
+
+
+@router.get("/paused")
+async def get_paused(request: Request) -> dict:
+    sub = _subscriber(request)
+    return {"paused": sub.paused_subsystems()}
+
+
+@router.post("/override/{subsystem}")
+async def set_override(subsystem: str, body: OverrideBody, request: Request) -> dict:
+    sub = _subscriber(request)
+    try:
+        sub.set_override(subsystem, body.verdict)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"subsystem": subsystem, "override": body.verdict}

--- a/cio/core/arbiter.py
+++ b/cio/core/arbiter.py
@@ -1,13 +1,23 @@
 """Signal arbitration layer for cross-strategy deduplication and conflict resolution."""
 
 import logging
+from typing import TYPE_CHECKING
 
 from cio.core.cache import AsyncRedisCache
+
+if TYPE_CHECKING:
+    from cio.core.evaluator_subscriber import EvaluatorSubscriber
 
 logger = logging.getLogger(__name__)
 
 _DEDUP_TTL_SECONDS = 60
 _CONFLICT_TTL_SECONDS = 300  # 5 minutes
+
+# P2.6 (#597): subsystems whose unhealthy verdict pauses arbitration on
+# every incoming signal. `ingest` is the first wired source (data-manager
+# ingest evaluator, #593). Future tickets can extend this set per-subject
+# (e.g. strategy-specific pauses keyed off `evaluator.strategy.<id>`).
+_PAUSE_GUARD_SUBSYSTEMS: tuple[str, ...] = ("ingest",)
 
 # Canonical action mapping: normalise producer-specific side names to buy/sell.
 _SIDE_NORMALISE: dict[str, str] = {
@@ -42,8 +52,17 @@ class SignalArbiter:
     a Redis SETNX / Lua atomic upgrade can be added when replica counts increase.
     """
 
-    def __init__(self, cache: AsyncRedisCache) -> None:
+    def __init__(
+        self,
+        cache: AsyncRedisCache,
+        evaluator_subscriber: "EvaluatorSubscriber | None" = None,
+    ) -> None:
         self._cache = cache
+        # P2.6 (#597): optional collaborator. When wired, every arbiter
+        # check first asks the subscriber whether any pause-guarded
+        # subsystem is currently unhealthy. None = legacy behavior (no
+        # upstream gate).
+        self._evaluator_subscriber = evaluator_subscriber
 
     async def check(
         self,
@@ -59,6 +78,19 @@ class SignalArbiter:
         Returns:
             (allowed, reason) — ``allowed=False`` means the signal must be suppressed.
         """
+        # P2.6 (#597, FR45): pause-on-unhealthy-upstream check runs FIRST so
+        # we never burn arbitration state on a signal we're about to
+        # suppress. The subscriber's read API is in-memory and lock-free.
+        if self._evaluator_subscriber is not None:
+            for guarded in _PAUSE_GUARD_SUBSYSTEMS:
+                if self._evaluator_subscriber.is_paused(guarded):
+                    reason = (
+                        f"ARBITER_PAUSED: upstream '{guarded}' evaluator unhealthy — "
+                        f"suppressing {symbol} {action} from {strategy_id}"
+                    )
+                    logger.info(reason, extra={"correlation_id": correlation_id})
+                    return False, reason
+
         # Guard: missing symbol or action means we cannot key arbitration state reliably.
         if not symbol or not action:
             reason = (

--- a/cio/core/evaluator_subscriber.py
+++ b/cio/core/evaluator_subscriber.py
@@ -1,0 +1,220 @@
+"""Evaluator-verdict subscriber for CIO arbitration pause (P2.6, #597).
+
+Subscribes to ``evaluator.>`` and tracks the latest verdict per subsystem.
+The arbiter consults :meth:`is_paused` before allowing a signal through
+so unhealthy upstream evaluators (ingest, strategies, audit, …) pause
+new arbitration on the affected scope rather than emitting decisions on
+stale or broken data (FR45).
+
+State is per-process and in-memory: the next published verdict refreshes
+it, and a restart re-syncs from the next evaluator tick on each subsystem
+(NFR-R1's detection-time window applies). Persistent state was out of
+scope for this ticket — pause events that need to survive a CIO restart
+should be filed as a follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATS
+
+logger = logging.getLogger(__name__)
+
+
+# `evaluator.{subsystem}.verdict` per the P2.1 publisher contract.
+EVALUATOR_SUBJECT_PATTERN = "evaluator.>"
+HEALTHY = "healthy"
+UNHEALTHY = "unhealthy"
+UNKNOWN = "unknown"
+
+
+class EvaluatorSubscriber:
+    """Subscribes to ``evaluator.>`` and exposes the current pause set.
+
+    Callers (``SignalArbiter`` today; an HTTP ``/state`` route too) only
+    interact with the read API — :meth:`is_paused` and
+    :meth:`paused_subsystems` — so the subject parsing + JSON decoding is
+    contained here.
+    """
+
+    def __init__(
+        self,
+        nats_client: NATS,
+        *,
+        on_change: Callable[[str, str, str], Awaitable[None]] | None = None,
+    ) -> None:
+        """
+        Args:
+            nats_client: connected nats-py client.
+            on_change: optional async callback fired on every committed
+                verdict change. Signature ``(subsystem, new_verdict,
+                reason) -> Awaitable[None]``. Lets main.py persist a
+                pause/resume audit trail without coupling the subscriber
+                to that path.
+        """
+        self._nc = nats_client
+        self._on_change = on_change
+        # subsystem -> (verdict, reason, observed_at)
+        self._verdicts: dict[str, tuple[str, str, datetime]] = {}
+        # Operator-driven overrides — when set, force arbiter pause/resume
+        # regardless of the subscriber's latest verdict. Stored as
+        # subsystem -> override_verdict.
+        self._overrides: dict[str, str] = {}
+        self._subscription = None
+
+    async def start(self) -> None:
+        """Subscribe to ``evaluator.>``."""
+        self._subscription = await self._nc.subscribe(
+            EVALUATOR_SUBJECT_PATTERN,
+            cb=self._handle_message,
+        )
+        logger.info(
+            "evaluator_subscriber_started",
+            extra={"subject": EVALUATOR_SUBJECT_PATTERN},
+        )
+
+    async def stop(self) -> None:
+        if self._subscription is not None:
+            try:
+                await self._subscription.unsubscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"evaluator subscriber unsubscribe failed: {exc}")
+            self._subscription = None
+
+    async def _handle_message(self, msg) -> None:
+        # Subject form: evaluator.{subsystem}.verdict — extract the
+        # subsystem token defensively; an unexpected shape just gets
+        # logged and dropped so the subscriber survives malformed traffic.
+        parts = msg.subject.split(".")
+        if len(parts) < 3 or parts[0] != "evaluator" or parts[-1] != "verdict":
+            logger.warning(
+                "evaluator_subject_malformed",
+                extra={"subject": msg.subject},
+            )
+            return
+        subsystem = ".".join(parts[1:-1])
+
+        try:
+            payload = json.loads(msg.data.decode())
+        except (json.JSONDecodeError, AttributeError) as exc:
+            logger.warning(
+                "evaluator_payload_unparsable",
+                extra={"subject": msg.subject, "error": str(exc)},
+            )
+            return
+
+        verdict = payload.get("verdict")
+        reason = (payload.get("reason") or "")[:200]
+        if verdict not in (HEALTHY, UNHEALTHY, UNKNOWN):
+            logger.warning(
+                "evaluator_verdict_invalid",
+                extra={"subject": msg.subject, "verdict": verdict},
+            )
+            return
+
+        previous = self._verdicts.get(subsystem)
+        now = datetime.now(UTC)
+        self._verdicts[subsystem] = (verdict, reason, now)
+
+        if previous is None or previous[0] != verdict:
+            logger.info(
+                "evaluator_verdict_changed",
+                extra={
+                    "subsystem": subsystem,
+                    "verdict": verdict,
+                    "reason": reason,
+                    "previous": previous[0] if previous else None,
+                },
+            )
+            if self._on_change is not None:
+                try:
+                    await self._on_change(subsystem, verdict, reason)
+                except Exception as exc:  # noqa: BLE001 — never crash subscribe
+                    logger.warning(f"on_change callback failed: {exc}")
+
+    def is_paused(self, subsystem: str) -> bool:
+        """True iff CIO arbitration should pause on this subsystem.
+
+        Operator overrides win; otherwise pause when the latest verdict
+        is unhealthy. ``unknown`` and ``healthy`` allow arbitration to
+        continue — operators tune the override to handle "unknown is
+        bad" semantics on a case-by-case basis.
+        """
+        override = self._overrides.get(subsystem)
+        if override is not None:
+            return override == UNHEALTHY
+        record = self._verdicts.get(subsystem)
+        if record is None:
+            return False
+        return record[0] == UNHEALTHY
+
+    def paused_subsystems(self) -> list[dict]:
+        """Snapshot of paused subsystems for the /state endpoint."""
+        result = []
+        # Union of observed-verdict subsystems and operator-override
+        # subsystems — operators may pause something that hasn't emitted
+        # a verdict yet, and that pause must still surface.
+        all_keys = set(self._verdicts.keys()) | set(self._overrides.keys())
+        for subsystem in sorted(all_keys):
+            record = self._verdicts.get(subsystem)
+            verdict = record[0] if record else None
+            reason = record[1] if record else ""
+            observed_at = record[2].isoformat() if record else None
+            override = self._overrides.get(subsystem)
+            effective = override if override is not None else verdict
+            if effective != UNHEALTHY:
+                continue
+            result.append(
+                {
+                    "subsystem": subsystem,
+                    "verdict": verdict,
+                    "reason": reason,
+                    "observed_at": observed_at,
+                    "override": override,
+                }
+            )
+        return result
+
+    def set_override(self, subsystem: str, verdict: str | None) -> None:
+        """Operator override — set to None to clear.
+
+        Surfaces in :meth:`paused_subsystems` so the dashboard can show
+        a manual pause/unpause separately from evaluator-driven state.
+        """
+        if verdict is None:
+            self._overrides.pop(subsystem, None)
+            return
+        if verdict not in (HEALTHY, UNHEALTHY, UNKNOWN):
+            raise ValueError(
+                f"override verdict must be one of healthy/unhealthy/unknown, got {verdict!r}"
+            )
+        self._overrides[subsystem] = verdict
+
+    def snapshot(self) -> dict:
+        """Full state — used by the /state endpoint to expose verdict
+        history for every observed subsystem (paused or not)."""
+        out = []
+        for subsystem, (verdict, reason, observed_at) in self._verdicts.items():
+            out.append(
+                {
+                    "subsystem": subsystem,
+                    "verdict": verdict,
+                    "reason": reason,
+                    "observed_at": observed_at.isoformat(),
+                    "override": self._overrides.get(subsystem),
+                }
+            )
+        return {"verdicts": out, "paused": self.paused_subsystems()}

--- a/cio/main.py
+++ b/cio/main.py
@@ -11,11 +11,13 @@ from nats.aio.client import Client as NATS
 from cio.apps.authority_api import router as authority_router
 from cio.apps.lifecycle_api import router as lifecycle_router
 from cio.apps.nurse.enforcer import NurseEnforcer
+from cio.apps.state_api import router as state_router
 from cio.clients.factory import ClientFactory
 from cio.core.arbiter import SignalArbiter
 from cio.core.authority import AuthorityStore
 from cio.core.cache import AsyncRedisCache
 from cio.core.context_builder import ContextBuilder
+from cio.core.evaluator_subscriber import EvaluatorSubscriber
 from cio.core.heartbeat import HeartbeatPublisher, HeartbeatResponder
 from cio.core.lifecycle import StrategyLifecycleStore
 from cio.core.listener import NATSListener
@@ -69,6 +71,12 @@ app.include_router(lifecycle_router)
 # (operator-only) mutates it via the authority_router endpoints.
 app.state.authority_store = AuthorityStore()
 app.include_router(authority_router)
+
+# Evaluator-driven pause gate (P2.6, #597). The subscriber lives at
+# `app.state.evaluator_subscriber` so the /state HTTP routes can read it.
+# It's set in `main()` after the NATS client connects — until then the
+# attribute is missing and the /state routes report 503.
+app.include_router(state_router)
 
 
 @app.get("/health/liveness")
@@ -182,10 +190,21 @@ async def main():
         realtime_strategies_url=realtime_strategies_url,
         cache=cache,
     )
+    # P2.6 (#597): evaluator-verdict subscriber + arbiter pause gate.
+    # Started before arbiter construction so the arbiter wires the
+    # subscriber reference, not None. Subscription itself begins below
+    # via `await evaluator_subscriber.start()` once the NATS connection
+    # is live.
+    evaluator_subscriber = EvaluatorSubscriber(nats_client=nc)
+    app.state.evaluator_subscriber = evaluator_subscriber
+
     arbiter = None
     if os.getenv("SIGNAL_ARBITRATION_ENABLED", "true").lower() in ("true", "1", "yes"):
-        arbiter = SignalArbiter(cache=cache)
-        logger.info("Signal arbitration enabled.")
+        arbiter = SignalArbiter(
+            cache=cache,
+            evaluator_subscriber=evaluator_subscriber,
+        )
+        logger.info("Signal arbitration enabled (with P2.6 pause gate).")
     else:
         logger.info("Signal arbitration disabled (SIGNAL_ARBITRATION_ENABLED=false).")
 
@@ -205,6 +224,12 @@ async def main():
 
     publisher = HeartbeatPublisher(nats_client=nc, interval_seconds=10.0)
     await publisher.start(subject=heartbeat_subject)
+
+    # P2.6 (#597): start the evaluator subscriber after NATS is live so
+    # arbitration begins consulting the latest upstream verdicts within
+    # one tick window of CIO startup.
+    await evaluator_subscriber.start()
+    logger.info("Evaluator subscriber listening on evaluator.>")
 
     # 3. Graceful Shutdown Setup
     stop_event = asyncio.Event()
@@ -248,6 +273,7 @@ async def main():
     logger.info("Cleaning up resources...")
     await publisher.stop()
     await responder.stop()
+    await evaluator_subscriber.stop()
     await listener.stop()
     await router.close()
     await builder.close()

--- a/tests/unit/test_evaluator_pause_gate.py
+++ b/tests/unit/test_evaluator_pause_gate.py
@@ -1,0 +1,226 @@
+"""Tests for the P2.6 evaluator pause gate (#597).
+
+Covers:
+  * `EvaluatorSubscriber` parses incoming `evaluator.<subsystem>.verdict`
+    messages and surfaces them via `is_paused` / `paused_subsystems`.
+  * Operator overrides win over the latest verdict.
+  * `SignalArbiter.check()` short-circuits to "suppressed" when any
+    pause-guarded subsystem is unhealthy.
+  * The /state HTTP routes expose the snapshot and accept overrides.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cio.apps.state_api import router as state_router
+from cio.core.arbiter import SignalArbiter
+from cio.core.evaluator_subscriber import (
+    HEALTHY,
+    UNHEALTHY,
+    UNKNOWN,
+    EvaluatorSubscriber,
+)
+
+
+def _msg(subject: str, payload: dict) -> SimpleNamespace:
+    return SimpleNamespace(subject=subject, data=json.dumps(payload).encode())
+
+
+@pytest.fixture
+def subscriber(mock_nats_client):
+    return EvaluatorSubscriber(nats_client=mock_nats_client)
+
+
+@pytest.mark.asyncio
+async def test_subscriber_tracks_per_subsystem_verdict(subscriber):
+    await subscriber._handle_message(
+        _msg("evaluator.ingest.verdict", {"verdict": HEALTHY, "reason": "ok"})
+    )
+    assert subscriber.is_paused("ingest") is False
+
+    await subscriber._handle_message(
+        _msg(
+            "evaluator.ingest.verdict",
+            {"verdict": UNHEALTHY, "reason": "binance.futures silent 90s"},
+        )
+    )
+    assert subscriber.is_paused("ingest") is True
+    paused = subscriber.paused_subsystems()
+    assert len(paused) == 1
+    assert paused[0]["subsystem"] == "ingest"
+    assert "silent" in paused[0]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_subscriber_resume_on_healthy_verdict(subscriber):
+    await subscriber._handle_message(
+        _msg("evaluator.ingest.verdict", {"verdict": UNHEALTHY, "reason": "stale"})
+    )
+    assert subscriber.is_paused("ingest") is True
+    await subscriber._handle_message(
+        _msg("evaluator.ingest.verdict", {"verdict": HEALTHY, "reason": "recovered"})
+    )
+    assert subscriber.is_paused("ingest") is False
+
+
+@pytest.mark.asyncio
+async def test_subscriber_ignores_malformed_messages(subscriber):
+    # Unparseable JSON
+    bad = SimpleNamespace(subject="evaluator.ingest.verdict", data=b"not json")
+    await subscriber._handle_message(bad)
+    # Subject pattern wrong
+    await subscriber._handle_message(
+        _msg("market.data.tick", {"verdict": UNHEALTHY, "reason": "x"})
+    )
+    # Verdict invalid
+    await subscriber._handle_message(
+        _msg("evaluator.ingest.verdict", {"verdict": "broken", "reason": "x"})
+    )
+    assert subscriber.is_paused("ingest") is False
+    assert subscriber.snapshot()["verdicts"] == []
+
+
+def test_override_pauses_even_when_verdict_healthy(subscriber):
+    # No verdict observed at all — operator manually pauses.
+    subscriber.set_override("ingest", UNHEALTHY)
+    assert subscriber.is_paused("ingest") is True
+    paused = subscriber.paused_subsystems()
+    assert paused[0]["override"] == UNHEALTHY
+
+
+@pytest.mark.asyncio
+async def test_override_unpauses_even_when_verdict_unhealthy(subscriber):
+    await subscriber._handle_message(
+        _msg("evaluator.ingest.verdict", {"verdict": UNHEALTHY, "reason": "x"})
+    )
+    subscriber.set_override("ingest", HEALTHY)
+    assert subscriber.is_paused("ingest") is False
+    # Cleared override returns to verdict-driven state.
+    subscriber.set_override("ingest", None)
+    assert subscriber.is_paused("ingest") is True
+
+
+def test_override_validates_verdict(subscriber):
+    with pytest.raises(ValueError) as exc_info:
+        subscriber.set_override("ingest", "not-a-verdict")
+    assert "healthy" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_arbiter_short_circuits_when_ingest_unhealthy(
+    subscriber, mock_redis_cache
+):
+    await subscriber._handle_message(
+        _msg("evaluator.ingest.verdict", {"verdict": UNHEALTHY, "reason": "silent"})
+    )
+    arbiter = SignalArbiter(cache=mock_redis_cache, evaluator_subscriber=subscriber)
+    allowed, reason = await arbiter.check(
+        symbol="BTCUSDT",
+        action="buy",
+        confidence=0.9,
+        strategy_id="ta-momentum",
+        correlation_id="corr-1",
+    )
+    assert allowed is False
+    assert "ARBITER_PAUSED" in reason
+    # The Redis cache must NOT be touched when arbitration is paused —
+    # that's the whole point of the early-exit guard.
+    mock_redis_cache.set.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_arbiter_passes_through_when_ingest_healthy(subscriber, mock_redis_cache):
+    await subscriber._handle_message(
+        _msg("evaluator.ingest.verdict", {"verdict": HEALTHY, "reason": "ok"})
+    )
+    mock_redis_cache.get = AsyncMock(return_value=None)
+    mock_redis_cache.set = AsyncMock()
+    arbiter = SignalArbiter(cache=mock_redis_cache, evaluator_subscriber=subscriber)
+    allowed, _ = await arbiter.check(
+        symbol="BTCUSDT",
+        action="buy",
+        confidence=0.9,
+        strategy_id="ta-momentum",
+        correlation_id="corr-1",
+    )
+    assert allowed is True
+    mock_redis_cache.set.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_arbiter_passes_through_when_no_subscriber_wired(mock_redis_cache):
+    """Legacy/no-eval-subscriber path must not break — ``None`` is allowed."""
+    mock_redis_cache.get = AsyncMock(return_value=None)
+    mock_redis_cache.set = AsyncMock()
+    arbiter = SignalArbiter(cache=mock_redis_cache, evaluator_subscriber=None)
+    allowed, _ = await arbiter.check(
+        symbol="BTCUSDT",
+        action="buy",
+        confidence=0.9,
+        strategy_id="ta-momentum",
+        correlation_id="corr-2",
+    )
+    assert allowed is True
+
+
+def _make_app(subscriber):
+    app = FastAPI()
+    app.state.evaluator_subscriber = subscriber
+    app.include_router(state_router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_state_endpoint_returns_snapshot(subscriber):
+    await subscriber._handle_message(
+        _msg(
+            "evaluator.ingest.verdict",
+            {"verdict": UNHEALTHY, "reason": "silent for 90s"},
+        )
+    )
+    client = TestClient(_make_app(subscriber))
+    r = client.get("/state")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["verdicts"]) == 1
+    assert len(body["paused"]) == 1
+    assert body["paused"][0]["subsystem"] == "ingest"
+
+
+@pytest.mark.asyncio
+async def test_state_override_endpoint(subscriber):
+    client = TestClient(_make_app(subscriber))
+    r = client.post("/state/override/ingest", json={"verdict": UNHEALTHY})
+    assert r.status_code == 200
+    assert r.json() == {"subsystem": "ingest", "override": UNHEALTHY}
+    assert subscriber.is_paused("ingest") is True
+
+
+def test_state_endpoint_503_when_subscriber_missing():
+    app = FastAPI()
+    app.include_router(state_router)
+    client = TestClient(app)
+    r = client.get("/state")
+    assert r.status_code == 503
+
+
+def test_unknown_verdict_does_not_pause(subscriber):
+    # The spec is explicit: only `unhealthy` pauses. `unknown` (e.g.
+    # ingest evaluator before its first message) must allow arbitration.
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(
+        subscriber._handle_message(
+            _msg(
+                "evaluator.ingest.verdict", {"verdict": UNKNOWN, "reason": "no msg yet"}
+            )
+        )
+    )
+    assert subscriber.is_paused("ingest") is False


### PR DESCRIPTION
Closes PetroSa2/petrosa_k8s#597

## Summary
- Adds `EvaluatorSubscriber` that subscribes to `evaluator.>` and tracks per-subsystem verdicts (healthy / unhealthy / unknown).
- `SignalArbiter` consults the subscriber before every check; unhealthy upstream → signal suppressed with `ARBITER_PAUSED` reason; Redis arbitration state untouched.
- Pause-guarded subsystems = `{ingest}` (consumer of [#593](https://github.com/PetroSa2/petrosa_k8s/issues/593)). Future tickets can extend.
- New HTTP routes (`cio/apps/state_api.py`):
  - `GET  /state` — full snapshot (verdicts + paused list).
  - `GET  /state/paused` — short paused-list (dashboard feed).
  - `POST /state/override/{subsystem}` body `{"verdict": "healthy"|"unhealthy"|"unknown"|null}` — operator override.

## FR Coverage
- **FR14, FR45** — verdict RED → GREEN (CIO halts cleanly when an upstream dependency is unhealthy).
- **Build Plan reference:** P2.6.
- **Depends on:** [#593](https://github.com/PetroSa2/petrosa_k8s/issues/593) P2.2 (merged earlier this session).

## Test plan
- [x] `pytest tests/unit/test_evaluator_pause_gate.py` — 13/13 pass.
- [x] `pytest tests/unit/` — 188/188 pass (no regression on arbiter/authority/lifecycle).
- [x] `ruff check` + `ruff format` clean.

## Known follow-ups (out of scope)
- Cross-restart persistence of pause state.
- Per-strategy / per-subject pause granularity.
- Audit-trail persistence of pause/resume as `signals.trading.>` decision events (today: structured logs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)