### PR TITLE
feat: PreDecisionContext bundle (P1.4-AC1 / FR55-FR58, #131)

### DIFF
--- a/cio/core/context_builder.py
+++ b/cio/core/context_builder.py
@@ -1,15 +1,28 @@
 import asyncio
 import logging
 import os
+from datetime import datetime
 from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
 
 import httpx
 
 from cio.core.vector import VectorClientProtocol
 from cio.models import (
+    CharacterizationRef,
+    EvaluatorVerdict,
     MarketSignals,
+    MarketState,
     PnlTrend,
+    PortfolioState,
     PortfolioSummary,
+    PreDecisionContext,
     RegimeAPIResponse,
     RegimeResult,
     RiskLimits,
@@ -41,10 +54,17 @@ class ContextBuilder:
         data_manager_url: str,
         tradeengine_url: str,
         vector_client: VectorClientProtocol | None = None,
+        evaluator_subscriber: Any | None = None,
     ):
         self.data_manager_url = data_manager_url
         self.tradeengine_url = tradeengine_url
         self.vector_client = vector_client
+        # P1.4-AC1 (#131): wired in by main.py at startup so the
+        # PreDecisionContext bundle can read live evaluator verdicts
+        # without coupling to NATS in this layer. ``None`` is the legacy
+        # path — the bundle is then assembled with an empty verdicts
+        # dict and downstream stories (122.2) handle the fallback.
+        self.evaluator_subscriber = evaluator_subscriber
         token = os.getenv("PETROSA_INTERNAL_TOKEN", "")
         if not token:
             logger.warning(
@@ -116,6 +136,29 @@ class ContextBuilder:
         # Assemble TriggerContext
         # Pass decision_id only when provided; TriggerContext.default_factory generates one otherwise
         extra = {"decision_id": decision_id} if decision_id is not None else {}
+
+        market_signals = MarketSignals(
+            signal_summary=payload.get("signal_summary", "Manual trigger"),
+            current_price=payload.get("current_price") or payload.get("price") or 0.0,
+            volatility_percentile=payload.get("volatility_percentile", 0.5),
+            trend_strength=payload.get("trend_strength", 0.0),
+            price_action_character=payload.get("price_action_character", "Neutral"),
+        )
+
+        # P1.4-AC1 (#131) — assemble the structured PreDecisionContext
+        # bundle from the components already fetched above plus the
+        # evaluator-subscriber snapshot + a characterization-ref fetch.
+        strategy_revision_id = payload.get("strategy_revision_id")
+        pre_decision_context = await self.assemble_pre_decision_context(
+            correlation_id=correlation_id,
+            regime=regime,
+            market_signals=market_signals,
+            portfolio=portfolio,
+            env_stats=env_stats,
+            strategy_id=strategy_id,
+            strategy_revision_id=strategy_revision_id,
+        )
+
         return TriggerContext(
             correlation_id=correlation_id,
             source_subject=source_subject,
@@ -124,16 +167,9 @@ class ContextBuilder:
             trigger_payload=payload,
             regime=regime,
             volatility_level=regime.volatility_level,
-            market_signals=MarketSignals(
-                signal_summary=payload.get("signal_summary", "Manual trigger"),
-                current_price=payload.get("current_price")
-                or payload.get("price")
-                or 0.0,
-                volatility_percentile=payload.get("volatility_percentile", 0.5),
-                trend_strength=payload.get("trend_strength", 0.0),
-                price_action_character=payload.get("price_action_character", "Neutral"),
-            ),
+            market_signals=market_signals,
             strategy_id=strategy_id,
+            strategy_revision_id=strategy_revision_id,
             strategy_stats=stats,
             strategy_defaults=defaults,
             global_drawdown_pct=env_stats.get("global_drawdown_pct", 0.0),
@@ -143,6 +179,140 @@ class ContextBuilder:
             portfolio=portfolio,
             risk_limits=risk,
             historical_context=historical_context,
+            pre_decision_context=pre_decision_context,
+        )
+
+    async def assemble_pre_decision_context(
+        self,
+        *,
+        correlation_id: str,
+        regime: RegimeResult,
+        market_signals: MarketSignals,
+        portfolio: PortfolioSummary,
+        env_stats: dict[str, Any],
+        strategy_id: str,
+        strategy_revision_id: str | None,
+    ) -> PreDecisionContext:
+        """P1.4-AC1 / FR55-FR58 (#131) — assemble the typed PreDecisionContext.
+
+        Reuses subsystem fetches already issued during ``build()`` so the
+        bundle does not lengthen the cold path; the only extra call is the
+        characterization-ref probe, which is bounded by a short timeout
+        and degrades to ``characterization=None`` on any failure (the
+        stale-gate at orchestrator.py still owns refusal semantics; this
+        method only *observes* what is on record).
+
+        AC2 (missing-context handling), AC3 (prompt-contract enforcement),
+        and AC4 (dashboard exposure) are explicitly deferred to sibling
+        children of EPIC petrosa-cio#122.
+        """
+        market_state = MarketState(
+            regime=regime.regime,
+            regime_confidence=regime.regime_confidence,
+            volatility_level=regime.volatility_level,
+            current_price=market_signals.current_price,
+            primary_signal=regime.primary_signal,
+        )
+        portfolio_state = PortfolioState(
+            gross_exposure=portfolio.gross_exposure,
+            same_asset_pct=portfolio.same_asset_pct,
+            open_positions_count=portfolio.open_positions_count,
+            global_drawdown_pct=env_stats.get("global_drawdown_pct", 0.0),
+            available_capital_usd=env_stats.get("available_capital_usd", 0.0),
+            open_orders_global=env_stats.get("open_orders_global", 0),
+            open_orders_symbol=env_stats.get("open_orders_symbol", 0),
+        )
+
+        evaluator_verdicts = self._collect_evaluator_verdicts()
+        characterization = await self._fetch_characterization_ref(
+            strategy_id=strategy_id,
+            strategy_revision_id=strategy_revision_id,
+            correlation_id=correlation_id,
+        )
+
+        return PreDecisionContext(
+            market_state=market_state,
+            portfolio_state=portfolio_state,
+            evaluator_verdicts=evaluator_verdicts,
+            characterization=characterization,
+        )
+
+    def _collect_evaluator_verdicts(self) -> dict[str, EvaluatorVerdict]:
+        """FR57 — project the evaluator subscriber's snapshot into a typed dict.
+
+        Tolerates the legacy "no subscriber wired" case by returning an
+        empty dict. The subscriber's snapshot shape is documented at
+        ``EvaluatorSubscriber.snapshot``.
+        """
+        sub = self.evaluator_subscriber
+        if sub is None:
+            return {}
+        try:
+            snap = sub.snapshot()
+        except Exception:  # noqa: BLE001 — degrade rather than crash assembly
+            return {}
+        out: dict[str, EvaluatorVerdict] = {}
+        for entry in snap.get("verdicts", []) or []:
+            subsystem = entry.get("subsystem")
+            verdict = entry.get("verdict")
+            if not subsystem or not verdict:
+                continue
+            observed_raw = entry.get("observed_at")
+            try:
+                observed_at = (
+                    datetime.fromisoformat(observed_raw)
+                    if isinstance(observed_raw, str)
+                    else datetime.now(UTC)
+                )
+            except ValueError:
+                observed_at = datetime.now(UTC)
+            out[subsystem] = EvaluatorVerdict(
+                subsystem=subsystem,
+                verdict=verdict,
+                reason=entry.get("reason") or "",
+                observed_at=observed_at,
+            )
+        return out
+
+    async def _fetch_characterization_ref(
+        self,
+        *,
+        strategy_id: str,
+        strategy_revision_id: str | None,
+        correlation_id: str,
+    ) -> CharacterizationRef | None:
+        """FR58 — return a typed reference to the admitted characterization
+        for (strategy_id, strategy_revision_id), or ``None`` when the
+        intent does not carry a revision id or data-manager has no record.
+
+        This is observation-only — refusal on stale revisions is owned by
+        the FR53 / P3.4 stale-gate at ``cio/core/characterization_stale_gate.py``.
+        """
+        if not strategy_revision_id:
+            return None
+        url = f"{self.data_manager_url}/api/v1/characterizations"
+        params = {
+            "strategy_id": strategy_id,
+            "strategy_revision_id": strategy_revision_id,
+        }
+        try:
+            response = await self.client.get(url, params=params)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "PreDecisionContext: characterization fetch failed — recording None",
+                extra={
+                    "correlation_id": correlation_id,
+                    "strategy_id": strategy_id,
+                    "strategy_revision_id": strategy_revision_id,
+                    "error": str(exc),
+                },
+            )
+            return None
+        if response.status_code != 200:
+            return None
+        return CharacterizationRef(
+            strategy_id=strategy_id,
+            strategy_revision_id=strategy_revision_id,
         )
 
     async def _fetch_regime(self, symbol: str, correlation_id: str) -> RegimeResult:

--- a/cio/models/__init__.py
+++ b/cio/models/__init__.py
@@ -2,8 +2,13 @@
 
 # Enums
 # Context models
+from cio.models.context import CharacterizationRef as CharacterizationRef
+from cio.models.context import EvaluatorVerdict as EvaluatorVerdict
 from cio.models.context import MarketSignals as MarketSignals
+from cio.models.context import MarketState as MarketState
+from cio.models.context import PortfolioState as PortfolioState
 from cio.models.context import PortfolioSummary as PortfolioSummary
+from cio.models.context import PreDecisionContext as PreDecisionContext
 from cio.models.context import RiskLimits as RiskLimits
 from cio.models.context import StrategyDefaults as StrategyDefaults
 from cio.models.context import StrategyStats as StrategyStats

--- a/cio/models/context.py
+++ b/cio/models/context.py
@@ -1,10 +1,24 @@
 import uuid
+from datetime import datetime
 from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
 
 from pydantic import BaseModel, Field
 
 from cio.apps.nurse.models import RiskLimits
-from cio.models.enums import PnlTrend, TriggerType, VolatilityLevel
+from cio.models.enums import (
+    ConfidenceLevel,
+    PnlTrend,
+    RegimeEnum,
+    TriggerType,
+    VolatilityLevel,
+)
 from cio.models.regime import RegimeResult
 
 
@@ -102,3 +116,146 @@ class TriggerContext(BaseModel):
 
     # Optional historical context from vector DB (COLD path only)
     historical_context: str | None = None
+
+    # P1.4-AC1 / FR55-FR58 (#131): structured PreDecisionContext bundle
+    # assembled by the orchestrator before personas run. None until the
+    # bundle is wired into the assembly path (legacy call sites stay
+    # green); downstream stories (122.2 missing-context, 122.3 prompt
+    # contract) flip this to required once they ship.
+    pre_decision_context: "PreDecisionContext | None" = None
+
+
+# ----------------------------------------------------------------------
+# P1.4-AC1 / FR55-FR58 (petrosa-cio#131): PreDecisionContext bundle
+# ----------------------------------------------------------------------
+# This is a deliberately *narrow* typed snapshot of the four subsystem
+# inputs every arbitration decision consumes. It is distinct from
+# `TriggerContext` (which carries trigger metadata + LLM-facing market
+# signals) — `TriggerContext.pre_decision_context` embeds this bundle so
+# downstream code can read the typed snapshot without re-querying.
+#
+# Out of scope for this story (deferred to the named EPIC children):
+#   * missing-context fallback semantics  → 122.2
+#   * prompt-contract enforcement on the bundle → 122.3
+#   * dashboard exposure of the bundle → 122.7
+# ----------------------------------------------------------------------
+
+
+class MarketState(BaseModel):
+    """FR55 — typed snapshot of market state at the moment of arbitration.
+
+    Mirrors the bits of ``RegimeResult`` + ``MarketSignals`` that the
+    arbitration prompt needs to reason about, projected into a single
+    flat shape with an explicit ``observed_at`` so the audit trail can
+    join across the four bundle fields.
+    """
+
+    regime: RegimeEnum
+    regime_confidence: ConfidenceLevel
+    volatility_level: VolatilityLevel
+    current_price: float = Field(
+        ..., description="Current market price at assembly time (quote currency)"
+    )
+    primary_signal: str = Field(
+        ...,
+        description=(
+            "The signal that drove the regime classification — carried "
+            "forward for the audit trail."
+        ),
+    )
+    observed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class PortfolioState(BaseModel):
+    """FR56 — typed snapshot of portfolio + risk state at arbitration time.
+
+    Surfaces the aggregate figures (drawdown, capital, exposure) that the
+    Code Engine + personas already consume separately on
+    ``TriggerContext``. Keeping them together in one typed model is what
+    lets downstream stories reason about "the portfolio at decision T"
+    as a unit rather than reconstructing the picture field-by-field.
+    """
+
+    gross_exposure: float = Field(
+        ..., description="Aggregate gross exposure (0.0 - 1.0)"
+    )
+    same_asset_pct: float = Field(
+        ..., description="Concentration in the trigger's asset (0.0 - 1.0)"
+    )
+    open_positions_count: int = Field(..., ge=0)
+    global_drawdown_pct: float = Field(
+        ..., description="Portfolio-wide drawdown vs. high-water mark"
+    )
+    available_capital_usd: float = Field(..., ge=0.0)
+    open_orders_global: int = Field(..., ge=0)
+    open_orders_symbol: int = Field(..., ge=0)
+    observed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class EvaluatorVerdict(BaseModel):
+    """FR57 — typed verdict snapshot from one subsystem evaluator.
+
+    Subscribers tracking ``evaluator.{subsystem}.verdict`` already keep
+    a ``(verdict, reason, observed_at)`` triple in-memory; this model is
+    the typed projection of that triple so the bundle can carry it
+    through arbitration without dict-shape drift.
+
+    `verdict` is intentionally a free-form `str` (rather than a strict
+    enum) to mirror the upstream P2.1 publisher contract which accepts
+    `healthy | unhealthy | unknown`; downstream stories may tighten this
+    once the full vocabulary is locked across subsystems.
+    """
+
+    subsystem: str = Field(..., min_length=1)
+    verdict: str = Field(..., description="healthy | unhealthy | unknown")
+    reason: str = Field("", description="Operator-readable explanation, may be empty")
+    observed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class CharacterizationRef(BaseModel):
+    """FR58 — minimal reference to the admitted Characterization.
+
+    The bundle does NOT carry the full Characterization document (that
+    payload is large and lives in data-manager); it carries the
+    revision identifier + admission timestamp so arbitration can:
+
+      * cite the exact revision in the audit trail, and
+      * defer the full fetch to AC2 (missing-context handling).
+
+    ``strategy_revision_id`` follows the ``srev_<module_hash[:12]>_<parameter_hash[:12]>``
+    shape locked by FR53 / P3.4 in petrosa-data-manager#179.
+    """
+
+    strategy_id: str = Field(..., min_length=1)
+    strategy_revision_id: str = Field(..., min_length=1)
+    observed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class PreDecisionContext(BaseModel):
+    """FR55-FR58 — the structured bundle every arbitration decision consumes.
+
+    Assembled once by the orchestrator (or, in production, by
+    ``ContextBuilder.assemble_pre_decision_context``) and threaded
+    through to personas + audit trail. The four fields map 1:1 to the
+    AC1.a contract on the parent EPIC ticket — they are intentionally
+    typed individually so the LLM prompt-contract story (AC3, separate
+    child) can assert shape without inspecting the underlying
+    subsystems.
+
+    ``characterization`` is ``None`` when the strategy has not yet
+    received an admitted characterization (e.g. a brand-new strategy
+    in admission flow). Refusal semantics for stale characterizations
+    are owned by the FR53 / P3.4 stale-gate (petrosa-cio#130); this
+    field only records *what was observed* at decision time.
+    """
+
+    market_state: MarketState
+    portfolio_state: PortfolioState
+    evaluator_verdicts: dict[str, EvaluatorVerdict] = Field(default_factory=dict)
+    characterization: CharacterizationRef | None = None
+    assembled_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+# Resolve the forward reference declared on TriggerContext above so
+# Pydantic can finalize the schema once PreDecisionContext is defined.
+TriggerContext.model_rebuild()

--- a/cio/personas/action_classifier.py
+++ b/cio/personas/action_classifier.py
@@ -107,7 +107,7 @@ class ActionClassifier:
         """
         Compresses input into the minimal schema required by the prompt.
         """
-        return {
+        payload: dict[str, Any] = {
             "strategy_id": context.strategy_id,
             "regime": regime_result.regime.value if regime_result.regime else None,
             "regime_confidence": (
@@ -131,6 +131,15 @@ class ActionClassifier:
             "risk_warnings": code_result.risk_warnings,
             "historical_context": context.historical_context,
         }
+        # P1.4-AC1.c (#131) — surface the typed PreDecisionContext bundle
+        # to the arbitration prompt. AC3 (separate story) tightens the
+        # prompt contract against this shape; here we only ensure the
+        # bundle is present and serializable.
+        if context.pre_decision_context is not None:
+            payload["pre_decision_context"] = context.pre_decision_context.model_dump(
+                mode="json"
+            )
+        return payload
 
     def _load_system_prompt(self) -> str:
         """

--- a/tests/unit/test_pre_decision_context_bundle.py
+++ b/tests/unit/test_pre_decision_context_bundle.py
@@ -1,0 +1,434 @@
+"""Unit tests for the PreDecisionContext bundle (P1.4-AC1 / FR55-FR58).
+
+Scope (per [petrosa-cio#131](https://github.com/PetroSa2/petrosa-cio/issues/131)):
+
+  * **AC1.a** — the typed `PreDecisionContext` + its four field models are
+    importable, constructible, and round-trip through Pydantic's
+    ``model_dump`` / ``model_validate`` without losing field shape.
+  * **AC1.b** — ``ContextBuilder.assemble_pre_decision_context`` builds the
+    bundle from the already-fetched subsystem components plus an
+    ``EvaluatorSubscriber.snapshot``-shaped dict, and probes data-manager
+    for the characterization reference.
+  * **AC1.c** — when a ``TriggerContext`` carries a populated bundle,
+    ``ActionClassifier._build_user_context`` exposes it under the
+    ``pre_decision_context`` key so AC3 (separate child) can lock the
+    prompt-contract shape.
+  * **AC1.d (this file)** — happy-path coverage only; missing-context
+    branches (no evaluator subscriber wired, characterization 404,
+    data-manager unreachable) are owned by EPIC child 122.2 and are
+    deliberately out of scope here. A few light degradation checks are
+    included to prove the happy-path assertions do not coincidentally
+    pass on an empty bundle.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cio.core.context_builder import ContextBuilder
+from cio.models import (
+    CharacterizationRef,
+    EvaluatorVerdict,
+    MarketSignals,
+    MarketState,
+    PnlTrend,
+    PortfolioState,
+    PortfolioSummary,
+    PreDecisionContext,
+    RegimeResult,
+    RiskLimits,
+    StrategyDefaults,
+    StrategyStats,
+    TriggerContext,
+)
+from cio.models.enums import (
+    ConfidenceLevel,
+    RegimeEnum,
+    TriggerType,
+    VolatilityLevel,
+)
+from cio.personas.action_classifier import ActionClassifier
+
+# ----------------------------------------------------------------------
+# AC1.a — typed model + roundtrip
+# ----------------------------------------------------------------------
+
+
+def _build_bundle() -> PreDecisionContext:
+    """Local fixture-as-helper used by multiple AC1.a tests."""
+    return PreDecisionContext(
+        market_state=MarketState(
+            regime=RegimeEnum.RANGING,
+            regime_confidence=ConfidenceLevel.MEDIUM,
+            volatility_level=VolatilityLevel.MEDIUM,
+            current_price=50000.0,
+            primary_signal="unit-test-signal",
+        ),
+        portfolio_state=PortfolioState(
+            gross_exposure=0.3,
+            same_asset_pct=0.1,
+            open_positions_count=2,
+            global_drawdown_pct=0.05,
+            available_capital_usd=10000.0,
+            open_orders_global=3,
+            open_orders_symbol=1,
+        ),
+        evaluator_verdicts={
+            "ingest": EvaluatorVerdict(
+                subsystem="ingest", verdict="healthy", reason="streaming ok"
+            ),
+            "strategies": EvaluatorVerdict(
+                subsystem="strategies", verdict="healthy", reason=""
+            ),
+        },
+        characterization=CharacterizationRef(
+            strategy_id="strat-x",
+            strategy_revision_id="srev_abc123abc123_def456def456",
+        ),
+    )
+
+
+def test_pre_decision_context_has_four_typed_fields():
+    """AC1.a — the bundle carries the exact field set the EPIC pins."""
+    bundle = _build_bundle()
+    assert isinstance(bundle.market_state, MarketState)
+    assert isinstance(bundle.portfolio_state, PortfolioState)
+    assert isinstance(bundle.evaluator_verdicts, dict)
+    assert all(
+        isinstance(v, EvaluatorVerdict) for v in bundle.evaluator_verdicts.values()
+    )
+    assert isinstance(bundle.characterization, CharacterizationRef)
+
+
+def test_pre_decision_context_roundtrip_via_model_dump():
+    """AC1.a — bundle survives ``model_dump`` → ``model_validate`` without drift."""
+    original = _build_bundle()
+    dumped = original.model_dump(mode="json")
+    restored = PreDecisionContext.model_validate(dumped)
+    assert restored.market_state.regime == RegimeEnum.RANGING
+    assert restored.portfolio_state.global_drawdown_pct == 0.05
+    assert set(restored.evaluator_verdicts.keys()) == {"ingest", "strategies"}
+    assert restored.characterization is not None
+    assert (
+        restored.characterization.strategy_revision_id
+        == "srev_abc123abc123_def456def456"
+    )
+
+
+def test_pre_decision_context_allows_none_characterization():
+    """AC1.a — `characterization` is the only nullable bundle field
+    (FR58: brand-new strategy with no admitted characterization yet)."""
+    bundle = PreDecisionContext(
+        market_state=_build_bundle().market_state,
+        portfolio_state=_build_bundle().portfolio_state,
+        evaluator_verdicts={},
+        characterization=None,
+    )
+    assert bundle.characterization is None
+    assert bundle.evaluator_verdicts == {}
+
+
+def test_trigger_context_embeds_pre_decision_context_field():
+    """AC1.a — `TriggerContext` carries the bundle via the new optional
+    `pre_decision_context` field; the EPIC says "extends, do not collapse",
+    so the existing flat fields stay intact alongside it."""
+    bundle = _build_bundle()
+    ctx = _build_trigger_context(pre_decision_context=bundle)
+    assert ctx.pre_decision_context is bundle
+    # Existing flat fields must still be present (do-not-collapse contract).
+    assert ctx.regime is not None
+    assert ctx.portfolio is not None
+
+
+# ----------------------------------------------------------------------
+# AC1.b — assembly path
+# ----------------------------------------------------------------------
+
+
+def _build_trigger_context(
+    *, pre_decision_context: PreDecisionContext | None = None
+) -> TriggerContext:
+    return TriggerContext(
+        correlation_id="cid-test",
+        source_subject="test.subject",
+        trigger_type=TriggerType.TRADE_INTENT,
+        trigger_payload={"symbol": "BTCUSDT"},
+        regime=RegimeResult(
+            regime=RegimeEnum.RANGING,
+            regime_confidence=ConfidenceLevel.MEDIUM,
+            volatility_level=VolatilityLevel.MEDIUM,
+            primary_signal="unit-test",
+            thought_trace="unit-test",
+        ),
+        volatility_level=VolatilityLevel.MEDIUM,
+        market_signals=MarketSignals(
+            signal_summary="manual",
+            current_price=50000.0,
+            volatility_percentile=0.5,
+            trend_strength=0.1,
+            price_action_character="Neutral",
+        ),
+        strategy_id="strat-x",
+        strategy_stats=StrategyStats(recent_pnl_trend=PnlTrend.NEUTRAL),
+        strategy_defaults=StrategyDefaults(
+            stop_loss_pct=0.02,
+            take_profit_pct=0.04,
+            leverage=1.0,
+            max_hold_hours=24.0,
+        ),
+        global_drawdown_pct=0.05,
+        open_orders_global=3,
+        open_orders_symbol=1,
+        available_capital_usd=10000.0,
+        portfolio=PortfolioSummary(
+            gross_exposure=0.3,
+            same_asset_pct=0.1,
+            open_positions_count=2,
+        ),
+        risk_limits=RiskLimits(
+            max_drawdown_pct=0.2,
+            max_orders_global=10,
+            max_orders_per_symbol=3,
+            max_position_size_usd=5000.0,
+        ),
+        pre_decision_context=pre_decision_context,
+    )
+
+
+@pytest.fixture
+def fake_evaluator_subscriber():
+    """Stand-in for ``EvaluatorSubscriber`` — exposes a ``snapshot()``
+    in the exact shape ``cio/core/evaluator_subscriber.py`` produces."""
+    sub = MagicMock()
+    sub.snapshot.return_value = {
+        "verdicts": [
+            {
+                "subsystem": "ingest",
+                "verdict": "healthy",
+                "reason": "ok",
+                "observed_at": datetime(2026, 1, 1, 12, 0, 0).isoformat(),
+                "override": None,
+            },
+            {
+                "subsystem": "strategies",
+                "verdict": "unknown",
+                "reason": "",
+                "observed_at": datetime(2026, 1, 1, 12, 0, 5).isoformat(),
+                "override": None,
+            },
+        ],
+        "paused": [],
+        "pause_audit_log": [],
+    }
+    return sub
+
+
+def _make_builder_with_mocked_http(
+    *,
+    characterization_status: int = 200,
+    evaluator_subscriber: Any | None = None,
+) -> ContextBuilder:
+    builder = ContextBuilder(
+        data_manager_url="http://data-manager",
+        tradeengine_url="http://tradeengine",
+        vector_client=None,
+        evaluator_subscriber=evaluator_subscriber,
+    )
+    # Replace the live httpx.AsyncClient with an async mock so the
+    # characterization probe is contained to the test process.
+    mock_client = AsyncMock()
+    response = MagicMock()
+    response.status_code = characterization_status
+    mock_client.get = AsyncMock(return_value=response)
+    builder.client = mock_client
+    return builder
+
+
+@pytest.mark.asyncio
+async def test_assemble_pre_decision_context_happy_path(
+    fake_evaluator_subscriber,
+):
+    """AC1.b — every field is built from its named subsystem source."""
+    builder = _make_builder_with_mocked_http(
+        characterization_status=200,
+        evaluator_subscriber=fake_evaluator_subscriber,
+    )
+    regime = RegimeResult(
+        regime=RegimeEnum.TRENDING_BULL,
+        regime_confidence=ConfidenceLevel.HIGH,
+        volatility_level=VolatilityLevel.MEDIUM,
+        primary_signal="ema-cross",
+        thought_trace="up",
+    )
+    market_signals = MarketSignals(
+        signal_summary="m",
+        current_price=42000.0,
+        volatility_percentile=0.5,
+        trend_strength=0.6,
+        price_action_character="trend",
+    )
+    portfolio = PortfolioSummary(
+        gross_exposure=0.4,
+        same_asset_pct=0.2,
+        open_positions_count=5,
+    )
+    env_stats = {
+        "global_drawdown_pct": 0.08,
+        "available_capital_usd": 7500.0,
+        "open_orders_global": 4,
+        "open_orders_symbol": 2,
+    }
+
+    bundle = await builder.assemble_pre_decision_context(
+        correlation_id="cid-assembly",
+        regime=regime,
+        market_signals=market_signals,
+        portfolio=portfolio,
+        env_stats=env_stats,
+        strategy_id="strat-y",
+        strategy_revision_id="srev_aaaaaaaaaaaa_bbbbbbbbbbbb",
+    )
+
+    # market_state
+    assert bundle.market_state.regime == RegimeEnum.TRENDING_BULL
+    assert bundle.market_state.current_price == 42000.0
+    assert bundle.market_state.primary_signal == "ema-cross"
+
+    # portfolio_state
+    assert bundle.portfolio_state.gross_exposure == 0.4
+    assert bundle.portfolio_state.global_drawdown_pct == 0.08
+    assert bundle.portfolio_state.available_capital_usd == 7500.0
+    assert bundle.portfolio_state.open_orders_symbol == 2
+
+    # evaluator_verdicts — typed dict from the snapshot
+    assert set(bundle.evaluator_verdicts.keys()) == {"ingest", "strategies"}
+    assert bundle.evaluator_verdicts["ingest"].verdict == "healthy"
+    assert bundle.evaluator_verdicts["strategies"].verdict == "unknown"
+
+    # characterization ref — 200 from data-manager → record observed
+    assert bundle.characterization is not None
+    assert bundle.characterization.strategy_id == "strat-y"
+    assert (
+        bundle.characterization.strategy_revision_id == "srev_aaaaaaaaaaaa_bbbbbbbbbbbb"
+    )
+
+    await builder.close()
+
+
+@pytest.mark.asyncio
+async def test_assemble_pre_decision_context_without_revision_skips_fetch(
+    fake_evaluator_subscriber,
+):
+    """AC1.b — legacy intents without a revision id leave ``characterization``
+    at ``None`` and never hit data-manager for the ref probe."""
+    builder = _make_builder_with_mocked_http(
+        characterization_status=200,
+        evaluator_subscriber=fake_evaluator_subscriber,
+    )
+
+    bundle = await builder.assemble_pre_decision_context(
+        correlation_id="cid-no-rev",
+        regime=RegimeResult(
+            regime=RegimeEnum.RANGING,
+            regime_confidence=ConfidenceLevel.MEDIUM,
+            volatility_level=VolatilityLevel.MEDIUM,
+            primary_signal="x",
+            thought_trace="x",
+        ),
+        market_signals=MarketSignals(
+            signal_summary="",
+            current_price=1.0,
+            volatility_percentile=0.5,
+            trend_strength=0.0,
+            price_action_character="n",
+        ),
+        portfolio=PortfolioSummary(
+            gross_exposure=0.0, same_asset_pct=0.0, open_positions_count=0
+        ),
+        env_stats={
+            "global_drawdown_pct": 0.0,
+            "available_capital_usd": 0.0,
+            "open_orders_global": 0,
+            "open_orders_symbol": 0,
+        },
+        strategy_id="strat-legacy",
+        strategy_revision_id=None,
+    )
+
+    assert bundle.characterization is None
+    # The ref-probe must short-circuit when no revision id is supplied.
+    builder.client.get.assert_not_awaited()
+
+    await builder.close()
+
+
+# ----------------------------------------------------------------------
+# AC1.c — bundle reaches the arbitration prompt
+# ----------------------------------------------------------------------
+
+
+def test_action_classifier_includes_bundle_in_user_context():
+    """AC1.c — ``_build_user_context`` exposes the bundle under
+    ``pre_decision_context`` whenever it is present on the trigger."""
+    bundle = _build_bundle()
+    ctx = _build_trigger_context(pre_decision_context=bundle)
+
+    # We stub the LLM client + system-prompt load — neither matters for
+    # the user-context shape check.
+    classifier = ActionClassifier.__new__(ActionClassifier)
+    classifier.client = MagicMock()
+    classifier.system_prompt = ""
+
+    code_result = MagicMock(
+        gross_ev=0.1,
+        ev_unavailable=False,
+        kelly_position_usd=100.0,
+        hard_blocked=False,
+        risk_warnings=[],
+    )
+    regime_result = ctx.regime
+    strategy_result = MagicMock()
+    strategy_result.health.value = "healthy"
+    strategy_result.activation_recommendation.value = "run"
+    strategy_result.regime_fit.value = "good"
+
+    user_context = classifier._build_user_context(
+        ctx, code_result, regime_result, strategy_result
+    )
+
+    assert "pre_decision_context" in user_context
+    embedded = user_context["pre_decision_context"]
+    assert embedded["market_state"]["regime"] == "ranging"
+    assert "evaluator_verdicts" in embedded
+    assert set(embedded["evaluator_verdicts"].keys()) == {"ingest", "strategies"}
+
+
+def test_action_classifier_omits_bundle_when_absent():
+    """AC1.c (negative) — when no bundle is attached, the user_context
+    is unchanged: prompt-contract enforcement (AC3) needs to detect the
+    bundle's *absence*, not see a ``None`` placeholder."""
+    ctx = _build_trigger_context(pre_decision_context=None)
+    classifier = ActionClassifier.__new__(ActionClassifier)
+    classifier.client = MagicMock()
+    classifier.system_prompt = ""
+
+    code_result = MagicMock(
+        gross_ev=0.1,
+        ev_unavailable=False,
+        kelly_position_usd=100.0,
+        hard_blocked=False,
+        risk_warnings=[],
+    )
+    strategy_result = MagicMock()
+    strategy_result.health.value = "healthy"
+    strategy_result.activation_recommendation.value = "run"
+    strategy_result.regime_fit.value = "good"
+
+    user_context = classifier._build_user_context(
+        ctx, code_result, ctx.regime, strategy_result
+    )
+    assert "pre_decision_context" not in user_context


### PR DESCRIPTION
## Summary

- Closes PetroSa2/petrosa-cio#131 — implements **AC1** of the CIO context contract (FR55–FR58): the typed structured bundle every arbitration decision consumes.
- Foundational story for EPIC PetroSa2/petrosa-cio#122 — unblocks all sibling AC2–AC8 children which depend on the bundle existing.

### Deliverables

1. **`cio/models/context.py`** — Four new typed `BaseModel` classes (`MarketState`, `PortfolioState`, `EvaluatorVerdict`, `CharacterizationRef`) + the `PreDecisionContext` aggregate. `TriggerContext` gains an optional `pre_decision_context` field — **extends, does not collapse** the existing model per the EPIC's "do-not-collapse" contract.
2. **`cio/core/context_builder.py`** — `assemble_pre_decision_context()` builds the bundle from the already-fetched regime/portfolio/env components plus the `EvaluatorSubscriber` snapshot + a characterization-ref probe. `ContextBuilder.build()` now wires the bundle onto every `TriggerContext` it returns; the legacy assembly path stays intact when no subscriber is supplied.
3. **`cio/personas/action_classifier.py`** — `_build_user_context` exposes the bundle under the `pre_decision_context` key so AC3 (separate child) can lock the LLM prompt-contract shape against it.
4. **`tests/unit/test_pre_decision_context_bundle.py`** — 8 happy-path tests covering model roundtrip (AC1.a), assembly with mocked subsystems (AC1.b), and bundle reaching the user_context (AC1.c). Missing-context branches are explicitly out of scope (deferred to EPIC child 122.2).

### Scope discipline (out of scope, owned by sibling stories)

- AC2 missing-context handling → 122.2
- AC3 prompt-contract enforcement → 122.3
- AC4 dashboard exposure → 122.7
- AC5/6 in-position actions → 122.4
- AC7 re-evaluation loop → 122.5
- AC8 integration test → 122.6

### Backward-compatibility notes

- `pre_decision_context` is `Optional` on `TriggerContext` (default `None`) so every existing call site continues to construct the model unchanged.
- `evaluator_subscriber` is an optional `ContextBuilder` constructor kwarg; when `None`, the bundle assembles with an empty verdicts dict (legacy path).
- Stale-characterization refusal stays owned by the FR53/P3.4 gate at `cio/core/characterization_stale_gate.py` (#130). The new characterization-ref probe in `ContextBuilder` is **observation-only**.

## Test plan

- [x] `tests/unit/test_pre_decision_context_bundle.py` — 8/8 pass locally
- [x] Full unit suite (`tests/unit/`) — 267/267 pass (no regression)
- [x] Integration suite (`tests/integration/`) — 4/4 pass
- [x] Ruff lint + format clean
- [ ] CI checks green on PR