### PR TITLE
feat: FR63 LLM spend tracker + ceiling-triggered fallback (petrosa-data-manager#170)

### DIFF
--- a/cio/apps/dashboard_api.py
+++ b/cio/apps/dashboard_api.py
@@ -85,6 +85,19 @@ async def get_decisions_recent(
     }
 
 
+@router.get("/llm-spend")
+async def get_llm_spend() -> dict:
+    """Current-period LLM spend bucketed by CIO decision type (FR63).
+
+    Returns the spend accumulated since midnight UTC, projected daily total,
+    per-day ceiling, and distance-to-ceiling so the operator dashboard SPA
+    can render the LlmSpendPane (AC1/AC2 of petrosa-data-manager#170).
+    """
+    from cio.core.spend_tracker import LlmSpendTracker
+
+    return LlmSpendTracker.instance().period_snapshot()
+
+
 @router.get("/evaluator/verdicts")
 async def get_evaluator_verdicts(
     request: Request,

--- a/cio/clients/llm_client.py
+++ b/cio/clients/llm_client.py
@@ -559,6 +559,16 @@ class LiteLLMClient(CIO_LLM_Client):
         except ImportError:
             pass
 
+        # FR63: record spend for ceiling tracking.
+        try:
+            from cio.core.spend_tracker import LlmSpendTracker
+
+            LlmSpendTracker.instance().record(
+                prompt_id, usage.prompt_tokens, usage.completion_tokens
+            )
+        except Exception:
+            pass
+
         return RawLLMResponse(
             prompt_id=prompt_id,
             content=content,

--- a/cio/core/orchestrator.py
+++ b/cio/core/orchestrator.py
@@ -4,6 +4,7 @@ import time
 
 from cio.clients.factory import ClientFactory
 from cio.core.engine import CodeEngine
+from cio.core.spend_tracker import LlmSpendTracker
 from cio.models import (
     SAFE_DECISION_RESULT,
     ActivationRecommendation,
@@ -45,6 +46,8 @@ class Orchestrator:
             logger.warning(
                 "⚠️ NURSE_USE_LLM_REASONING is disabled. CIO will operate in deterministic bypass mode."
             )
+        # FR63: track whether ceiling triggered the bypass so period-reset can restore it.
+        self._ceiling_triggered_bypass = False
 
     async def run(self, context: TriggerContext) -> DecisionResult:
         """
@@ -200,6 +203,9 @@ class Orchestrator:
                 context, code_result, regime, strategy
             )
 
+            # FR63 / AC4 — ceiling check after each LLM decision cycle.
+            await self._check_spend_ceiling(context.correlation_id)
+
             latency_ms = int((time.perf_counter() - start_time) * 1000)
             logger.info(
                 f"✅ REASONING LOOP COMPLETE | Action: {decision.action} | Latency: {latency_ms}ms",
@@ -219,3 +225,52 @@ class Orchestrator:
                 extra={"correlation_id": context.correlation_id},
             )
             return SAFE_DECISION_RESULT
+
+    async def _check_spend_ceiling(self, correlation_id: str) -> None:
+        """FR63 / AC4: check LLM spend ceiling; transition to deterministic bypass on breach.
+
+        On period roll (new UTC day), restore LLM reasoning if the ceiling previously
+        triggered the bypass (AC5 recovery path).
+        """
+        tracker = LlmSpendTracker.instance()
+        breached, total_cost, projected = tracker.check_ceiling()
+
+        if not breached and self._ceiling_triggered_bypass:
+            # New period: projected spend reset below ceiling — restore LLM mode.
+            self._ceiling_triggered_bypass = False
+            self.use_llm_reasoning = True
+            logger.info(
+                "FR63: New UTC period — LLM reasoning re-enabled after ceiling reset.",
+                extra={"total_cost_usd": total_cost, "correlation_id": correlation_id},
+            )
+            return
+
+        if breached and self.use_llm_reasoning:
+            # Transition to deterministic fallback for the rest of the period.
+            self.use_llm_reasoning = False
+            self._ceiling_triggered_bypass = True
+            logger.warning(
+                "FR63: LLM spend ceiling breached — switching to deterministic bypass (FR13).",
+                extra={
+                    "projected_daily_usd": projected,
+                    "ceiling_usd": tracker._current.ceiling_usd_per_day,
+                    "correlation_id": correlation_id,
+                },
+            )
+            try:
+                from cio.core.alerting.manager import AlertManager
+
+                await AlertManager.dispatch_critical_alert(
+                    "LLM daily spend ceiling breached — CIO switched to deterministic-fallback mode.",
+                    context={
+                        "alert_type": "RED",
+                        "correlation_id": correlation_id,
+                        "projected_daily_usd": projected,
+                        "ceiling_usd": tracker._current.ceiling_usd_per_day,
+                        "fr": "FR63+FR66",
+                    },
+                )
+            except Exception as alert_err:
+                logger.error(
+                    "FR63: Failed to dispatch ceiling-breach alert: %s", alert_err
+                )

--- a/cio/core/spend_tracker.py
+++ b/cio/core/spend_tracker.py
@@ -1,0 +1,170 @@
+"""LLM spend tracker — FR63 cost ceiling and operator visibility.
+
+Accumulates cost per prompt_id (decision_type) and UTC calendar day. On each
+call the orchestrator may check whether the projected daily spend has crossed
+the configurable per-day ceiling; when it does, `check_ceiling` returns
+`ceiling_breached=True` and the orchestrator transitions CIO to deterministic-
+fallback mode (FR13) and fires a critical alert (FR66).
+
+Recovery path: at the start of each new UTC day the tracker auto-resets its
+period accumulator. When `ceiling_breached` transitions from True→False (new
+period), the orchestrator re-enables `use_llm_reasoning=True`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+
+# ── Cost rates (per million tokens) ──────────────────────────────────────────
+# Defaults match Claude Haiku pricing. Override via env to match actual model.
+_INPUT_COST_PER_MILLION = float(os.getenv("LLM_COST_INPUT_PER_MILLION", "0.25"))
+_OUTPUT_COST_PER_MILLION = float(os.getenv("LLM_COST_OUTPUT_PER_MILLION", "1.25"))
+
+# Prompt-id → human-readable decision type label.
+DECISION_TYPE_LABELS: dict[str, str] = {
+    "PETROSA_PROMPT_REGIME_CLASSIFIER": "regime_classification",
+    "PETROSA_PROMPT_STRATEGY_ASSESSOR": "strategy_assessment",
+    "PETROSA_PROMPT_ACTION_CLASSIFIER": "action_classification",
+}
+
+
+def _tokens_to_usd(input_tokens: int, output_tokens: int) -> float:
+    return (
+        input_tokens / 1_000_000 * _INPUT_COST_PER_MILLION
+        + output_tokens / 1_000_000 * _OUTPUT_COST_PER_MILLION
+    )
+
+
+@dataclass
+class BucketAccumulator:
+    decision_type: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    call_count: int = 0
+
+    @property
+    def cost_usd(self) -> float:
+        return _tokens_to_usd(self.input_tokens, self.output_tokens)
+
+
+@dataclass
+class PeriodSpend:
+    period_date: date
+    buckets: dict[str, BucketAccumulator] = field(default_factory=dict)
+    ceiling_usd_per_day: float = 5.0
+
+    @property
+    def total_cost_usd(self) -> float:
+        return sum(b.cost_usd for b in self.buckets.values())
+
+    @property
+    def total_input_tokens(self) -> int:
+        return sum(b.input_tokens for b in self.buckets.values())
+
+    @property
+    def total_output_tokens(self) -> int:
+        return sum(b.output_tokens for b in self.buckets.values())
+
+    def record(self, prompt_id: str, input_tokens: int, output_tokens: int) -> None:
+        label = DECISION_TYPE_LABELS.get(prompt_id, prompt_id)
+        if label not in self.buckets:
+            self.buckets[label] = BucketAccumulator(decision_type=label)
+        b = self.buckets[label]
+        b.input_tokens += input_tokens
+        b.output_tokens += output_tokens
+        b.call_count += 1
+
+    def projected_daily_usd(self) -> float:
+        """Linearly project current spend to a full UTC day based on elapsed time."""
+        now = datetime.now(UTC)
+        period_start = datetime(now.year, now.month, now.day, tzinfo=UTC)
+        elapsed_seconds = (now - period_start).total_seconds()
+        if elapsed_seconds < 60:
+            return self.total_cost_usd
+        daily_seconds = 86_400.0
+        return self.total_cost_usd * (daily_seconds / elapsed_seconds)
+
+    def ceiling_breached(self) -> bool:
+        return self.projected_daily_usd() >= self.ceiling_usd_per_day
+
+
+class LlmSpendTracker:
+    """Thread-safe (asyncio-safe) singleton for intra-process spend tracking."""
+
+    _instance: LlmSpendTracker | None = None
+
+    @classmethod
+    def instance(cls) -> LlmSpendTracker:
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def __init__(self) -> None:
+        self._current: PeriodSpend = self._new_period()
+
+    def _new_period(self) -> PeriodSpend:
+        ceiling = float(os.getenv("LLM_SPEND_CEILING_USD_PER_DAY", "5.0"))
+        return PeriodSpend(
+            period_date=datetime.now(UTC).date(),
+            ceiling_usd_per_day=ceiling,
+        )
+
+    def _maybe_roll_period(self) -> bool:
+        """Roll to a new period if the UTC date has changed. Returns True on roll."""
+        today = datetime.now(UTC).date()
+        if today != self._current.period_date:
+            self._current = self._new_period()
+            return True
+        return False
+
+    def record(self, prompt_id: str, input_tokens: int, output_tokens: int) -> None:
+        self._maybe_roll_period()
+        self._current.record(prompt_id, input_tokens, output_tokens)
+
+    def check_ceiling(self) -> tuple[bool, float, float]:
+        """Return (ceiling_breached, total_cost_usd, projected_daily_usd)."""
+        rolled = self._maybe_roll_period()
+        if rolled:
+            return False, 0.0, 0.0
+        period = self._current
+        return (
+            period.ceiling_breached(),
+            period.total_cost_usd,
+            period.projected_daily_usd(),
+        )
+
+    def period_snapshot(self) -> dict:
+        """Serialisable snapshot for the dashboard API."""
+        self._maybe_roll_period()
+        p = self._current
+        return {
+            "period_date": p.period_date.isoformat(),
+            "ceiling_usd_per_day": p.ceiling_usd_per_day,
+            "total_cost_usd": round(p.total_cost_usd, 6),
+            "projected_daily_usd": round(p.projected_daily_usd(), 6),
+            "ceiling_breached": p.ceiling_breached(),
+            "distance_to_ceiling_usd": round(
+                max(0.0, p.ceiling_usd_per_day - p.projected_daily_usd()), 6
+            ),
+            "buckets": [
+                {
+                    "decision_type": b.decision_type,
+                    "cost_usd": round(b.cost_usd, 6),
+                    "input_tokens": b.input_tokens,
+                    "output_tokens": b.output_tokens,
+                    "call_count": b.call_count,
+                }
+                for b in sorted(
+                    p.buckets.values(), key=lambda x: x.cost_usd, reverse=True
+                )
+            ],
+        }
+
+    def reset_for_test(self, ceiling_usd: float = 5.0) -> None:
+        """Only for tests — resets the singleton's period state."""
+        self._current = PeriodSpend(
+            period_date=datetime.now(UTC).date(),
+            ceiling_usd_per_day=ceiling_usd,
+        )

--- a/tests/unit/test_spend_tracker.py
+++ b/tests/unit/test_spend_tracker.py
@@ -1,0 +1,168 @@
+"""Unit tests for LlmSpendTracker (FR63 — petrosa-data-manager#170)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cio.apps.dashboard_api import router as dashboard_router
+from cio.core.spend_tracker import (
+    DECISION_TYPE_LABELS,
+    LlmSpendTracker,
+    PeriodSpend,
+    _tokens_to_usd,
+)
+
+# ---------------------------------------------------------------------------
+# Cost helpers
+# ---------------------------------------------------------------------------
+
+
+def test_tokens_to_usd_zero():
+    assert _tokens_to_usd(0, 0) == 0.0
+
+
+def test_tokens_to_usd_only_input():
+    # 1M input tokens @ default $0.25/1M = $0.25
+    cost = _tokens_to_usd(1_000_000, 0)
+    assert abs(cost - 0.25) < 1e-9
+
+
+def test_tokens_to_usd_only_output():
+    # 1M output tokens @ default $1.25/1M = $1.25
+    cost = _tokens_to_usd(0, 1_000_000)
+    assert abs(cost - 1.25) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# PeriodSpend
+# ---------------------------------------------------------------------------
+
+
+def test_period_spend_record_and_bucket():
+    p = PeriodSpend(period_date=date.today())
+    p.record("PETROSA_PROMPT_REGIME_CLASSIFIER", 1000, 500)
+    label = DECISION_TYPE_LABELS["PETROSA_PROMPT_REGIME_CLASSIFIER"]
+    assert label in p.buckets
+    assert p.buckets[label].input_tokens == 1000
+    assert p.buckets[label].output_tokens == 500
+    assert p.buckets[label].call_count == 1
+
+
+def test_period_spend_unknown_prompt_id_falls_back_to_raw_id():
+    p = PeriodSpend(period_date=date.today())
+    p.record("UNKNOWN_PROMPT", 100, 50)
+    assert "UNKNOWN_PROMPT" in p.buckets
+
+
+def test_period_spend_ceiling_not_breached_at_zero():
+    p = PeriodSpend(period_date=date.today(), ceiling_usd_per_day=5.0)
+    assert not p.ceiling_breached()
+
+
+def test_period_spend_ceiling_breached_when_projected_exceeds():
+    p = PeriodSpend(period_date=date.today(), ceiling_usd_per_day=0.0)
+    p.record("PETROSA_PROMPT_ACTION_CLASSIFIER", 1000, 100)
+    assert p.ceiling_breached()
+
+
+# ---------------------------------------------------------------------------
+# LlmSpendTracker singleton
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_tracker():
+    LlmSpendTracker.instance().reset_for_test()
+    yield
+    LlmSpendTracker.instance().reset_for_test()
+
+
+def test_tracker_record_accumulates():
+    tracker = LlmSpendTracker.instance()
+    tracker.record("PETROSA_PROMPT_REGIME_CLASSIFIER", 1000, 200)
+    tracker.record("PETROSA_PROMPT_REGIME_CLASSIFIER", 500, 100)
+    snap = tracker.period_snapshot()
+    # Only one bucket
+    assert len(snap["buckets"]) == 1
+    b = snap["buckets"][0]
+    assert b["input_tokens"] == 1500
+    assert b["output_tokens"] == 300
+    assert b["call_count"] == 2
+
+
+def test_tracker_multiple_decision_types():
+    tracker = LlmSpendTracker.instance()
+    tracker.record("PETROSA_PROMPT_REGIME_CLASSIFIER", 1000, 100)
+    tracker.record("PETROSA_PROMPT_STRATEGY_ASSESSOR", 800, 200)
+    tracker.record("PETROSA_PROMPT_ACTION_CLASSIFIER", 600, 150)
+    snap = tracker.period_snapshot()
+    assert len(snap["buckets"]) == 3
+
+
+def test_tracker_check_ceiling_no_breach():
+    tracker = LlmSpendTracker.instance()
+    tracker.record("PETROSA_PROMPT_ACTION_CLASSIFIER", 100, 50)
+    breached, total, projected = tracker.check_ceiling()
+    assert not breached
+    assert total > 0
+
+
+def test_tracker_check_ceiling_breached_on_zero_ceiling():
+    tracker = LlmSpendTracker.instance()
+    tracker.reset_for_test(ceiling_usd=0.0)
+    tracker.record("PETROSA_PROMPT_ACTION_CLASSIFIER", 100_000, 50_000)
+    breached, total, projected = tracker.check_ceiling()
+    assert breached
+
+
+def test_tracker_snapshot_keys():
+    snap = LlmSpendTracker.instance().period_snapshot()
+    expected = {
+        "period_date",
+        "ceiling_usd_per_day",
+        "total_cost_usd",
+        "projected_daily_usd",
+        "ceiling_breached",
+        "distance_to_ceiling_usd",
+        "buckets",
+    }
+    assert expected.issubset(snap.keys())
+
+
+# ---------------------------------------------------------------------------
+# /api/dashboard/llm-spend route
+# ---------------------------------------------------------------------------
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(dashboard_router)
+    return app
+
+
+@pytest.fixture
+def client():
+    return TestClient(_make_app())
+
+
+def test_llm_spend_route_ok(client):
+    resp = client.get("/api/dashboard/llm-spend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "ceiling_usd_per_day" in data
+    assert "total_cost_usd" in data
+    assert "buckets" in data
+
+
+def test_llm_spend_route_reflects_recorded_spend(client):
+    LlmSpendTracker.instance().record("PETROSA_PROMPT_REGIME_CLASSIFIER", 10_000, 5_000)
+    resp = client.get("/api/dashboard/llm-spend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_cost_usd"] > 0
+    assert len(data["buckets"]) == 1
+    assert data["buckets"][0]["decision_type"] == "regime_classification"

--- a/tests/unit/test_spend_tracker.py
+++ b/tests/unit/test_spend_tracker.py
@@ -166,3 +166,106 @@ def test_llm_spend_route_reflects_recorded_spend(client):
     assert data["total_cost_usd"] > 0
     assert len(data["buckets"]) == 1
     assert data["buckets"][0]["decision_type"] == "regime_classification"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator._check_spend_ceiling — FR63 / AC4 + AC5 integration
+# ---------------------------------------------------------------------------
+
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+from cio.core.orchestrator import Orchestrator  # noqa: E402
+
+
+def _build_orchestrator() -> Orchestrator:
+    """Construct an Orchestrator with a stub LLM client so the personas don't
+    touch real settings / network — we only exercise _check_spend_ceiling.
+    """
+    with patch("cio.core.orchestrator.ClientFactory.create", return_value=MagicMock()):
+        return Orchestrator()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_check_spend_ceiling_breach_switches_to_bypass():
+    """AC4: ceiling breach → use_llm_reasoning=False + alert dispatched."""
+    orch = _build_orchestrator()
+    assert orch.use_llm_reasoning is True
+
+    with (
+        patch.object(
+            LlmSpendTracker.instance(),
+            "check_ceiling",
+            return_value=(True, 12.5, 25.0),
+        ),
+        patch(
+            "cio.core.alerting.manager.AlertManager.dispatch_critical_alert",
+            new_callable=AsyncMock,
+        ) as mock_alert,
+    ):
+        await orch._check_spend_ceiling(correlation_id="cid-1")
+
+    assert orch.use_llm_reasoning is False
+    assert orch._ceiling_triggered_bypass is True
+    mock_alert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_check_spend_ceiling_recovery_restores_llm_mode():
+    """AC5: on period roll (not breached) after the ceiling triggered the bypass,
+    LLM reasoning is restored.
+    """
+    orch = _build_orchestrator()
+    # Simulate the prior breach: bypass-active state.
+    orch.use_llm_reasoning = False
+    orch._ceiling_triggered_bypass = True
+
+    with patch.object(
+        LlmSpendTracker.instance(),
+        "check_ceiling",
+        return_value=(False, 0.0, 0.0),
+    ):
+        await orch._check_spend_ceiling(correlation_id="cid-recover")
+
+    assert orch.use_llm_reasoning is True
+    assert orch._ceiling_triggered_bypass is False
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_check_spend_ceiling_alert_failure_does_not_propagate():
+    """AC4 robustness: an AlertManager exception must not stop the bypass switch."""
+    orch = _build_orchestrator()
+
+    with (
+        patch.object(
+            LlmSpendTracker.instance(),
+            "check_ceiling",
+            return_value=(True, 50.0, 100.0),
+        ),
+        patch(
+            "cio.core.alerting.manager.AlertManager.dispatch_critical_alert",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("alert backend down"),
+        ),
+    ):
+        # Must not raise even though the alert dispatch fails.
+        await orch._check_spend_ceiling(correlation_id="cid-alert-fail")
+
+    assert orch.use_llm_reasoning is False
+    assert orch._ceiling_triggered_bypass is True
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_check_spend_ceiling_no_breach_when_already_llm():
+    """No-op path: ceiling not breached and LLM mode is already on."""
+    orch = _build_orchestrator()
+    assert orch.use_llm_reasoning is True
+
+    with patch.object(
+        LlmSpendTracker.instance(),
+        "check_ceiling",
+        return_value=(False, 0.5, 1.0),
+    ):
+        await orch._check_spend_ceiling(correlation_id="cid-noop")
+
+    assert orch.use_llm_reasoning is True
+    assert orch._ceiling_triggered_bypass is False


### PR DESCRIPTION
## Summary

- Adds `LlmSpendTracker` singleton (`cio/core/spend_tracker.py`) accumulating token cost per decision type and UTC day
- Wires spend recording into `LiteLLMClient._process_response()` after each successful LLM call
- Exposes `GET /api/dashboard/llm-spend` on the CIO dashboard API (AC1 of petrosa-data-manager#170)
- Orchestrator ceiling check: on breach → `AlertManager.dispatch_critical_alert()` (FR66) + disables `use_llm_reasoning` (FR13 deterministic bypass, AC4)
- Period roll at UTC midnight auto-restores LLM mode (AC5 recovery path)

## Linked issue
Implements AC1, AC4, AC5 of PetroSa2/petrosa-data-manager#170.
Frontend component (AC2), operator-config ceiling (AC3), and integration test (AC6) are in the companion PR on petrosa-data-manager.

## Test plan
- [x] 14 new unit tests in `tests/unit/test_spend_tracker.py` covering cost helpers, period accumulation, ceiling breach, and the `/api/dashboard/llm-spend` route
- [x] Full suite: 249/249 pass

## ⚠️ Dashboard image CI gap
Reminder: `yurisa2/petrosa-dashboard` has no auto-build pipeline (#657). After merging the companion data-manager PR, a manual `docker build` is required to pick up the new `LlmSpendPane.tsx` component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)