### PR TITLE
feat: 126 - migrate cio prometheus_client metrics to OTel SDK

### DIFF
--- a/cio/clients/llm_client.py
+++ b/cio/clients/llm_client.py
@@ -159,9 +159,9 @@ class CIO_LLM_Client(ABC):
             try:
                 from cio.core.metrics import LLM_FALLBACK_SKIPS
 
-                LLM_FALLBACK_SKIPS.labels(
-                    prompt_id=prompt_id, reason="transport_error"
-                ).inc()
+                LLM_FALLBACK_SKIPS.add(
+                    1, {"prompt_id": prompt_id, "reason": "transport_error"}
+                )
             except ImportError:
                 pass
             logger.error(
@@ -195,9 +195,9 @@ class CIO_LLM_Client(ABC):
             try:
                 from cio.core.metrics import LLM_VALIDATION_FAILURES
 
-                LLM_VALIDATION_FAILURES.labels(
-                    prompt_id=prompt_id, model=raw.model
-                ).inc()
+                LLM_VALIDATION_FAILURES.add(
+                    1, {"prompt_id": prompt_id, "model": raw.model}
+                )
             except ImportError:
                 pass
 
@@ -232,9 +232,9 @@ class CIO_LLM_Client(ABC):
                     try:
                         from cio.core.metrics import LLM_VALIDATION_FAILURES
 
-                        LLM_VALIDATION_FAILURES.labels(
-                            prompt_id=prompt_id, model=fallback_raw.model
-                        ).inc()
+                        LLM_VALIDATION_FAILURES.add(
+                            1, {"prompt_id": prompt_id, "model": fallback_raw.model}
+                        )
                     except ImportError:
                         pass
                     logger.warning(
@@ -249,9 +249,9 @@ class CIO_LLM_Client(ABC):
             try:
                 from cio.core.metrics import LLM_FALLBACK_SKIPS
 
-                LLM_FALLBACK_SKIPS.labels(
-                    prompt_id=prompt_id, reason="validation_error"
-                ).inc()
+                LLM_FALLBACK_SKIPS.add(
+                    1, {"prompt_id": prompt_id, "reason": "validation_error"}
+                )
             except ImportError:
                 pass
             logger.error(
@@ -527,19 +527,35 @@ class LiteLLMClient(CIO_LLM_Client):
         try:
             from cio.core.metrics import LLM_LATENCY, LLM_TOKENS
 
-            LLM_LATENCY.labels(prompt_id=prompt_id, model=response.model).observe(
-                latency_ms / 1000.0
+            LLM_LATENCY.record(
+                latency_ms / 1000.0,
+                {"prompt_id": prompt_id, "model": response.model},
             )
-            LLM_TOKENS.labels(
-                prompt_id=prompt_id, model=response.model, token_type="input"
-            ).inc(usage.prompt_tokens)
-            LLM_TOKENS.labels(
-                prompt_id=prompt_id, model=response.model, token_type="output"
-            ).inc(usage.completion_tokens)
+            LLM_TOKENS.add(
+                usage.prompt_tokens,
+                {
+                    "prompt_id": prompt_id,
+                    "model": response.model,
+                    "token_type": "input",
+                },
+            )
+            LLM_TOKENS.add(
+                usage.completion_tokens,
+                {
+                    "prompt_id": prompt_id,
+                    "model": response.model,
+                    "token_type": "output",
+                },
+            )
             if cached_tokens > 0:
-                LLM_TOKENS.labels(
-                    prompt_id=prompt_id, model=response.model, token_type="cached"
-                ).inc(cached_tokens)
+                LLM_TOKENS.add(
+                    cached_tokens,
+                    {
+                        "prompt_id": prompt_id,
+                        "model": response.model,
+                        "token_type": "cached",
+                    },
+                )
         except ImportError:
             pass
 
@@ -673,18 +689,22 @@ class MockLLMClient(CIO_LLM_Client):
             from cio.core.metrics import LLM_LATENCY, LLM_TOKENS
 
             model = "mock-claude-3-haiku"
-            LLM_LATENCY.labels(prompt_id=prompt_id, model=model).observe(
-                latency_ms / 1000.0
+            LLM_LATENCY.record(
+                latency_ms / 1000.0,
+                {"prompt_id": prompt_id, "model": model},
             )
-            LLM_TOKENS.labels(prompt_id=prompt_id, model=model, token_type="input").inc(
-                150
+            LLM_TOKENS.add(
+                150,
+                {"prompt_id": prompt_id, "model": model, "token_type": "input"},
             )
-            LLM_TOKENS.labels(
-                prompt_id=prompt_id, model=model, token_type="output"
-            ).inc(50)
-            LLM_TOKENS.labels(
-                prompt_id=prompt_id, model=model, token_type="cached"
-            ).inc(240)
+            LLM_TOKENS.add(
+                50,
+                {"prompt_id": prompt_id, "model": model, "token_type": "output"},
+            )
+            LLM_TOKENS.add(
+                240,
+                {"prompt_id": prompt_id, "model": model, "token_type": "cached"},
+            )
         except ImportError:
             pass
 

--- a/cio/core/metrics.py
+++ b/cio/core/metrics.py
@@ -1,32 +1,32 @@
-from prometheus_client import Counter, Histogram
+from opentelemetry import metrics
+
+meter = metrics.get_meter("cio")
 
 # LLM Performance Metrics
-LLM_LATENCY = Histogram(
-    "cio_llm_latency_seconds", "Latency of LLM calls in seconds", ["prompt_id", "model"]
+LLM_LATENCY = meter.create_histogram(
+    "cio_llm_latency_seconds",
+    description="Latency of LLM calls in seconds",
+    unit="s",
 )
 
-LLM_TOKENS = Counter(
+LLM_TOKENS = meter.create_counter(
     "cio_llm_tokens_total",
-    "Total number of tokens used",
-    ["prompt_id", "model", "token_type"],
+    description="Total number of tokens used",
 )
 
 # CIO Decision Metrics
-DECISION_ACTIONS = Counter(
+DECISION_ACTIONS = meter.create_counter(
     "cio_decision_actions_total",
-    "Total number of final decisions by action type",
-    ["action_type", "strategy_id"],
+    description="Total number of final decisions by action type",
 )
 
 # LLM Validation Failures
-LLM_VALIDATION_FAILURES = Counter(
+LLM_VALIDATION_FAILURES = meter.create_counter(
     "cio_llm_validation_failures_total",
-    "Total number of LLM response schema validation failures",
-    ["prompt_id", "model"],
+    description="Total number of LLM response schema validation failures",
 )
 
-LLM_FALLBACK_SKIPS = Counter(
+LLM_FALLBACK_SKIPS = meter.create_counter(
     "cio_llm_fallback_skips_total",
-    "Total SAFE_DEFAULT fallbacks that force SKIP-like behavior",
-    ["prompt_id", "reason"],
+    description="Total SAFE_DEFAULT fallbacks that force SKIP-like behavior",
 )

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -113,7 +113,9 @@ class OutputRouter:
         # 0. Record Metrics
         from cio.core.metrics import DECISION_ACTIONS
 
-        DECISION_ACTIONS.labels(action_type=action.value, strategy_id=strategy_id).inc()
+        DECISION_ACTIONS.add(
+            1, {"action_type": action.value, "strategy_id": strategy_id}
+        )
 
         # Set OTel decision context attributes on the current span
         try:

--- a/cio/main.py
+++ b/cio/main.py
@@ -101,13 +101,6 @@ async def readiness():
 
 
 async def main():
-    # 0. Start Metrics Server (Epic 5)
-    import prometheus_client
-
-    prometheus_port = int(os.getenv("METRICS_PORT", "9090"))
-    prometheus_client.start_http_server(prometheus_port)
-    logger.info(f"Prometheus metrics server started on port {prometheus_port}")
-
     # 1. Setup OpenTelemetry
     if (
         os.getenv("ENABLE_OTEL", "true").lower() in ("true", "1", "yes")

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,10 +21,6 @@ opentelemetry-sdk>=1.22.0
 
 # Unified OpenTelemetry package for Petrosa services
 petrosa-otel[all]>=1.0.6
-prometheus-client>=0.19.0
-
-# Logging and observability
-prometheus-client>=0.19.0
 
 # Validation and configuration
 pydantic>=2.5.0

--- a/tests/unit/test_llm_client.py
+++ b/tests/unit/test_llm_client.py
@@ -120,10 +120,10 @@ async def test_safe_default_emits_parse_failure_skip_metric_and_log(caplog):
         )
 
     assert result == SAFE_DEFAULTS["PETROSA_PROMPT_ACTION_CLASSIFIER"]
-    mock_counter.labels.assert_called_with(
-        prompt_id="PETROSA_PROMPT_ACTION_CLASSIFIER", reason="validation_error"
+    mock_counter.add.assert_called_once_with(
+        1,
+        {"prompt_id": "PETROSA_PROMPT_ACTION_CLASSIFIER", "reason": "validation_error"},
     )
-    mock_counter.labels.return_value.inc.assert_called_once()
     assert "LLM_PARSE_FAILURE_SKIP" in caplog.text
 
 
@@ -418,10 +418,10 @@ async def test_complete_with_schema_transport_error_emits_fallback_skip(caplog):
         )
 
     assert result == SAFE_DEFAULTS["PETROSA_PROMPT_ACTION_CLASSIFIER"]
-    mock_counter.labels.assert_called_with(
-        prompt_id="PETROSA_PROMPT_ACTION_CLASSIFIER", reason="transport_error"
+    mock_counter.add.assert_called_once_with(
+        1,
+        {"prompt_id": "PETROSA_PROMPT_ACTION_CLASSIFIER", "reason": "transport_error"},
     )
-    mock_counter.labels.return_value.inc.assert_called_once()
     assert "LLM_PARSE_FAILURE_SKIP" in caplog.text
 
 
@@ -595,8 +595,8 @@ def test_process_response_records_cached_prompt_tokens():
         out = client._process_response("pid", response, 100)
 
     assert out.cached_tokens == 7
-    lat.labels.return_value.observe.assert_called_once()
-    assert tok.labels.return_value.inc.call_count >= 3
+    lat.record.assert_called_once()
+    assert tok.add.call_count >= 3
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -38,7 +38,6 @@ async def test_nats_subscription_with_wildcard():
         patch("cio.main.OutputRouter") as MockOutputRouter,
         patch("cio.main.HeartbeatResponder") as MockHeartbeatResponder,
         patch("cio.main.HeartbeatPublisher") as MockHeartbeatPublisher,
-        patch("prometheus_client.start_http_server"),
     ):
         mock_nats_listener = MockNATSListener.return_value
         mock_nats_listener.start = AsyncMock()


### PR DESCRIPTION
## Summary

Implements `PetroSa2/petrosa-cio#126` — full migration of CIO's five custom metric instruments from `prometheus_client` (pull/scrape) to OTel SDK instruments shipped through the already-configured OTLP push pipeline, so the previously-empty OTLP app-metric stream for CIO carries real data in Grafana.

- **`cio/core/metrics.py`** — replaced `prometheus_client.{Counter,Histogram}` with `opentelemetry.metrics.get_meter("cio")` instruments. **All five metric names preserved exactly**: `cio_llm_latency_seconds`, `cio_llm_tokens_total`, `cio_decision_actions_total`, `cio_llm_validation_failures_total`, `cio_llm_fallback_skips_total`.
- **`cio/clients/llm_client.py`** — updated all 8 call sites from `.labels(...).inc()/.observe()` to OTel `.add(n, {attrs})` / `.record(val, {attrs})`.
- **`cio/core/router.py`** — `DECISION_ACTIONS.labels(...).inc()` → `DECISION_ACTIONS.add(1, {...})`.
- **`cio/main.py`** — removed the `prometheus_client.start_http_server()` scrape-server block (OTLP push replaces it).
- **`requirements.txt`** — removed `prometheus-client` (verified no remaining source callers).
- **tests** — removed the `prometheus_client.start_http_server` mock in `test_main.py`; updated `test_llm_client.py` assertions from the prometheus `.labels().inc()/.observe()` mock API to the OTel `.add()/.record()` API.

## Acceptance criteria

- ✅ `cio/core/metrics.py` no longer imports `prometheus_client`; all 5 instruments via `get_meter("cio")`.
- ✅ `prometheus_client.start_http_server()` removed from `cio/main.py`.
- ✅ `prometheus-client` removed from `requirements.txt` (no remaining callers — verified via repo-wide grep).
- ✅ All 5 metric names preserved exactly.
- ✅ All call sites in `llm_client.py` and `router.py` updated to the OTel instrument API.
- ✅ `prometheus_client.start_http_server` mock removed from `test_main.py`; suite passes.
- ✅ CI passes — full suite **235 passed**, coverage **82.91%** (threshold 40%); `ruff check .` clean. `mypy` is non-blocking in CI; this change introduces no new mypy findings (pre-existing errors in personas/orchestrator/enforcer are untouched).
- ⏳ Smoke check (post-deploy): confirm all 5 `cio_*` series appear in Grafana Alloy/Cloud — requires deploy, cannot be verified in CI.

## API mapping applied

- `Counter(...).labels(k=v).inc(n)` → `counter.add(n, {"k": v})`
- `Histogram(...).labels(k=v).observe(val)` → `histogram.record(val, {"k": v})`

## Test plan

- [x] `ruff check .` — clean
- [x] full `pytest tests/` — 235 passed, coverage 82.91%
- [x] verified no remaining `prometheus` references in source or requirements
- [ ] post-deploy: 5 `cio_*` metrics visible in Grafana with recent data points

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
