### PR TITLE
feat(cio): #610 - CIO health evaluator emits evaluator.cio.verdict (P7.1)

### DIFF
--- a/cio/core/health_evaluator.py
+++ b/cio/core/health_evaluator.py
@@ -1,0 +1,434 @@
+"""CIO health evaluator (P7.1, #610).
+
+Emits ``evaluator.cio.verdict`` so Outcome 5's "all 8 services reporting"
+gate closes. Verdict is driven by structural + light behavioral checks
+against recent CIO activity — per-action-type outcome grading is
+explicitly deferred to Phase 2.
+
+The MVP verdict combines three signals over a sliding window:
+
+1. **Reasoning-context presence (structural).** Recent CIO decisions
+   must carry a non-empty, non-fallback ``thought_trace``. Empty traces
+   or known fallback markers (``PARSE_FAILURE``, ``SYSTEM_ERROR``,
+   ``CRITICAL_FAILURE_ENFORCEMENT``, ``TIMEOUT_ENFORCEMENT``,
+   ``DETERMINISTIC_BYPASS``) indicate the LLM-degraded path. If the
+   fraction of fallback-marked decisions in the window exceeds
+   ``missing_context_threshold`` the evaluator reports unhealthy.
+
+2. **Degraded-mode dominance (behavioral).** Sustained dominance of
+   ``FAIL_SAFE`` / ``SKIP`` actions over the window indicates the safe-
+   fail path is on (FR13 / NFR-R5). If that fraction exceeds
+   ``degraded_threshold`` the evaluator reports unhealthy.
+
+3. **Cadence / silence (behavioral).** When ``cio.intent.trading.>`` is
+   active in the window but ``signals.trading.>`` is silent, CIO is
+   receiving intents but not emitting any signals (or audit-copy
+   decisions). A long silence flag is unhealthy.
+
+Per-decision realized-outcome correlation is persisted via the optional
+:class:`OutcomeCorrelator` (Phase-2 substrate) but does NOT feed the
+verdict in MVP. The hook is in place so the Phase-2 judgment grader can
+build on the same audit copy without a second observability rewrite.
+
+Hysteresis: the evaluator emits at every tick but only flips its
+externally-published verdict after observing the same raw verdict for
+``stable_ticks_required`` consecutive ticks. This avoids flapping when
+the window straddles a single anomalous decision.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATS
+
+logger = logging.getLogger(__name__)
+
+
+VERDICT_SUBJECT = "evaluator.cio.verdict"
+DECISION_AUDIT_PATTERN = "cio.decision.audit.>"
+INTENT_PATTERN = "cio.intent.trading.>"
+SIGNAL_PATTERN = "signals.trading.>"
+
+HEALTHY = "healthy"
+UNHEALTHY = "unhealthy"
+UNKNOWN = "unknown"
+
+# Action values that count as "degraded mode" — these come straight from
+# `cio.models.enums.ActionType` but the evaluator keeps them as raw
+# strings so it can tolerate enum drift across releases without hard
+# import coupling on the audit subject's payload.
+DEGRADED_ACTIONS: frozenset[str] = frozenset({"fail_safe", "skip"})
+
+# Thought-trace markers we treat as "missing reasoning context". These
+# match the SAFE_DEFAULTS / fallback markers produced by
+# `cio.models.decision` and `cio.core.orchestrator` when the LLM path
+# degrades or is bypassed.
+FALLBACK_TRACE_MARKERS: frozenset[str] = frozenset(
+    {
+        "PARSE_FAILURE",
+        "SYSTEM_ERROR",
+        "CRITICAL_FAILURE_ENFORCEMENT",
+        "TIMEOUT_ENFORCEMENT",
+        "DETERMINISTIC_BYPASS",
+    }
+)
+
+
+@dataclass(slots=True)
+class _DecisionRecord:
+    observed_at: datetime
+    action: str
+    thought_trace: str
+    decision_id: str
+    strategy_id: str
+    correlation_id: str
+
+
+@dataclass(slots=True)
+class _EventTick:
+    observed_at: datetime
+
+
+class OutcomeCorrelator:
+    """Persists decision/outcome correlation records.
+
+    MVP scope: hook in place. When a P&L event lands matching a recently
+    observed decision_id, the correlator writes a single audit record
+    via the same vector_client used by the OutputRouter. This is the
+    "Phase-2-ready substrate" called out in the ticket AC.
+
+    In MVP no NATS subscription is created here — the wiring point is
+    intentionally narrow so Phase 2 can attach its own subject
+    convention without churning this class.
+    """
+
+    def __init__(self, vector_client) -> None:
+        self._vc = vector_client
+
+    async def record(
+        self,
+        *,
+        decision_id: str,
+        strategy_id: str,
+        correlation_id: str,
+        outcome_payload: dict,
+    ) -> None:
+        """Persist one correlation record. Failures are logged, not raised."""
+        try:
+            await self._vc.upsert(
+                strategy_id=strategy_id,
+                payload={
+                    "event_type": "decision_outcome_correlation",
+                    "decision_id": decision_id,
+                    "correlation_id": correlation_id,
+                    "observed_at": datetime.now(UTC).isoformat(),
+                    "outcome": outcome_payload,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "outcome_correlation_persist_failed",
+                extra={
+                    "decision_id": decision_id,
+                    "strategy_id": strategy_id,
+                    "error": str(exc),
+                },
+            )
+
+
+class CIOHealthEvaluator:
+    """Emits ``evaluator.cio.verdict`` from sliding-window CIO activity.
+
+    The class is split into two cooperating loops:
+
+    * **Observation loop** — three NATS subscriptions feed the
+      sliding-window deques (decisions, intents, signal-outputs).
+    * **Emit loop** — a periodic task computes the raw verdict, applies
+      hysteresis, and publishes on ``evaluator.cio.verdict``.
+
+    Both loops are non-blocking: NATS handlers append to deques and
+    return; the emit loop reads them at a coarse cadence. State is
+    per-process / in-memory (consistent with the existing
+    EvaluatorSubscriber's posture).
+    """
+
+    def __init__(
+        self,
+        nats_client: NATS,
+        *,
+        window: timedelta = timedelta(seconds=60),
+        emit_interval: timedelta = timedelta(seconds=15),
+        stable_ticks_required: int = 2,
+        missing_context_threshold: float = 0.5,
+        degraded_threshold: float = 0.5,
+        min_intents_for_silence_check: int = 3,
+        silence_min_age: timedelta = timedelta(seconds=20),
+        on_emit: Callable[[str, str], Awaitable[None]] | None = None,
+    ) -> None:
+        self._nc = nats_client
+        self._window = window
+        self._emit_interval = emit_interval
+        self._stable_ticks_required = max(1, stable_ticks_required)
+        self._missing_context_threshold = missing_context_threshold
+        self._degraded_threshold = degraded_threshold
+        self._min_intents_for_silence_check = min_intents_for_silence_check
+        self._silence_min_age = silence_min_age
+        self._on_emit = on_emit
+
+        self._decisions: deque[_DecisionRecord] = deque()
+        self._intents: deque[_EventTick] = deque()
+        self._signals: deque[_EventTick] = deque()
+
+        # NATS Subscription is loosely typed (the upstream `nats-py`
+        # client uses a runtime-private class) — keep these as Any-typed
+        # ``object`` slots so mypy doesn't infer ``None`` and reject
+        # later assignments.
+        self._decision_sub: object | None = None
+        self._intent_sub: object | None = None
+        self._signal_sub: object | None = None
+        self._emit_task: asyncio.Task | None = None
+
+        # Hysteresis state. ``_emitted_verdict`` is the last verdict we
+        # actually published; ``_candidate_verdict`` is the raw verdict
+        # we've been observing consecutively, with ``_candidate_streak``
+        # counting consecutive observations.
+        self._emitted_verdict: str = UNKNOWN
+        self._candidate_verdict: str = UNKNOWN
+        self._candidate_streak: int = 0
+
+    # ----- lifecycle -----
+
+    async def start(self) -> None:
+        self._decision_sub = await self._nc.subscribe(
+            DECISION_AUDIT_PATTERN, cb=self._on_decision
+        )
+        self._intent_sub = await self._nc.subscribe(INTENT_PATTERN, cb=self._on_intent)
+        self._signal_sub = await self._nc.subscribe(SIGNAL_PATTERN, cb=self._on_signal)
+        self._emit_task = asyncio.create_task(self._emit_loop())
+        logger.info(
+            "cio_health_evaluator_started",
+            extra={
+                "decision_subject": DECISION_AUDIT_PATTERN,
+                "intent_subject": INTENT_PATTERN,
+                "signal_subject": SIGNAL_PATTERN,
+                "verdict_subject": VERDICT_SUBJECT,
+                "window_s": self._window.total_seconds(),
+                "emit_interval_s": self._emit_interval.total_seconds(),
+            },
+        )
+
+    async def stop(self) -> None:
+        if self._emit_task is not None:
+            self._emit_task.cancel()
+            try:
+                await self._emit_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._emit_task = None
+        for sub in (self._decision_sub, self._intent_sub, self._signal_sub):
+            if sub is None:
+                continue
+            unsubscribe = getattr(sub, "unsubscribe", None)
+            if unsubscribe is None:
+                continue
+            try:
+                await unsubscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"cio_health_evaluator unsubscribe failed: {exc}")
+        self._decision_sub = self._intent_sub = self._signal_sub = None
+
+    # ----- NATS handlers -----
+
+    async def _on_decision(self, msg) -> None:
+        try:
+            payload = json.loads(msg.data.decode())
+        except (json.JSONDecodeError, AttributeError, UnicodeDecodeError) as exc:
+            logger.warning(
+                "health_evaluator_decision_unparsable",
+                extra={"subject": msg.subject, "error": str(exc)},
+            )
+            return
+
+        record = _DecisionRecord(
+            observed_at=datetime.now(UTC),
+            action=str(payload.get("action") or "").lower(),
+            thought_trace=(payload.get("thought_trace") or "").strip(),
+            decision_id=str(payload.get("decision_id") or ""),
+            strategy_id=str(payload.get("strategy_id") or ""),
+            correlation_id=str(payload.get("correlation_id") or ""),
+        )
+        self._decisions.append(record)
+
+    async def _on_intent(self, msg) -> None:
+        self._intents.append(_EventTick(observed_at=datetime.now(UTC)))
+
+    async def _on_signal(self, msg) -> None:
+        self._signals.append(_EventTick(observed_at=datetime.now(UTC)))
+
+    # ----- evaluation -----
+
+    def _prune(self, now: datetime) -> None:
+        cutoff = now - self._window
+        for q in (self._decisions, self._intents, self._signals):
+            while q and q[0].observed_at < cutoff:
+                q.popleft()
+
+    def evaluate(self, now: datetime | None = None) -> tuple[str, str]:
+        """Compute the raw verdict + reason for the current window.
+
+        Exposed for testability — the emit loop calls this with
+        ``now = datetime.now(UTC)`` on each tick.
+
+        Returns ``(verdict, reason)`` where verdict is one of HEALTHY /
+        UNHEALTHY / UNKNOWN and reason is the verbatim-render text the
+        dashboard surfaces (NFR-O5).
+        """
+        now = now or datetime.now(UTC)
+        self._prune(now)
+
+        decisions = list(self._decisions)
+        intents = list(self._intents)
+        signals = list(self._signals)
+
+        # Silence check first — covers the case where intents are
+        # flowing but CIO has produced nothing (neither decisions nor
+        # signal outputs). Require the oldest qualifying intent to be at
+        # least ``silence_min_age`` old, otherwise a fresh burst can
+        # trip the check prematurely on startup.
+        if (
+            len(intents) >= self._min_intents_for_silence_check
+            and not signals
+            and not decisions
+        ):
+            oldest = intents[0].observed_at
+            if (now - oldest) >= self._silence_min_age:
+                return (
+                    UNHEALTHY,
+                    (
+                        f"silence: {len(intents)} intents on "
+                        "cio.intent.trading.> in last "
+                        f"{int(self._window.total_seconds())}s, no "
+                        "signals.trading.> emitted"
+                    ),
+                )
+
+        if not decisions:
+            return UNKNOWN, "no recent CIO decisions observed in window"
+
+        total = len(decisions)
+        missing_context = sum(
+            1
+            for d in decisions
+            if not d.thought_trace or d.thought_trace in FALLBACK_TRACE_MARKERS
+        )
+        degraded = sum(1 for d in decisions if d.action in DEGRADED_ACTIONS)
+
+        missing_fraction = missing_context / total
+        degraded_fraction = degraded / total
+
+        if missing_fraction > self._missing_context_threshold:
+            pct = round(missing_fraction * 100)
+            return (
+                UNHEALTHY,
+                (
+                    f"reasoning-context missing on {pct}% of recent decisions "
+                    f"({missing_context}/{total}) — fallback path active"
+                ),
+            )
+
+        if degraded_fraction > self._degraded_threshold:
+            pct = round(degraded_fraction * 100)
+            return (
+                UNHEALTHY,
+                (
+                    f"degraded-mode dominance: {pct}% of recent decisions "
+                    f"({degraded}/{total}) in FAIL_SAFE/SKIP"
+                ),
+            )
+
+        return (
+            HEALTHY,
+            (
+                f"{total} decisions in last "
+                f"{int(self._window.total_seconds())}s, "
+                f"missing-context {missing_context}, degraded {degraded}"
+            ),
+        )
+
+    def _apply_hysteresis(self, raw_verdict: str) -> str:
+        """Return the verdict the evaluator should publish this tick.
+
+        Same raw verdict for ``stable_ticks_required`` consecutive ticks
+        flips the externally-published verdict. Until then, the previous
+        emitted verdict stays in place (avoids flapping).
+        """
+        if raw_verdict == self._emitted_verdict:
+            self._candidate_verdict = raw_verdict
+            self._candidate_streak = 0
+            return self._emitted_verdict
+
+        if raw_verdict == self._candidate_verdict:
+            self._candidate_streak += 1
+        else:
+            self._candidate_verdict = raw_verdict
+            self._candidate_streak = 1
+
+        if self._candidate_streak >= self._stable_ticks_required:
+            self._emitted_verdict = raw_verdict
+            self._candidate_streak = 0
+        return self._emitted_verdict
+
+    async def _publish(self, verdict: str, reason: str) -> None:
+        payload = json.dumps({"verdict": verdict, "reason": reason[:200]}).encode()
+        try:
+            await self._nc.publish(VERDICT_SUBJECT, payload)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "cio_health_evaluator_publish_failed",
+                extra={"error": str(exc), "verdict": verdict},
+            )
+            return
+        if self._on_emit is not None:
+            try:
+                await self._on_emit(verdict, reason)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"cio_health_evaluator on_emit failed: {exc}")
+
+    async def tick(self) -> tuple[str, str]:
+        """One evaluation + publish cycle. Returns (emitted_verdict, reason).
+
+        Exposed so tests can drive ticks deterministically without
+        waiting on the emit loop's sleep.
+        """
+        raw_verdict, reason = self.evaluate()
+        emitted = self._apply_hysteresis(raw_verdict)
+        await self._publish(emitted, reason)
+        return emitted, reason
+
+    async def _emit_loop(self) -> None:
+        interval_s = self._emit_interval.total_seconds()
+        while True:
+            try:
+                await self.tick()
+            except Exception as exc:  # noqa: BLE001 — never crash the loop
+                logger.warning(
+                    "cio_health_evaluator_tick_failed",
+                    extra={"error": str(exc)},
+                )
+            await asyncio.sleep(interval_s)

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -451,6 +451,28 @@ class OutputRouter:
                 except Exception as e:
                     logger.error(f"Failed to fire fail-safe REST pause: {e}")
 
+        # 2b. Audit copy on cio.decision.audit.<action> — feeds the CIO
+        # health evaluator (P7.1, #610) and is the Phase-2 substrate for
+        # decision/outcome correlation. Published for *every* action so
+        # the evaluator can compute reasoning-context presence and
+        # FAIL_SAFE/SKIP dominance over a sliding window.
+        audit_copy_payload = {
+            "decision_id": decision_id,
+            "correlation_id": correlation_id,
+            "strategy_id": strategy_id,
+            "action": action.value,
+            "thought_trace": decision.thought_trace,
+            "justification": decision.justification,
+        }
+        if authority_was_disabled:
+            audit_copy_payload["authority_fallback_from"] = original_action.value
+        dispatch_tasks_data.append(
+            (
+                f"cio.decision.audit.{action.value}",
+                json.dumps(audit_copy_payload).encode(),
+            )
+        )
+
         # 3. Handle Dispatch execution (Checking DRY_RUN)
         nats_publish_tasks = []
 

--- a/cio/main.py
+++ b/cio/main.py
@@ -18,6 +18,7 @@ from cio.core.authority import AuthorityStore
 from cio.core.cache import AsyncRedisCache
 from cio.core.context_builder import ContextBuilder
 from cio.core.evaluator_subscriber import EvaluatorSubscriber
+from cio.core.health_evaluator import CIOHealthEvaluator
 from cio.core.heartbeat import HeartbeatPublisher, HeartbeatResponder
 from cio.core.lifecycle import StrategyLifecycleStore
 from cio.core.listener import NATSListener
@@ -231,6 +232,16 @@ async def main():
     await evaluator_subscriber.start()
     logger.info("Evaluator subscriber listening on evaluator.>")
 
+    # P7.1 (#610): CIO health evaluator. Subscribes to its own decision
+    # audit copies + intent/signal cadence and publishes
+    # evaluator.cio.verdict, closing Outcome 5's 8/8 evaluator coverage
+    # gate. Started after the upstream subscriber so the loop has fresh
+    # state by the time it ticks.
+    health_evaluator = CIOHealthEvaluator(nats_client=nc)
+    app.state.cio_health_evaluator = health_evaluator
+    await health_evaluator.start()
+    logger.info("CIO health evaluator publishing on evaluator.cio.verdict")
+
     # 3. Graceful Shutdown Setup
     stop_event = asyncio.Event()
 
@@ -273,6 +284,7 @@ async def main():
     logger.info("Cleaning up resources...")
     await publisher.stop()
     await responder.stop()
+    await health_evaluator.stop()
     await evaluator_subscriber.stop()
     await listener.stop()
     await router.close()

--- a/tests/integration/test_nats_to_nats_loop.py
+++ b/tests/integration/test_nats_to_nats_loop.py
@@ -144,8 +144,12 @@ async def test_full_nats_to_nats_loop():
             await listener._handle_message(mock_msg)
 
             # 5. Assertions
-            # Verify NATS publish was called TWICE (Legacy + Modern)
-            assert mock_nc.publish.call_count == 2
+            # Verify NATS publish was called THREE times:
+            #   1) Legacy signal      (signals.trading.<strategy_id>)
+            #   2) Modern decision    (trade.execute.<strategy_id>)
+            #   3) Decision audit copy for the CIO health evaluator
+            #      (cio.decision.audit.<action>, added in P7.1 / #610)
+            assert mock_nc.publish.call_count == 3
             assert orchestrator.run.await_count == 1
 
             # Check Legacy Call (signals.trading.<strategy_id> — matches tradeengine signals.trading.>)
@@ -163,6 +167,14 @@ async def test_full_nats_to_nats_loop():
             modern_payload = json.loads(modern_call[0][1].decode())
             assert modern_payload["action"] == "execute"
             assert modern_payload["computed_position_size_usd"] == pytest.approx(5000.0)
+
+            # Check Audit-Copy Call (cio.decision.audit.execute)
+            audit_call = mock_nc.publish.call_args_list[2]
+            assert audit_call[0][0] == "cio.decision.audit.execute"
+            audit_payload = json.loads(audit_call[0][1].decode())
+            assert audit_payload["action"] == "execute"
+            assert audit_payload["strategy_id"] == "momentum_v1"
+            assert audit_payload["correlation_id"] == "test-loop-id"
 
             # Verify Vector Upsert (Audit Path)
             mock_vc.upsert.assert_called_once()

--- a/tests/unit/test_cio_health_evaluator.py
+++ b/tests/unit/test_cio_health_evaluator.py
@@ -1,0 +1,421 @@
+"""Tests for the CIO health evaluator (P7.1, #610).
+
+Covers the three failure-injection cases from the ticket's acceptance
+criteria:
+
+  (a) CIO decision with missing reasoning context  → unhealthy
+  (b) sustained FAIL_SAFE dominance window         → unhealthy (degraded)
+  (c) silence on signals.trading.> while intents flowing → unhealthy
+
+Plus structural coverage of the publish path, hysteresis, idle/unknown
+state, and the OutcomeCorrelator's persistence hook.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from cio.core.health_evaluator import (
+    DECISION_AUDIT_PATTERN,
+    HEALTHY,
+    INTENT_PATTERN,
+    SIGNAL_PATTERN,
+    UNHEALTHY,
+    UNKNOWN,
+    VERDICT_SUBJECT,
+    CIOHealthEvaluator,
+    OutcomeCorrelator,
+)
+
+
+def _msg(subject: str, payload: dict) -> SimpleNamespace:
+    return SimpleNamespace(subject=subject, data=json.dumps(payload).encode())
+
+
+@pytest.fixture
+def evaluator(mock_nats_client):
+    return CIOHealthEvaluator(
+        nats_client=mock_nats_client,
+        window=timedelta(seconds=60),
+        emit_interval=timedelta(seconds=15),
+        stable_ticks_required=1,  # default 1 in tests → no flap delay
+        missing_context_threshold=0.5,
+        degraded_threshold=0.5,
+        min_intents_for_silence_check=3,
+        silence_min_age=timedelta(seconds=20),
+    )
+
+
+async def _decision(
+    evaluator: CIOHealthEvaluator,
+    *,
+    action: str,
+    thought_trace: str = "regime_choppy → SKIP",
+    decision_id: str = "d-1",
+    strategy_id: str = "ta-momentum",
+    correlation_id: str = "c-1",
+) -> None:
+    payload = {
+        "decision_id": decision_id,
+        "correlation_id": correlation_id,
+        "strategy_id": strategy_id,
+        "action": action,
+        "thought_trace": thought_trace,
+        "justification": "test",
+    }
+    await evaluator._on_decision(_msg(f"cio.decision.audit.{action}", payload))
+
+
+# ---------------------------------------------------------------------------
+# AC (a): missing reasoning context → unhealthy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_reasoning_context_yields_unhealthy(evaluator):
+    # Dominantly empty / fallback-marker thought traces. The fallback
+    # marker set comes straight from cio.models.decision SAFE_DEFAULTS.
+    for i, trace in enumerate(["PARSE_FAILURE", "", "SYSTEM_ERROR", "PARSE_FAILURE"]):
+        await _decision(
+            evaluator,
+            action="execute",
+            thought_trace=trace,
+            decision_id=f"d-{i}",
+        )
+    # A single well-reasoned decision is not enough to recover when the
+    # fallback fraction exceeds the threshold.
+    await _decision(evaluator, action="execute", thought_trace="solid trace")
+
+    verdict, reason = evaluator.evaluate()
+    assert verdict == UNHEALTHY
+    assert "reasoning-context" in reason or "fallback" in reason
+
+
+# ---------------------------------------------------------------------------
+# AC (b): sustained FAIL_SAFE / SKIP dominance → unhealthy (degraded mode)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fail_safe_dominance_yields_degraded_unhealthy(evaluator):
+    # Use non-fallback thought traces so the degraded-mode check (the
+    # behavioral signal) wins over the structural reasoning-context
+    # check — when both fire, the more specific structural symptom
+    # takes precedence by design, so this test isolates the behavioral
+    # path with traces that look reasoned.
+    for i in range(4):
+        await _decision(
+            evaluator,
+            action="fail_safe",
+            thought_trace=f"upstream health failing: ingest stale for {i}s",
+            decision_id=f"fs-{i}",
+        )
+    await _decision(
+        evaluator,
+        action="execute",
+        thought_trace="good",
+        decision_id="exec-1",
+    )
+
+    verdict, reason = evaluator.evaluate()
+    assert verdict == UNHEALTHY
+    # The reason must name the degraded mode so the operator can act.
+    assert "degraded" in reason.lower() or "FAIL_SAFE" in reason
+
+
+@pytest.mark.asyncio
+async def test_skip_dominance_also_counts_as_degraded(evaluator):
+    # SKIP dominance is the same family of failure — the SAFE_DEFAULTS
+    # action classifier emits SKIP on parse failure, so a window
+    # dominated by SKIP is a degraded-mode signal too.
+    for i in range(3):
+        await _decision(
+            evaluator,
+            action="skip",
+            thought_trace="PARSE_FAILURE",
+            decision_id=f"sk-{i}",
+        )
+    await _decision(
+        evaluator,
+        action="execute",
+        thought_trace="ok",
+        decision_id="exec-1",
+    )
+    # 75% SKIP — but wait, all three SKIP entries also have
+    # PARSE_FAILURE traces, so the missing-context check fires first.
+    # That's the correct precedence: reasoning context is the more
+    # specific symptom. Re-run with non-fallback traces on the SKIPs
+    # to isolate the degraded-mode path.
+    evaluator._decisions.clear()
+    for i in range(3):
+        await _decision(
+            evaluator,
+            action="skip",
+            thought_trace="cooldown active for strategy",
+            decision_id=f"sk-{i}",
+        )
+    await _decision(
+        evaluator,
+        action="execute",
+        thought_trace="ok",
+        decision_id="exec-1",
+    )
+
+    verdict, reason = evaluator.evaluate()
+    assert verdict == UNHEALTHY
+    assert "degraded" in reason.lower() or "FAIL_SAFE" in reason
+
+
+# ---------------------------------------------------------------------------
+# AC (c): intents flowing but signals silent → unhealthy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_intents_flowing_no_signals_yields_unhealthy(evaluator):
+    # 4 intents back-dated to look like a sustained flow over the past
+    # ~30s. No signals, no decisions — CIO is receiving but not
+    # producing.
+    now = datetime.now(UTC)
+    intent_age = timedelta(seconds=30)
+    for i in range(4):
+        await evaluator._on_intent(
+            _msg(f"cio.intent.trading.BTCUSDT.{i}", {"symbol": "BTCUSDT"})
+        )
+    # Backdate the intents so the silence_min_age check fires.
+    for tick in evaluator._intents:
+        tick.observed_at = now - intent_age
+
+    verdict, reason = evaluator.evaluate(now=now)
+    assert verdict == UNHEALTHY
+    assert "silence" in reason.lower() or "no signals" in reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_fresh_intent_burst_does_not_trigger_silence_check(evaluator):
+    # The silence check must NOT fire when intents are fresh enough that
+    # CIO simply hasn't had time to respond yet (silence_min_age = 20s).
+    for i in range(4):
+        await evaluator._on_intent(
+            _msg(f"cio.intent.trading.BTCUSDT.{i}", {"symbol": "BTCUSDT"})
+        )
+
+    verdict, reason = evaluator.evaluate()
+    assert verdict == UNKNOWN
+    assert "no recent CIO decisions" in reason
+
+
+@pytest.mark.asyncio
+async def test_signals_present_keeps_evaluator_quiet_on_silence(evaluator):
+    # Even if intents are flowing AND no decisions are in the window,
+    # the presence of signal output on signals.trading.> means CIO is
+    # producing — the silence rule must not fire.
+    now = datetime.now(UTC)
+    for i in range(4):
+        await evaluator._on_intent(_msg(f"cio.intent.trading.{i}", {}))
+        await evaluator._on_signal(_msg(f"signals.trading.s-{i}", {}))
+    for tick in evaluator._intents:
+        tick.observed_at = now - timedelta(seconds=30)
+    for tick in evaluator._signals:
+        tick.observed_at = now - timedelta(seconds=25)
+
+    verdict, _ = evaluator.evaluate(now=now)
+    assert verdict == UNKNOWN  # no decisions in window, but no silence either
+
+
+# ---------------------------------------------------------------------------
+# Steady-state behaviors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_decisions_well_reasoned(evaluator):
+    for i in range(5):
+        await _decision(
+            evaluator,
+            action="execute",
+            thought_trace=f"regime trend; momentum positive; {i}",
+            decision_id=f"e-{i}",
+        )
+    verdict, reason = evaluator.evaluate()
+    assert verdict == HEALTHY
+    assert "decisions in last" in reason
+
+
+@pytest.mark.asyncio
+async def test_empty_window_yields_unknown(evaluator):
+    verdict, reason = evaluator.evaluate()
+    assert verdict == UNKNOWN
+    assert "no recent" in reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_window_prune_removes_stale_records(evaluator):
+    # Inject a decision and immediately backdate it past the window.
+    await _decision(evaluator, action="execute", thought_trace="solid")
+    for rec in evaluator._decisions:
+        rec.observed_at = datetime.now(UTC) - timedelta(seconds=120)
+
+    verdict, _ = evaluator.evaluate()
+    assert verdict == UNKNOWN  # stale record dropped
+
+
+# ---------------------------------------------------------------------------
+# Publish path + hysteresis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_publishes_on_verdict_subject(evaluator, mock_nats_client):
+    for i in range(3):
+        await _decision(
+            evaluator,
+            action="execute",
+            thought_trace="solid",
+            decision_id=f"e-{i}",
+        )
+    verdict, reason = await evaluator.tick()
+    assert verdict == HEALTHY
+    mock_nats_client.publish.assert_awaited_once()
+    args, _ = mock_nats_client.publish.call_args
+    subject, payload = args
+    assert subject == VERDICT_SUBJECT
+    body = json.loads(payload.decode())
+    assert body["verdict"] == HEALTHY
+    assert body["reason"]  # non-empty
+    assert len(body["reason"]) <= 200
+
+
+@pytest.mark.asyncio
+async def test_hysteresis_delays_verdict_flip(mock_nats_client):
+    ev = CIOHealthEvaluator(
+        nats_client=mock_nats_client,
+        window=timedelta(seconds=60),
+        emit_interval=timedelta(seconds=15),
+        stable_ticks_required=2,
+    )
+    # The initial emitted state is UNKNOWN; flipping to HEALTHY also
+    # requires the hysteresis to clear. Seed healthy decisions and tick
+    # twice to settle into HEALTHY before testing the unhealthy flip.
+    for i in range(3):
+        await _decision(
+            ev,
+            action="execute",
+            thought_trace=f"solid {i}",
+            decision_id=f"h-{i}",
+        )
+    settle1, _ = await ev.tick()
+    settle2, _ = await ev.tick()
+    assert settle1 == UNKNOWN  # first observation pending
+    assert settle2 == HEALTHY  # second observation flips
+
+    # Now flood with FAIL_SAFE. First tick must NOT flip (hysteresis).
+    ev._decisions.clear()
+    for i in range(4):
+        await _decision(
+            ev,
+            action="fail_safe",
+            thought_trace="upstream stale, safe-failing",
+            decision_id=f"fs-{i}",
+        )
+    flip1, _ = await ev.tick()
+    flip2, _ = await ev.tick()
+    assert flip1 == HEALTHY  # hysteresis holding
+    assert flip2 == UNHEALTHY  # flipped after second consecutive raw observation
+
+
+@pytest.mark.asyncio
+async def test_emit_truncates_long_reason_to_200_chars(evaluator, mock_nats_client):
+    # Construct a synthetic-but-realistic many-decision corpus that will
+    # cause the reason string to approach 200 chars; the publish path
+    # must hard-cap at 200 regardless.
+    for i in range(40):
+        await _decision(
+            evaluator,
+            action="fail_safe",
+            thought_trace="CRITICAL_FAILURE_ENFORCEMENT" + "x" * 20,
+            decision_id=f"fs-{i}",
+        )
+    await evaluator.tick()
+    args, _ = mock_nats_client.publish.call_args
+    _, payload = args
+    body = json.loads(payload.decode())
+    assert len(body["reason"]) <= 200
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle (subscribe / unsubscribe)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_subscribes_to_three_subjects(mock_nats_client):
+    ev = CIOHealthEvaluator(nats_client=mock_nats_client)
+    await ev.start()
+    subjects = [call.args[0] for call in mock_nats_client.subscribe.call_args_list]
+    assert DECISION_AUDIT_PATTERN in subjects
+    assert INTENT_PATTERN in subjects
+    assert SIGNAL_PATTERN in subjects
+    await ev.stop()
+
+
+# ---------------------------------------------------------------------------
+# Outcome correlator (Phase-2 substrate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_outcome_correlator_persists_record():
+    vc = AsyncMock()
+    correlator = OutcomeCorrelator(vector_client=vc)
+    await correlator.record(
+        decision_id="d-1",
+        strategy_id="ta-momentum",
+        correlation_id="c-1",
+        outcome_payload={"realized_pnl_usd": 12.5},
+    )
+    vc.upsert.assert_awaited_once()
+    kwargs = vc.upsert.call_args.kwargs
+    assert kwargs["strategy_id"] == "ta-momentum"
+    payload = kwargs["payload"]
+    assert payload["event_type"] == "decision_outcome_correlation"
+    assert payload["decision_id"] == "d-1"
+    assert payload["outcome"]["realized_pnl_usd"] == 12.5
+
+
+@pytest.mark.asyncio
+async def test_outcome_correlator_swallows_vector_errors():
+    vc = AsyncMock()
+    vc.upsert.side_effect = RuntimeError("vector unreachable")
+    correlator = OutcomeCorrelator(vector_client=vc)
+    # MUST NOT raise — correlation persistence is best-effort.
+    await correlator.record(
+        decision_id="d-1",
+        strategy_id="ta",
+        correlation_id="c-1",
+        outcome_payload={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Malformed input resilience (consistent with EvaluatorSubscriber posture)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unparsable_decision_payload_dropped(evaluator):
+    bad = SimpleNamespace(subject="cio.decision.audit.execute", data=b"not json")
+    await evaluator._on_decision(bad)
+    assert not evaluator._decisions

--- a/tests/unit/test_router_authority.py
+++ b/tests/unit/test_router_authority.py
@@ -78,10 +78,12 @@ async def test_enabled_action_dispatches_normally_via_authority_store():
     with patch.dict(os.environ, {"DRY_RUN": "false"}):
         await router.route(_make_context(), _make_decision(ActionType.ADMIT))
 
-    # ADMIT (a lifecycle action) publishes on cio.lifecycle.admit.<sid>.
-    router.nats_client.publish.assert_called_once()
-    subject, _payload = router.nats_client.publish.call_args.args
-    assert subject == "cio.lifecycle.admit.strat_a"
+    # ADMIT (a lifecycle action) publishes on cio.lifecycle.admit.<sid>,
+    # plus the audit copy on cio.decision.audit.admit (#610 P7.1).
+    assert router.nats_client.publish.call_count == 2
+    subjects = [c.args[0] for c in router.nats_client.publish.call_args_list]
+    assert "cio.lifecycle.admit.strat_a" in subjects
+    assert "cio.decision.audit.admit" in subjects
     # No pending-approval entries because action was ENABLED.
     assert store.list_pending() == []
 
@@ -164,8 +166,15 @@ async def test_disabled_action_substitutes_fallback_and_records_original():
     with patch.dict(os.environ, {"DRY_RUN": "false"}):
         await router.route(_make_context(), _make_decision(ActionType.EXECUTE))
 
-    # EXECUTE → SKIP fallback. SKIP does not publish.
-    mock_nc.publish.assert_not_called()
+    # EXECUTE → SKIP fallback. SKIP itself does not publish, but the
+    # decision audit copy (#610 P7.1) is published unconditionally so
+    # the CIO health evaluator sees every decision — including SKIPs.
+    assert mock_nc.publish.call_count == 1
+    subject, payload_bytes = mock_nc.publish.call_args.args
+    assert subject == "cio.decision.audit.skip"
+    audit_payload = json.loads(payload_bytes.decode())
+    assert audit_payload["action"] == "skip"
+    assert audit_payload["authority_fallback_from"] == "execute"
 
     mock_vc.upsert.assert_called_once()
     payload = mock_vc.upsert.call_args.kwargs["payload"]
@@ -201,15 +210,21 @@ async def test_disabled_lifecycle_action_dispatches_safe_fallback():
         await router.route(_make_context(), _make_decision(ActionType.ADMIT))
 
     # Fallback publishes on cio.lifecycle.reject.<sid>, NOT cio.lifecycle.admit.<sid>.
-    mock_nc.publish.assert_called_once()
-    subject, payload_bytes = mock_nc.publish.call_args.args
-    assert subject == "cio.lifecycle.reject.strat_a"
+    # Plus the audit copy on cio.decision.audit.reject (#610 P7.1).
+    assert mock_nc.publish.call_count == 2
+    calls = {c.args[0]: c.args[1] for c in mock_nc.publish.call_args_list}
+    assert "cio.lifecycle.reject.strat_a" in calls
+    assert "cio.decision.audit.reject" in calls
 
-    payload = json.loads(payload_bytes.decode())
+    payload = json.loads(calls["cio.lifecycle.reject.strat_a"].decode())
     # The decision payload's `action` field is the original — we do not mutate
     # the DecisionResult on the wire; only the dispatch subject reflects the
     # fallback. (Audit-trail captures the swap via authority_fallback_from.)
     assert payload["action"] == "admit"
+
+    audit = json.loads(calls["cio.decision.audit.reject"].decode())
+    assert audit["action"] == "reject"
+    assert audit["authority_fallback_from"] == "admit"
 
     audit_payload = mock_vc.upsert.call_args.kwargs["payload"]
     assert audit_payload["action"] == "reject"
@@ -235,9 +250,11 @@ async def test_router_without_authority_store_preserves_behavior():
     with patch.dict(os.environ, {"DRY_RUN": "false"}):
         await router.route(_make_context(), _make_decision(ActionType.ADMIT))
 
-    mock_nc.publish.assert_called_once()
-    subject, _payload = mock_nc.publish.call_args.args
-    assert subject == "cio.lifecycle.admit.strat_a"
+    # Lifecycle publish + decision audit copy (#610 P7.1).
+    assert mock_nc.publish.call_count == 2
+    subjects = [c.args[0] for c in mock_nc.publish.call_args_list]
+    assert "cio.lifecycle.admit.strat_a" in subjects
+    assert "cio.decision.audit.admit" in subjects
 
 
 # ---------------------------------------------------------------------------
@@ -274,8 +291,15 @@ async def test_decision_id_propagates_in_every_outcome(
 
     if expect_publish:
         assert mock_nc.publish.called
-    else:
+    elif expect_pending:
+        # OPERATOR_APPROVAL_REQUIRED diverts before any dispatch (incl. audit).
         mock_nc.publish.assert_not_called()
+    else:
+        # DISABLED EXECUTE→SKIP: no dispatch publish, but the audit copy
+        # (#610 P7.1) IS published so the CIO health evaluator sees the
+        # SKIP. So the subject set must be exactly the audit copy.
+        subjects = [c.args[0] for c in mock_nc.publish.call_args_list]
+        assert subjects == ["cio.decision.audit.skip"]
 
     if expect_pending:
         pending = store.list_pending()

--- a/tests/unit/test_router_governance_actions.py
+++ b/tests/unit/test_router_governance_actions.py
@@ -82,11 +82,15 @@ async def test_governance_action_publishes_on_dedicated_subject(
     with patch.dict(os.environ, {"DRY_RUN": "false"}):
         await router.route(context, decision)
 
-    mock_nc.publish.assert_called_once()
-    subject, payload_bytes = mock_nc.publish.call_args.args
-    assert subject == f"{expected_subject_prefix}.{strategy_id}"
+    # Governance dispatch + decision audit copy (#610 P7.1).
+    assert mock_nc.publish.call_count == 2
+    calls = {c.args[0]: c.args[1] for c in mock_nc.publish.call_args_list}
+    governance_subject = f"{expected_subject_prefix}.{strategy_id}"
+    audit_subject = f"cio.decision.audit.{action.value}"
+    assert governance_subject in calls
+    assert audit_subject in calls
 
-    payload = json.loads(payload_bytes.decode())
+    payload = json.loads(calls[governance_subject].decode())
     assert payload["action"] == action.value
     assert payload["justification"] == "governance reasoning"
 

--- a/tests/unit/test_router_lifecycle_actions.py
+++ b/tests/unit/test_router_lifecycle_actions.py
@@ -99,11 +99,15 @@ async def test_lifecycle_action_publishes_on_dedicated_subject(action: ActionTyp
     with patch.dict(os.environ, {"DRY_RUN": "false"}):
         await router.route(context, decision)
 
-    mock_nc.publish.assert_called_once()
-    subject, payload_bytes = mock_nc.publish.call_args.args
-    assert subject == f"cio.lifecycle.{action.value}.{strategy_id}"
+    # Lifecycle dispatch + decision audit copy (#610 P7.1).
+    assert mock_nc.publish.call_count == 2
+    calls = {c.args[0]: c.args[1] for c in mock_nc.publish.call_args_list}
+    lifecycle_subject = f"cio.lifecycle.{action.value}.{strategy_id}"
+    audit_subject = f"cio.decision.audit.{action.value}"
+    assert lifecycle_subject in calls
+    assert audit_subject in calls
 
-    payload = json.loads(payload_bytes.decode())
+    payload = json.loads(calls[lifecycle_subject].decode())
     assert payload["action"] == action.value
     assert payload["justification"] == "lifecycle reasoning"
 

--- a/tests/unit/test_shadow_mode.py
+++ b/tests/unit/test_shadow_mode.py
@@ -116,8 +116,10 @@ async def test_output_router_shadow_mode():
     with patch.dict(os.environ, {"DRY_RUN": "false"}):
         await router.route(context, decision)
 
-        # Assertion: NATS publish SHOULD have been called (Twice for T-Junction)
-        assert mock_nc.publish.call_count == 2
+        # Assertion: NATS publish SHOULD have been called 3 times —
+        # legacy signal + modern trade.execute + decision audit copy
+        # (cio.decision.audit.execute added by #610 P7.1).
+        assert mock_nc.publish.call_count == 3
         mock_vc.upsert.assert_called_once()
         print(
             "✅ Verified: OutputRouter performed T-Junction NATS publish and Vector upsert in active mode."
@@ -199,6 +201,7 @@ async def test_output_router_defaults_to_active_mode_when_dry_run_unset(
     with caplog.at_level("INFO"):
         await router.route(context, decision)
 
-    assert mock_nc.publish.call_count == 2
+    # Legacy signal + modern trade.execute + decision audit copy (#610).
+    assert mock_nc.publish.call_count == 3
     mock_vc.upsert.assert_called_once()
     assert caplog.messages.count("T-Junction dispatch successful") == 1


### PR DESCRIPTION
## Summary
- Adds `CIOHealthEvaluator` that subscribes to its own decision audit copies + intent/signal cadence and emits `evaluator.cio.verdict` with hysteresis, closing Outcome 5's 8/8 evaluator-coverage gate.
- `OutputRouter` now publishes a decision audit copy on `cio.decision.audit.<action>` for every decision (including SKIP / BLOCK / DISABLED-fallback). This is also the Phase-2 substrate for the deferred per-action judgment grader.
- `OutcomeCorrelator` exposes a persistence hook today even though no P&L subject is wired in MVP, per the ticket's "Phase-2-ready substrate" AC.

## Issue
Closes PetroSa2/petrosa_k8s#610 (P7.1).
FR15 — partial RED → GREEN (full judgment grader explicitly deferred to Phase 2 per the ticket body).
Outcome 5 evaluator coverage now 8/8 once this ships.

## Verdict logic (sliding window, default 60s)
1. **Structural** — reasoning-context presence on recent decisions. Known SAFE_DEFAULTS fallback markers (`PARSE_FAILURE`, `SYSTEM_ERROR`, `CRITICAL_FAILURE_ENFORCEMENT`, `TIMEOUT_ENFORCEMENT`, `DETERMINISTIC_BYPASS`) count as "missing"; >50% missing flags unhealthy.
2. **Behavioral** — FAIL_SAFE / SKIP dominance over the window (>50%) flags the degraded-mode path being on (FR13 / NFR-R5).
3. **Behavioral** — silence on `signals.trading.>` while `cio.intent.trading.>` is active for ≥20s flags the receive-but-don't-produce failure mode.

Precedence: the more specific structural symptom wins when both fire.

Hysteresis: `stable_ticks_required=2` consecutive raw observations before flipping the externally-published verdict — avoids flapping when a window straddles a single anomalous decision.

## Test plan
- [x] AC (a) — missing reasoning context → unhealthy
- [x] AC (b) — sustained FAIL_SAFE dominance → unhealthy (degraded)
- [x] AC (c) — intents flowing but signals silent → unhealthy
- [x] Hysteresis delays verdict flip across both directions
- [x] Idle window → UNKNOWN
- [x] Fresh-burst silence-suppression
- [x] Publish payload truncation to 200 chars
- [x] OutcomeCorrelator persistence (and graceful failure)
- [x] Subscription lifecycle / stop()
- [x] Existing router tests updated for the new audit-copy publish (authority, governance, lifecycle, shadow-mode, NATS-to-NATS loop)

Pipeline: `make pipeline` clean (ruff, format, mypy on new module, pytest 214 passing, coverage 82.88% / new module 87%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)