### PR TITLE
feat: CIO refuses intents against stale characterizations (#130)

### DIFF
--- a/cio/apps/dashboard_api.py
+++ b/cio/apps/dashboard_api.py
@@ -79,6 +79,9 @@ async def get_decisions_recent(
                 "reasoning_trace": r.reasoning_trace,
                 "confidence": r.confidence,
                 "timestamp": r.timestamp.isoformat(),
+                # FR53 / P3.4 (#130): refusal taxonomy + revision drift visibility.
+                "rejection_source": r.rejection_source,
+                "strategy_revision_id": r.strategy_revision_id,
             }
             for r in records
         ],

--- a/cio/core/characterization_stale_gate.py
+++ b/cio/core/characterization_stale_gate.py
@@ -1,0 +1,112 @@
+"""Stale-characterization refusal gate (FR53 / P3.4 — petrosa-cio#130).
+
+The CIO refuses any intent whose `strategy_revision_id` does not match a
+persisted `Characterization` for the same `strategy_id`. The check is a
+single HTTP GET against the data-manager endpoint introduced in
+`petrosa-data-manager#179` (`GET /api/v1/characterizations?strategy_id=…
+&strategy_revision_id=…`):
+
+  * **200**  ⇒  a characterization exists for the exact revision → not stale.
+  * **404**  ⇒  no characterization for that revision → **stale**, refuse.
+  * Any other outcome (timeout, 5xx, connection error) is treated as
+    **not stale** so a data-manager outage does not silently block every
+    intent (fail-open). The outage is logged at WARNING for ops visibility.
+
+Design notes
+------------
+* The check is intentionally narrow — it does NOT recompute hashes, mutate
+  the characterization, or attempt to cache. The producer-side hash
+  canonicalization is already byte-stable with the consumer (data-manager's
+  `compute_inputs_hash`), so a string compare against the `404` signal is
+  sufficient.
+* `strategy_revision_id` is the only required input beyond `strategy_id`.
+  If the intent does not carry one (legacy producer pre-P3.4), the gate
+  returns `False` (not stale) — refusing every legacy intent would be a
+  hostile rollout.
+* The gate is `async` and uses a short timeout so it does not lengthen
+  the cold path beyond its existing SLO.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Final
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DATA_MANAGER_URL_ENV: Final[str] = "DATA_MANAGER_URL"
+DEFAULT_DATA_MANAGER_URL: Final[str] = "http://petrosa-data-manager:8000"
+DEFAULT_TIMEOUT_S: Final[float] = 2.0
+
+
+def _base_url() -> str:
+    return os.getenv(DEFAULT_DATA_MANAGER_URL_ENV, DEFAULT_DATA_MANAGER_URL).rstrip("/")
+
+
+async def is_characterization_stale(
+    *,
+    strategy_id: str,
+    strategy_revision_id: str | None,
+    base_url: str | None = None,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    client: httpx.AsyncClient | None = None,
+) -> bool:
+    """Return True iff data-manager has no characterization for the (strategy,
+    revision) pair — the operator-visible "stale, refuse" signal (FR53 / AC3).
+
+    A missing or empty ``strategy_revision_id`` is **not** treated as stale —
+    pre-P3.4 producers continue to pass through.
+    """
+    if not strategy_revision_id:
+        return False
+
+    url = (base_url or _base_url()) + "/api/v1/characterizations"
+    params = {
+        "strategy_id": strategy_id,
+        "strategy_revision_id": strategy_revision_id,
+    }
+
+    async def _do(client_: httpx.AsyncClient) -> bool:
+        try:
+            resp = await client_.get(url, params=params, timeout=timeout_s)
+        except (httpx.RequestError, httpx.TimeoutException) as exc:
+            logger.warning(
+                "stale-characterization gate: data-manager unreachable — failing open",
+                extra={
+                    "strategy_id": strategy_id,
+                    "strategy_revision_id": strategy_revision_id,
+                    "url": url,
+                    "error": str(exc),
+                },
+            )
+            return False
+        if resp.status_code == 404:
+            logger.info(
+                "stale-characterization gate: revision not found → refusing intent",
+                extra={
+                    "strategy_id": strategy_id,
+                    "strategy_revision_id": strategy_revision_id,
+                },
+            )
+            return True
+        if resp.status_code == 200:
+            return False
+        # Any other status: log and fail open so the operator can investigate
+        # without losing every intent in the meantime.
+        logger.warning(
+            "stale-characterization gate: unexpected status — failing open",
+            extra={
+                "strategy_id": strategy_id,
+                "strategy_revision_id": strategy_revision_id,
+                "status_code": resp.status_code,
+            },
+        )
+        return False
+
+    if client is not None:
+        return await _do(client)
+    async with httpx.AsyncClient() as owned:
+        return await _do(owned)

--- a/cio/core/decision_store.py
+++ b/cio/core/decision_store.py
@@ -23,6 +23,15 @@ class DecisionRecord:
     confidence: float
     decision_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     timestamp: datetime = field(default_factory=lambda: datetime.now(_UTC))
+    # FR53 / P3.4 (#130) — structured refusal source. None on accepts and on
+    # refusals that are not categorized (legacy / "OTHER"); set to e.g.
+    # "stale_characterization" by the CIO refusal gate so the operator
+    # dashboard can group + filter without grepping `reasoning_trace`.
+    rejection_source: str | None = None
+    # FR53 / P3.4 (#130) — content-addressable revision the intent claimed.
+    # Surfaced so the operator can compare against what the most-recent
+    # characterization is bound to (i.e. spot drift at a glance).
+    strategy_revision_id: str | None = None
 
 
 class DecisionStore:

--- a/cio/core/orchestrator.py
+++ b/cio/core/orchestrator.py
@@ -3,10 +3,12 @@ import os
 import time
 
 from cio.clients.factory import ClientFactory
+from cio.core.characterization_stale_gate import is_characterization_stale
 from cio.core.engine import CodeEngine
 from cio.core.spend_tracker import LlmSpendTracker
 from cio.models import (
     SAFE_DECISION_RESULT,
+    ActionType,
     ActivationRecommendation,
     ConfidenceLevel,
     DecisionResult,
@@ -16,8 +18,10 @@ from cio.models import (
     RegimeResult,
     StrategyResult,
     TriggerContext,
+    TriggerType,
     VolatilityLevel,
 )
+from cio.models.enums import RejectionSource
 from cio.personas.action_classifier import ActionClassifier
 from cio.personas.regime_analyst import RegimeAnalyst
 from cio.personas.strategy_assessor import StrategyAssessor
@@ -67,6 +71,56 @@ class Orchestrator:
                 "use_llm_reasoning": self.use_llm_reasoning,
             },
         )
+
+        # FR53 / P3.4 (#130) — stale-characterization refusal gate. Only runs
+        # on trade-intent triggers that actually carry a revision id; legacy
+        # intents (no revision id) and non-intent triggers pass through.
+        if (
+            context.trigger_type == TriggerType.TRADE_INTENT
+            and context.strategy_revision_id
+        ):
+            try:
+                stale = await is_characterization_stale(
+                    strategy_id=context.strategy_id,
+                    strategy_revision_id=context.strategy_revision_id,
+                )
+            except Exception as gate_exc:  # noqa: BLE001 — fail-open, never crash
+                logger.warning(
+                    "stale-characterization gate raised — failing open",
+                    extra={
+                        "correlation_id": context.correlation_id,
+                        "error": str(gate_exc),
+                    },
+                )
+                stale = False
+            if stale:
+                reason = (
+                    f"stale_characterization: no Characterization for "
+                    f"strategy_id={context.strategy_id} "
+                    f"strategy_revision_id={context.strategy_revision_id}"
+                )
+                logger.warning(
+                    "🛑 REJECTING INTENT: stale characterization",
+                    extra={
+                        "correlation_id": context.correlation_id,
+                        "strategy_id": context.strategy_id,
+                        "strategy_revision_id": context.strategy_revision_id,
+                    },
+                )
+                return DecisionResult(
+                    hard_blocked=True,
+                    hard_block_reason=reason,
+                    ev_passes=False,
+                    cost_viable=False,
+                    regime_confidence=ConfidenceLevel.LOW,
+                    regime_fit=RegimeFit.NEUTRAL,
+                    strategy_health=HealthStatus.HEALTHY,
+                    activation_recommendation=ActivationRecommendation.PAUSE,
+                    action=ActionType.REJECT,
+                    justification=reason,
+                    thought_trace="STALE_CHARACTERIZATION",
+                    rejection_source=RejectionSource.STALE_CHARACTERIZATION,
+                )
 
         try:
             # Placeholder results for deterministic bypass (Ticket #334/337)

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -13,6 +13,14 @@ from cio.core.vector import VectorClientProtocol
 from cio.models import ActionType, DecisionResult, TriggerContext
 from cio.output.translator import TradeEngineTranslator
 
+try:
+    from petrosa_otel import inject_trace_context as _inject_trace_context
+
+    _CIO_NATS_INJECT = True
+except ImportError:
+    _CIO_NATS_INJECT = False
+    _inject_trace_context = None
+
 logger = logging.getLogger(__name__)
 
 
@@ -224,6 +232,8 @@ class OutputRouter:
             legacy_subject = f"{base_signals}.{strategy_id}"
             legacy_data = TradeEngineTranslator.to_legacy_signal(context, decision)
             if legacy_data:
+                if _CIO_NATS_INJECT and _inject_trace_context is not None:
+                    legacy_data = _inject_trace_context(legacy_data)
                 dispatch_tasks_data.append(
                     (legacy_subject, json.dumps(legacy_data).encode())
                 )
@@ -534,6 +544,15 @@ class OutputRouter:
         # Record in the dashboard decision store (#654).
         if self.decision_store is not None:
             _confidence_map = {"HIGH": 0.9, "MEDIUM": 0.6, "LOW": 0.3}
+            # FR53 / P3.4 (#130): surface structured rejection_source +
+            # strategy_revision_id so the operator dashboard can show "why" +
+            # which revision the intent claimed vs the one characterizations
+            # are bound to.
+            rejection_source_value = (
+                decision.rejection_source.value
+                if decision.rejection_source is not None
+                else None
+            )
             self.decision_store.record(
                 DecisionRecord(
                     strategy_id=strategy_id,
@@ -544,6 +563,8 @@ class OutputRouter:
                     confidence=_confidence_map.get(
                         getattr(decision.regime_confidence, "value", "").upper(), 0.5
                     ),
+                    rejection_source=rejection_source_value,
+                    strategy_revision_id=getattr(context, "strategy_revision_id", None),
                 )
             )
 

--- a/cio/models/context.py
+++ b/cio/models/context.py
@@ -79,6 +79,10 @@ class TriggerContext(BaseModel):
 
     # Strategy Context
     strategy_id: str
+    # FR53 / P3.4 (#130): content-addressable strategy revision the intent
+    # claims to apply to. None ⇒ legacy intent (pre-P3.4) — refusal gate
+    # skips silently rather than rejecting every legacy producer.
+    strategy_revision_id: str | None = None
     strategy_stats: StrategyStats
     strategy_defaults: StrategyDefaults
 

--- a/cio/models/decision.py
+++ b/cio/models/decision.py
@@ -8,6 +8,7 @@ from cio.models.enums import (
     OrderType,
     RegimeEnum,
     RegimeFit,
+    RejectionSource,
     VolatilityLevel,
 )
 from cio.models.regime import RegimeResult
@@ -67,6 +68,12 @@ class DecisionResult(BaseModel):
     action: ActionType | None = None
     justification: str | None = None
     thought_trace: str | None = None
+
+    # 8. Structured rejection metadata (FR53 / P3.4, #130).
+    # When `action` is a refusal (REJECT / BLOCK / FAIL_SAFE), `rejection_source`
+    # records the structured reason so audit-trail consumers and the operator
+    # dashboard can group refusals without parsing `hard_block_reason`.
+    rejection_source: RejectionSource | None = None
 
 
 # SAFE_DEFAULTS: Authoritative source for parse failure fallbacks

--- a/cio/models/enums.py
+++ b/cio/models/enums.py
@@ -108,6 +108,18 @@ class ActionType(StrEnum):
     RETIRE = "retire"
 
 
+class RejectionSource(StrEnum):
+    """FR53 / P3.4 (#130) — structured *why* for a CIO refusal.
+
+    `ActionType` carries *what* the CIO decided (REJECT / FAIL_SAFE / …);
+    `RejectionSource` carries *why*. Persisted on the audit trail (FR12) so
+    operator dashboards and post-mortems can group refusals by reason without
+    parsing free-text `hard_block_reason` strings.
+    """
+
+    STALE_CHARACTERIZATION = "stale_characterization"
+
+
 class TriggerType(StrEnum):
     """Types of events that trigger the CIO reasoning loop."""
 

--- a/tests/unit/test_stale_characterization_refusal.py
+++ b/tests/unit/test_stale_characterization_refusal.py
@@ -1,0 +1,262 @@
+"""Unit tests for FR53 / P3.4 stale-characterization refusal (petrosa-cio#130).
+
+Covers the three layers shipped by this PR:
+
+  1. ``is_characterization_stale`` — single HTTP GET against data-manager,
+     with the documented 404 ⇒ stale, 200 ⇒ fresh, error ⇒ fail-open
+     semantics.
+  2. ``Orchestrator.run`` — when the gate reports stale, the loop short-
+     circuits with `ActionType.REJECT` + `RejectionSource.STALE_CHARACTERIZATION`
+     and never invokes the LLM personas.
+  3. ``DecisionRecord`` / dashboard surface — the structured refusal source
+     and the claimed revision id round-trip through the recent-decisions
+     feed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from cio.apps.nurse.models import RiskLimits
+from cio.core.characterization_stale_gate import is_characterization_stale
+from cio.core.decision_store import DecisionRecord, DecisionStore
+from cio.models import (
+    ConfidenceLevel,
+    RegimeEnum,
+    RegimeResult,
+    StrategyDefaults,
+    StrategyStats,
+    TriggerContext,
+    VolatilityLevel,
+)
+from cio.models.context import MarketSignals, PortfolioSummary
+from cio.models.enums import ActionType, RegimeFit, RejectionSource, TriggerType
+
+# ---------------------------------------------------------------------------
+# Layer 1 — gate HTTP semantics
+# ---------------------------------------------------------------------------
+
+
+def _mock_async_client_returning(status_code: int) -> AsyncMock:
+    """Build an httpx.AsyncClient stub whose `get` returns the given status."""
+    response = MagicMock()
+    response.status_code = status_code
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(return_value=response)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_gate_returns_false_when_revision_id_absent():
+    """Legacy intent (no revision) is never refused."""
+    assert (
+        await is_characterization_stale(strategy_id="s1", strategy_revision_id=None)
+        is False
+    )
+    assert (
+        await is_characterization_stale(strategy_id="s1", strategy_revision_id="")
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_gate_returns_true_on_404():
+    """404 from data-manager is the canonical 'stale → refuse' signal."""
+    client = _mock_async_client_returning(404)
+    stale = await is_characterization_stale(
+        strategy_id="s1",
+        strategy_revision_id="srev_abc",
+        client=client,
+    )
+    assert stale is True
+    client.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_gate_returns_false_on_200():
+    client = _mock_async_client_returning(200)
+    assert (
+        await is_characterization_stale(
+            strategy_id="s1", strategy_revision_id="srev_abc", client=client
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_gate_fails_open_on_unexpected_status():
+    """5xx / 4xx (other than 404) → log + fail-open (False)."""
+    client = _mock_async_client_returning(503)
+    assert (
+        await is_characterization_stale(
+            strategy_id="s1", strategy_revision_id="srev_abc", client=client
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_gate_fails_open_on_request_error():
+    """Connection / timeout → log + fail-open."""
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(side_effect=httpx.ConnectError("boom"))
+    assert (
+        await is_characterization_stale(
+            strategy_id="s1", strategy_revision_id="srev_abc", client=client
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — Orchestrator short-circuits with REJECT + STALE_CHARACTERIZATION
+# ---------------------------------------------------------------------------
+
+
+def _make_context(*, revision_id: str | None = "srev_abc") -> TriggerContext:
+    return TriggerContext(
+        correlation_id="cid-1",
+        source_subject="cio.intent.trading.s1",
+        trigger_type=TriggerType.TRADE_INTENT,
+        trigger_payload={},
+        regime=RegimeResult(
+            regime=RegimeEnum.RANGING,
+            regime_confidence=ConfidenceLevel.HIGH,
+            volatility_level=VolatilityLevel.MEDIUM,
+            primary_signal="t",
+            confidence=0.9,
+            fit=RegimeFit.GOOD,
+            thought_trace="t",
+        ),
+        volatility_level=VolatilityLevel.MEDIUM,
+        market_signals=MarketSignals(
+            signal_summary="ok",
+            current_price=100.0,
+            volatility_percentile=0.5,
+            trend_strength=0.5,
+            price_action_character="ranging",
+        ),
+        strategy_id="s1",
+        strategy_revision_id=revision_id,
+        strategy_stats=StrategyStats(),
+        strategy_defaults=StrategyDefaults(
+            stop_loss_pct=0.01, take_profit_pct=0.02, max_hold_hours=4.0
+        ),
+        global_drawdown_pct=0.0,
+        open_orders_global=0,
+        open_orders_symbol=0,
+        available_capital_usd=1000.0,
+        portfolio=PortfolioSummary(
+            gross_exposure=0.0, same_asset_pct=0.0, open_positions_count=0
+        ),
+        risk_limits=RiskLimits(),
+    )
+
+
+def _build_orchestrator():
+    from cio.core.orchestrator import Orchestrator
+
+    with patch("cio.core.orchestrator.ClientFactory.create", return_value=MagicMock()):
+        return Orchestrator()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_rejects_when_characterization_is_stale():
+    """Stale characterization short-circuits the reasoning loop."""
+    orch = _build_orchestrator()
+    context = _make_context(revision_id="srev_stale")
+
+    with patch(
+        "cio.core.orchestrator.is_characterization_stale",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as mock_gate:
+        result = await orch.run(context)
+
+    mock_gate.assert_awaited_once()
+    assert result.action == ActionType.REJECT
+    assert result.rejection_source == RejectionSource.STALE_CHARACTERIZATION
+    assert result.hard_blocked is True
+    assert "stale_characterization" in (result.hard_block_reason or "")
+    assert "srev_stale" in (result.hard_block_reason or "")
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_skips_gate_when_no_revision_id():
+    """Legacy intent (no revision id) skips the gate entirely."""
+    orch = _build_orchestrator()
+    context = _make_context(revision_id=None)
+
+    with patch(
+        "cio.core.orchestrator.is_characterization_stale",
+        new_callable=AsyncMock,
+        return_value=True,  # would refuse if called — but should NOT be called
+    ) as mock_gate:
+        # Force the deterministic-bypass path so the test does not depend on
+        # the LLM personas: NURSE_USE_LLM_REASONING=false.
+        orch.use_llm_reasoning = False
+        result = await orch.run(context)
+
+    mock_gate.assert_not_awaited()
+    assert result.rejection_source is None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_passes_through_when_revision_is_fresh():
+    """Fresh characterization (gate returns False) does not refuse."""
+    orch = _build_orchestrator()
+    context = _make_context(revision_id="srev_fresh")
+
+    with patch(
+        "cio.core.orchestrator.is_characterization_stale",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        orch.use_llm_reasoning = False  # take the deterministic-bypass branch
+        result = await orch.run(context)
+
+    assert result.rejection_source is None
+    # The deterministic-bypass branch ultimately classifies the action; the
+    # key invariant here is that the gate did NOT veto the loop.
+    assert result.action != ActionType.REJECT or result.rejection_source is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — DecisionRecord + dashboard surface
+# ---------------------------------------------------------------------------
+
+
+def test_decision_record_carries_refusal_metadata():
+    """DecisionRecord persists rejection_source + strategy_revision_id."""
+    store = DecisionStore()
+    store.record(
+        DecisionRecord(
+            strategy_id="s1",
+            action="reject",
+            reasoning_trace="STALE_CHARACTERIZATION",
+            confidence=0.3,
+            rejection_source="stale_characterization",
+            strategy_revision_id="srev_stale",
+        )
+    )
+    records = store.recent(datetime.now(UTC).replace(year=2020))
+    assert len(records) == 1
+    r = records[0]
+    assert r.rejection_source == "stale_characterization"
+    assert r.strategy_revision_id == "srev_stale"
+
+
+def test_decision_record_defaults_refusal_metadata_to_none():
+    """Existing call sites that do not set the new fields keep working (None default)."""
+    record = DecisionRecord(
+        strategy_id="s1",
+        action="execute",
+        reasoning_trace="ok",
+        confidence=0.7,
+    )
+    assert record.rejection_source is None
+    assert record.strategy_revision_id is None


### PR DESCRIPTION
Closes #130. Closes the FR53 / P3.4 cross-repo loop — CIO consumer side after producer (bot-ta-analysis#250) + storage filter (data-manager#181).

## What changed
- **Gate** (`cio/core/characterization_stale_gate.py`): one HTTP GET against data-manager's `/api/v1/characterizations?strategy_revision_id=...` — 404 ⇒ stale, 200 ⇒ fresh, anything else ⇒ fail-open (logged WARNING). 2 s timeout so the cold path SLO is unaffected.
- **Orchestrator**: gate runs at the top of `Orchestrator.run` only for `TRADE_INTENT` triggers that carry a `strategy_revision_id` (legacy intents pass through). Stale ⇒ short-circuit with `ActionType.REJECT` + `rejection_source=STALE_CHARACTERIZATION` + `hard_blocked=True`, never invokes the LLM personas.
- **Models**: new `RejectionSource` StrEnum (`stale_characterization`); `DecisionResult.rejection_source: RejectionSource | None`; `TriggerContext.strategy_revision_id: str | None`.
- **Audit / dashboard**: `DecisionRecord` gains `rejection_source` + `strategy_revision_id` fields; `GET /api/dashboard/decisions/recent` surfaces both so operators see refusal taxonomy + claimed-vs-bound revision drift at a glance.

## Test plan
- [x] `pytest tests/unit/test_stale_characterization_refusal.py` — 10 tests pass: gate HTTP semantics (legacy None / 404 / 200 / 5xx fail-open / request-error fail-open), Orchestrator short-circuit (stale → REJECT + STALE_CHARACTERIZATION, no revision id ⇒ skipped, fresh ⇒ pass through), DecisionRecord defaults + round-trip.
- [x] Full suite: **263 passed**.
- [x] `ruff check` + `ruff format --check` clean.

Closes #130