### PR TITLE
feat: 132 - PreDecisionContext AC2 missing-context handling + AC4 dashboard surface

### DIFF
--- a/cio/apps/dashboard_api.py
+++ b/cio/apps/dashboard_api.py
@@ -82,6 +82,17 @@ async def get_decisions_recent(
                 # FR53 / P3.4 (#130): refusal taxonomy + revision drift visibility.
                 "rejection_source": r.rejection_source,
                 "strategy_revision_id": r.strategy_revision_id,
+                # P1.4-AC4 (#132): structured PreDecisionContext snapshot.
+                # `None` for pre-EPIC-#122 historical records that predate
+                # the bundle — the dashboard renders "context not recorded"
+                # rather than hiding the row. FR12 gap-event back-link is
+                # carried inside the bundle (`gaps` list) so the operator
+                # can pivot to the audit-trail consumer.
+                "pre_decision_context": (
+                    r.pre_decision_context.model_dump(mode="json")
+                    if r.pre_decision_context is not None
+                    else None
+                ),
             }
             for r in records
         ],

--- a/cio/core/context_builder.py
+++ b/cio/core/context_builder.py
@@ -16,6 +16,7 @@ import httpx
 from cio.core.vector import VectorClientProtocol
 from cio.models import (
     CharacterizationRef,
+    ContextGap,
     EvaluatorVerdict,
     MarketSignals,
     MarketState,
@@ -109,9 +110,25 @@ class ContextBuilder:
         strategy_id = payload.get("strategy_id", "unknown")
 
         # 1. Parallelize independent fetches to reduce total latency (max vs sum)
+        # P1.4-AC2 (#132): per-build gap collector — passed to fetches so they
+        # can record "this surface fell back to safe defaults" events without
+        # changing their existing return types (tests still mock _fetch_*
+        # directly). Same per-build availability map keys are read by
+        # assemble_pre_decision_context to set the *_available flags.
+        gaps: list[ContextGap] = []
+        availability: dict[str, bool] = {
+            "market": True,
+            "portfolio": True,
+            "evaluators": True,
+            "characterization": True,
+        }
         fetch_tasks = [
-            self._fetch_regime(symbol, correlation_id),
-            self._fetch_portfolio_and_risk(symbol, correlation_id),
+            self._fetch_regime(
+                symbol, correlation_id, gaps=gaps, availability=availability
+            ),
+            self._fetch_portfolio_and_risk(
+                symbol, correlation_id, gaps=gaps, availability=availability
+            ),
             self._fetch_strategy_data(strategy_id, correlation_id),
         ]
 
@@ -148,6 +165,9 @@ class ContextBuilder:
         # P1.4-AC1 (#131) — assemble the structured PreDecisionContext
         # bundle from the components already fetched above plus the
         # evaluator-subscriber snapshot + a characterization-ref fetch.
+        # P1.4-AC2 (#132) — pass the accumulated gap collector + availability
+        # map so the bundle carries per-surface flags and an audit-trail-ready
+        # gaps list.
         strategy_revision_id = payload.get("strategy_revision_id")
         pre_decision_context = await self.assemble_pre_decision_context(
             correlation_id=correlation_id,
@@ -157,6 +177,8 @@ class ContextBuilder:
             env_stats=env_stats,
             strategy_id=strategy_id,
             strategy_revision_id=strategy_revision_id,
+            gaps=gaps,
+            availability=availability,
         )
 
         return TriggerContext(
@@ -192,6 +214,8 @@ class ContextBuilder:
         env_stats: dict[str, Any],
         strategy_id: str,
         strategy_revision_id: str | None,
+        gaps: list[ContextGap] | None = None,
+        availability: dict[str, bool] | None = None,
     ) -> PreDecisionContext:
         """P1.4-AC1 / FR55-FR58 (#131) — assemble the typed PreDecisionContext.
 
@@ -202,9 +226,13 @@ class ContextBuilder:
         stale-gate at orchestrator.py still owns refusal semantics; this
         method only *observes* what is on record).
 
-        AC2 (missing-context handling), AC3 (prompt-contract enforcement),
-        and AC4 (dashboard exposure) are explicitly deferred to sibling
-        children of EPIC petrosa-cio#122.
+        P1.4-AC2 (#132) — when ``gaps``/``availability`` are provided by
+        ``build()`` they carry the per-surface state captured during the
+        upstream fetches; this method only ADDS to them (it does not reset
+        them). When called directly by tests/orchestration on the
+        already-fetched path, the caller may supply ``availability=None``
+        to keep all surfaces flagged ``True`` and only record evaluator/
+        characterization gaps detected here.
         """
         market_state = MarketState(
             regime=regime.regime,
@@ -223,33 +251,92 @@ class ContextBuilder:
             open_orders_symbol=env_stats.get("open_orders_symbol", 0),
         )
 
-        evaluator_verdicts = self._collect_evaluator_verdicts()
+        local_gaps: list[ContextGap] = gaps if gaps is not None else []
+        evaluator_verdicts = self._collect_evaluator_verdicts(gaps=local_gaps)
         characterization = await self._fetch_characterization_ref(
             strategy_id=strategy_id,
             strategy_revision_id=strategy_revision_id,
             correlation_id=correlation_id,
+            gaps=local_gaps,
         )
+
+        # AC2.a — flag synthesis: when the caller did not pass an availability
+        # map, default each surface to True and only flip on evidence of a gap
+        # surfaced from this method's local fetches (subscriber missing,
+        # characterization 404).
+        avail = (
+            dict(availability)
+            if availability is not None
+            else {
+                "market": True,
+                "portfolio": True,
+                "evaluators": True,
+                "characterization": True,
+            }
+        )
+
+        # Evaluators are unavailable when no subscriber is wired OR snapshot
+        # raised (the gap collector captured the reason). Empty verdicts with
+        # a wired subscriber is *not* a gap — that's the steady-state "no
+        # subsystem reported yet".
+        if self.evaluator_subscriber is None or any(
+            g.surface == "evaluators" for g in local_gaps
+        ):
+            avail["evaluators"] = False
+
+        # Characterization is unavailable only when the caller supplied a
+        # revision id AND the fetch did not surface a ref. The legacy
+        # "no revision id" path keeps available=True with characterization=None,
+        # which mirrors AC1's contract.
+        if strategy_revision_id and characterization is None:
+            avail["characterization"] = False
 
         return PreDecisionContext(
             market_state=market_state,
             portfolio_state=portfolio_state,
             evaluator_verdicts=evaluator_verdicts,
             characterization=characterization,
+            market_state_available=avail.get("market", True),
+            portfolio_state_available=avail.get("portfolio", True),
+            evaluator_verdicts_available=avail.get("evaluators", True),
+            characterization_available=avail.get("characterization", True),
+            gaps=list(local_gaps),
         )
 
-    def _collect_evaluator_verdicts(self) -> dict[str, EvaluatorVerdict]:
+    def _collect_evaluator_verdicts(
+        self, gaps: list[ContextGap] | None = None
+    ) -> dict[str, EvaluatorVerdict]:
         """FR57 — project the evaluator subscriber's snapshot into a typed dict.
 
         Tolerates the legacy "no subscriber wired" case by returning an
         empty dict. The subscriber's snapshot shape is documented at
         ``EvaluatorSubscriber.snapshot``.
+
+        P1.4-AC2 (#132): when the subscriber is missing or ``snapshot()``
+        raises, append a ``ContextGap(surface='evaluators')`` to ``gaps`` so
+        the bundle's availability flag is flipped and the FR12 audit-trail
+        consumer can persist the event.
         """
         sub = self.evaluator_subscriber
         if sub is None:
+            if gaps is not None:
+                gaps.append(
+                    ContextGap(
+                        surface="evaluators",
+                        reason="subscriber_not_wired",
+                    )
+                )
             return {}
         try:
             snap = sub.snapshot()
-        except Exception:  # noqa: BLE001 — degrade rather than crash assembly
+        except Exception as exc:  # noqa: BLE001 — degrade rather than crash assembly
+            if gaps is not None:
+                gaps.append(
+                    ContextGap(
+                        surface="evaluators",
+                        reason=f"snapshot_error: {exc}",
+                    )
+                )
             return {}
         out: dict[str, EvaluatorVerdict] = {}
         for entry in snap.get("verdicts", []) or []:
@@ -280,6 +367,7 @@ class ContextBuilder:
         strategy_id: str,
         strategy_revision_id: str | None,
         correlation_id: str,
+        gaps: list[ContextGap] | None = None,
     ) -> CharacterizationRef | None:
         """FR58 — return a typed reference to the admitted characterization
         for (strategy_id, strategy_revision_id), or ``None`` when the
@@ -287,6 +375,12 @@ class ContextBuilder:
 
         This is observation-only — refusal on stale revisions is owned by
         the FR53 / P3.4 stale-gate at ``cio/core/characterization_stale_gate.py``.
+
+        P1.4-AC2 (#132): when a revision id WAS supplied but data-manager
+        returns non-200 or the call raises, append a
+        ``ContextGap(surface='characterization')`` so the bundle flag is
+        flipped. Missing revision id is *not* a gap — the legacy intent
+        path is the expected steady-state for unrevisioned strategies.
         """
         if not strategy_revision_id:
             return None
@@ -307,16 +401,45 @@ class ContextBuilder:
                     "error": str(exc),
                 },
             )
+            if gaps is not None:
+                gaps.append(
+                    ContextGap(
+                        surface="characterization",
+                        reason=f"fetch_error: {exc}",
+                    )
+                )
             return None
         if response.status_code != 200:
+            if gaps is not None:
+                gaps.append(
+                    ContextGap(
+                        surface="characterization",
+                        reason=f"endpoint_{response.status_code}",
+                    )
+                )
             return None
         return CharacterizationRef(
             strategy_id=strategy_id,
             strategy_revision_id=strategy_revision_id,
         )
 
-    async def _fetch_regime(self, symbol: str, correlation_id: str) -> RegimeResult:
-        """Fetches and maps regime data from petrosa-data-manager."""
+    async def _fetch_regime(
+        self,
+        symbol: str,
+        correlation_id: str,
+        gaps: list[ContextGap] | None = None,
+        availability: dict[str, bool] | None = None,
+    ) -> RegimeResult:
+        """Fetches and maps regime data from petrosa-data-manager.
+
+        P1.4-AC2 (#132): when the fetch falls back to the safe default
+        (HTTP error, exception, or Data-Manager-reported empty regime),
+        record a ``ContextGap(surface='market')`` and flip
+        ``availability['market']=False`` if the optional collectors were
+        supplied by ``build()``. Existing test paths that call this method
+        directly (e.g. tests/unit/test_cold_path.py:115) pass no
+        collectors, so the existing return contract is preserved.
+        """
         try:
             url = f"{self.data_manager_url}/analysis/regime?pair={symbol}"
             response = await self.client.get(url)
@@ -330,6 +453,15 @@ class ContextBuilder:
                 and "message" in metadata
                 and "No regime data" in metadata["message"]
             ):
+                if gaps is not None:
+                    gaps.append(
+                        ContextGap(
+                            surface="market",
+                            reason=f"data_manager_empty: {metadata['message']}",
+                        )
+                    )
+                if availability is not None:
+                    availability["market"] = False
                 return RegimeResult(
                     regime="choppy",
                     regime_confidence="low",
@@ -344,6 +476,15 @@ class ContextBuilder:
             logger.error(
                 f"Failed to fetch regime: {e}", extra={"correlation_id": correlation_id}
             )
+            if gaps is not None:
+                gaps.append(
+                    ContextGap(
+                        surface="market",
+                        reason=f"fetch_error: {e}",
+                    )
+                )
+            if availability is not None:
+                availability["market"] = False
             # Return safe default
             return RegimeResult(
                 regime="choppy",
@@ -354,9 +495,21 @@ class ContextBuilder:
             )
 
     async def _fetch_portfolio_and_risk(
-        self, symbol: str, correlation_id: str
+        self,
+        symbol: str,
+        correlation_id: str,
+        gaps: list[ContextGap] | None = None,
+        availability: dict[str, bool] | None = None,
     ) -> tuple[PortfolioSummary, RiskLimits, dict[str, Any]]:
-        """Fetches portfolio and risk data from tradeengine."""
+        """Fetches portfolio and risk data from tradeengine.
+
+        P1.4-AC2 (#132): when the call falls back to conservative defaults
+        (exception path), record a ``ContextGap(surface='portfolio')`` and
+        flip ``availability['portfolio']=False`` if the optional collectors
+        were supplied. The conservative defaults are still returned so the
+        Code Engine's gross_exposure=1.0 / orders=999 trigger-block path
+        continues to fire — AC2 is record-not-block.
+        """
         try:
             url = f"{self.tradeengine_url}/state?symbol={symbol}"
             response = await self.client.get(url)
@@ -373,6 +526,15 @@ class ContextBuilder:
                 f"Failed to fetch portfolio/risk: {e}",
                 extra={"correlation_id": correlation_id},
             )
+            if gaps is not None:
+                gaps.append(
+                    ContextGap(
+                        surface="portfolio",
+                        reason=f"fetch_error: {e}",
+                    )
+                )
+            if availability is not None:
+                availability["portfolio"] = False
             # Safe conservative defaults (trigger blocks)
             return (
                 PortfolioSummary(

--- a/cio/core/decision_store.py
+++ b/cio/core/decision_store.py
@@ -10,6 +10,10 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cio.models.context import PreDecisionContext
 
 _UTC = timezone.utc  # noqa: UP017
 DEFAULT_MAX_SIZE = 500
@@ -32,6 +36,11 @@ class DecisionRecord:
     # Surfaced so the operator can compare against what the most-recent
     # characterization is bound to (i.e. spot drift at a glance).
     strategy_revision_id: str | None = None
+    # P1.4-AC4 (#132) — structured PreDecisionContext snapshot at the
+    # moment of dispatch. ``None`` on pre-EPIC-#122 historical records
+    # (legacy ring-buffer entries written before this field existed) so
+    # the dashboard surface can render "context not recorded" deterministically.
+    pre_decision_context: PreDecisionContext | None = None
 
 
 class DecisionStore:

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -553,6 +553,10 @@ class OutputRouter:
                 if decision.rejection_source is not None
                 else None
             )
+            # P1.4-AC4 (#132): carry the PreDecisionContext snapshot into the
+            # ring buffer so /api/dashboard/decisions/recent can return it
+            # verbatim. Pre-EPIC-#122 historical records have no bundle —
+            # the dashboard renders them with null context.
             self.decision_store.record(
                 DecisionRecord(
                     strategy_id=strategy_id,
@@ -563,10 +567,45 @@ class OutputRouter:
                     confidence=_confidence_map.get(
                         getattr(decision.regime_confidence, "value", "").upper(), 0.5
                     ),
+                    decision_id=decision_id,
                     rejection_source=rejection_source_value,
                     strategy_revision_id=getattr(context, "strategy_revision_id", None),
+                    pre_decision_context=getattr(context, "pre_decision_context", None),
                 )
             )
+
+        # P1.4-AC2.b (#132): publish per-surface context-gap audit events on
+        # `cio.context.gap.<surface>`. data-manager's FR12 audit-trail
+        # consumer subscribes to `cio.context.gap.>` and persists each event
+        # keyed by decision_id. Producer-side only — the decision itself has
+        # already proceeded so the publish is best-effort: a NATS hiccup
+        # must not block the dispatch.
+        pdc = getattr(context, "pre_decision_context", None)
+        if pdc is not None and pdc.gaps and not is_dry_run:
+            for gap in pdc.gaps:
+                gap_payload = {
+                    "decision_id": decision_id,
+                    "correlation_id": correlation_id,
+                    "strategy_id": strategy_id,
+                    "surface": gap.surface,
+                    "reason": gap.reason,
+                    "observed_at": gap.observed_at.isoformat(),
+                }
+                try:
+                    await self.nats_client.publish(
+                        f"cio.context.gap.{gap.surface}",
+                        json.dumps(gap_payload).encode(),
+                    )
+                except Exception as exc:  # noqa: BLE001 — best-effort
+                    logger.warning(
+                        "Failed to publish context.gap event",
+                        extra={
+                            "correlation_id": correlation_id,
+                            "decision_id": decision_id,
+                            "surface": gap.surface,
+                            "error": str(exc),
+                        },
+                    )
 
     async def _apply_rate_limit_freeze(
         self, strategy_id: str, correlation_id: str, response: httpx.Response

--- a/cio/models/__init__.py
+++ b/cio/models/__init__.py
@@ -3,6 +3,7 @@
 # Enums
 # Context models
 from cio.models.context import CharacterizationRef as CharacterizationRef
+from cio.models.context import ContextGap as ContextGap
 from cio.models.context import EvaluatorVerdict as EvaluatorVerdict
 from cio.models.context import MarketSignals as MarketSignals
 from cio.models.context import MarketState as MarketState

--- a/cio/models/context.py
+++ b/cio/models/context.py
@@ -231,6 +231,30 @@ class CharacterizationRef(BaseModel):
     observed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 
+class ContextGap(BaseModel):
+    """P1.4-AC2.b (#132) — one missing-context event recorded at assembly time.
+
+    Carries the operator-visible reason a surface (market / portfolio /
+    evaluators / characterization) was unavailable when the bundle was
+    assembled, so the FR12 audit-trail consumer in `data-manager` can
+    persist it next to the decision_id. ``observed_at`` is the wall-clock
+    moment the gap was detected — not when the underlying outage began.
+    """
+
+    surface: str = Field(
+        ...,
+        description="One of: market | portfolio | evaluators | characterization",
+    )
+    reason: str = Field(
+        ...,
+        description=(
+            "Free-form operator-readable reason "
+            "(e.g. 'subscription dropped', 'endpoint 500', 'timeout')."
+        ),
+    )
+    observed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
 class PreDecisionContext(BaseModel):
     """FR55-FR58 — the structured bundle every arbitration decision consumes.
 
@@ -247,12 +271,25 @@ class PreDecisionContext(BaseModel):
     in admission flow). Refusal semantics for stale characterizations
     are owned by the FR53 / P3.4 stale-gate (petrosa-cio#130); this
     field only records *what was observed* at decision time.
+
+    P1.4-AC2 (#132): The ``*_available`` flags carry per-surface
+    availability. When a fetch fails the corresponding typed field is
+    populated with the safe-default snapshot the builder already returned
+    on the legacy path, and the flag is flipped to ``False`` so downstream
+    consumers (personas, dashboard, audit-trail) can tell live observation
+    from fallback. ``gaps`` is the structured list of those events for
+    FR12 audit-trail persistence — empty in the all-surfaces-healthy case.
     """
 
     market_state: MarketState
     portfolio_state: PortfolioState
     evaluator_verdicts: dict[str, EvaluatorVerdict] = Field(default_factory=dict)
     characterization: CharacterizationRef | None = None
+    market_state_available: bool = True
+    portfolio_state_available: bool = True
+    evaluator_verdicts_available: bool = True
+    characterization_available: bool = True
+    gaps: list[ContextGap] = Field(default_factory=list)
     assembled_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/tests/integration/test_nats_to_nats_loop.py
+++ b/tests/integration/test_nats_to_nats_loop.py
@@ -144,37 +144,68 @@ async def test_full_nats_to_nats_loop():
             await listener._handle_message(mock_msg)
 
             # 5. Assertions
-            # Verify NATS publish was called THREE times:
-            #   1) Legacy signal      (signals.trading.<strategy_id>)
-            #   2) Modern decision    (trade.execute.<strategy_id>)
-            #   3) Decision audit copy for the CIO health evaluator
-            #      (cio.decision.audit.<action>, added in P7.1 / #610)
-            assert mock_nc.publish.call_count == 3
+            # Verify NATS publish call set. P1.4-AC2.b (#132) added an extra
+            # `cio.context.gap.evaluators` audit event when ContextBuilder has
+            # no evaluator subscriber wired (the integration harness does not
+            # wire one — mirrors today's main.py path until that wiring lands).
+            #   1) Legacy signal       (signals.trading.<strategy_id>)
+            #   2) Modern decision     (trade.execute.<strategy_id>)
+            #   3) Decision audit copy (cio.decision.audit.<action>, P7.1 / #610)
+            #   4) Context-gap audit   (cio.context.gap.evaluators, #132)
+            published_subjects = [c.args[0] for c in mock_nc.publish.call_args_list]
+            assert "signals.trading.momentum_v1" in published_subjects
+            assert "trade.execute.momentum_v1" in published_subjects
+            assert "cio.decision.audit.execute" in published_subjects
+            assert "cio.context.gap.evaluators" in published_subjects
+            assert mock_nc.publish.call_count == 4
             assert orchestrator.run.await_count == 1
 
             # Check Legacy Call (signals.trading.<strategy_id> — matches tradeengine signals.trading.>)
-            legacy_call = mock_nc.publish.call_args_list[0]
-            assert legacy_call[0][0] == "signals.trading.momentum_v1"
-            legacy_payload = json.loads(legacy_call[0][1].decode())
+            legacy_call = next(
+                c
+                for c in mock_nc.publish.call_args_list
+                if c.args[0] == "signals.trading.momentum_v1"
+            )
+            legacy_payload = json.loads(legacy_call.args[1].decode())
             assert legacy_payload["action"] == "buy"
             # Verify quantity fix: size / price.
             # CodeEngine size ~ $5000 (capped), price 50000 -> qty 0.1
             assert legacy_payload["quantity"] == pytest.approx(0.1)
 
             # Check Modern Call (trade.execute.momentum_v1)
-            modern_call = mock_nc.publish.call_args_list[1]
-            assert modern_call[0][0] == "trade.execute.momentum_v1"
-            modern_payload = json.loads(modern_call[0][1].decode())
+            modern_call = next(
+                c
+                for c in mock_nc.publish.call_args_list
+                if c.args[0] == "trade.execute.momentum_v1"
+            )
+            modern_payload = json.loads(modern_call.args[1].decode())
             assert modern_payload["action"] == "execute"
             assert modern_payload["computed_position_size_usd"] == pytest.approx(5000.0)
 
             # Check Audit-Copy Call (cio.decision.audit.execute)
-            audit_call = mock_nc.publish.call_args_list[2]
-            assert audit_call[0][0] == "cio.decision.audit.execute"
-            audit_payload = json.loads(audit_call[0][1].decode())
+            audit_call = next(
+                c
+                for c in mock_nc.publish.call_args_list
+                if c.args[0] == "cio.decision.audit.execute"
+            )
+            audit_payload = json.loads(audit_call.args[1].decode())
             assert audit_payload["action"] == "execute"
             assert audit_payload["strategy_id"] == "momentum_v1"
             assert audit_payload["correlation_id"] == "test-loop-id"
+
+            # P1.4-AC2.b (#132): the gap audit event MUST carry the
+            # decision_id + structured surface so data-manager can persist it.
+            gap_call = next(
+                c
+                for c in mock_nc.publish.call_args_list
+                if c.args[0].startswith("cio.context.gap.")
+            )
+            gap_payload = json.loads(gap_call.args[1].decode())
+            assert gap_payload["surface"] == "evaluators"
+            assert gap_payload["strategy_id"] == "momentum_v1"
+            assert gap_payload["correlation_id"] == "test-loop-id"
+            assert gap_payload["reason"]  # populated, free-form string
+            assert "observed_at" in gap_payload
 
             # Verify Vector Upsert (Audit Path)
             mock_vc.upsert.assert_called_once()

--- a/tests/unit/test_dashboard_api.py
+++ b/tests/unit/test_dashboard_api.py
@@ -199,5 +199,112 @@ class TestEvaluatorVerdicts:
         assert "application/json" in resp.headers["content-type"]
 
 
+# ---------------------------------------------------------------------------
+# P1.4-AC4 (#132) — dashboard surfaces pre_decision_context
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionsRecentPreDecisionContext:
+    def _make_bundle(self):
+        from cio.models import (
+            CharacterizationRef,
+            ContextGap,
+            EvaluatorVerdict,
+            MarketState,
+            PortfolioState,
+            PreDecisionContext,
+        )
+        from cio.models.enums import (
+            ConfidenceLevel,
+            RegimeEnum,
+            VolatilityLevel,
+        )
+
+        return PreDecisionContext(
+            market_state=MarketState(
+                regime=RegimeEnum.RANGING,
+                regime_confidence=ConfidenceLevel.MEDIUM,
+                volatility_level=VolatilityLevel.MEDIUM,
+                current_price=50000.0,
+                primary_signal="dashboard-test",
+            ),
+            portfolio_state=PortfolioState(
+                gross_exposure=0.3,
+                same_asset_pct=0.1,
+                open_positions_count=2,
+                global_drawdown_pct=0.05,
+                available_capital_usd=10000.0,
+                open_orders_global=3,
+                open_orders_symbol=1,
+            ),
+            evaluator_verdicts={
+                "ingest": EvaluatorVerdict(
+                    subsystem="ingest", verdict="healthy", reason="ok"
+                ),
+            },
+            characterization=CharacterizationRef(
+                strategy_id="strat-x",
+                strategy_revision_id="srev_abc123abc123_def456def456",
+            ),
+            evaluator_verdicts_available=False,
+            gaps=[
+                ContextGap(
+                    surface="evaluators",
+                    reason="subscriber_not_wired",
+                ),
+            ],
+        )
+
+    def test_recent_includes_pre_decision_context_when_attached(self):
+        bundle = self._make_bundle()
+        store = DecisionStore()
+        store.record(
+            DecisionRecord(
+                strategy_id="strat-x",
+                action="EXECUTE",
+                reasoning_trace="trace with context",
+                confidence=0.8,
+                timestamp=datetime.now(_UTC) - timedelta(minutes=5),
+                pre_decision_context=bundle,
+            )
+        )
+        client = TestClient(_make_app(decision_store=store))
+        resp = client.get("/api/dashboard/decisions/recent")
+        assert resp.status_code == 200
+        d = resp.json()["decisions"][0]
+        assert "pre_decision_context" in d
+        pdc = d["pre_decision_context"]
+        assert pdc is not None
+        assert pdc["market_state"]["regime"] == "ranging"
+        assert pdc["portfolio_state"]["gross_exposure"] == 0.3
+        # AC2.a — per-surface availability flags survive the dashboard hop.
+        assert pdc["evaluator_verdicts_available"] is False
+        assert pdc["market_state_available"] is True
+        # AC4.a — the gaps list lets the dashboard back-link to FR12 audit events.
+        assert len(pdc["gaps"]) == 1
+        assert pdc["gaps"][0]["surface"] == "evaluators"
+        assert pdc["gaps"][0]["reason"] == "subscriber_not_wired"
+
+    def test_recent_returns_null_pre_decision_context_for_legacy_records(self):
+        store = DecisionStore()
+        store.record(
+            DecisionRecord(
+                strategy_id="legacy-strat",
+                action="EXECUTE",
+                reasoning_trace="historical",
+                confidence=0.7,
+                timestamp=datetime.now(_UTC) - timedelta(minutes=2),
+                # pre_decision_context intentionally omitted to mimic
+                # pre-EPIC-#122 historical entries.
+            )
+        )
+        client = TestClient(_make_app(decision_store=store))
+        resp = client.get("/api/dashboard/decisions/recent")
+        assert resp.status_code == 200
+        d = resp.json()["decisions"][0]
+        assert "pre_decision_context" in d
+        assert d["pre_decision_context"] is None
+
+
 # Suppress pytest collection warning for unused import
 _ = pytest

--- a/tests/unit/test_pre_decision_context_bundle.py
+++ b/tests/unit/test_pre_decision_context_bundle.py
@@ -432,3 +432,279 @@ def test_action_classifier_omits_bundle_when_absent():
         ctx, code_result, ctx.regime, strategy_result
     )
     assert "pre_decision_context" not in user_context
+
+
+# ----------------------------------------------------------------------
+# AC2 — missing-context handling (per-surface availability + gap log)
+# ----------------------------------------------------------------------
+
+
+def test_pre_decision_context_defaults_all_surfaces_available():
+    """AC2.a — happy-path bundle has every flag at True and no gaps."""
+    bundle = _build_bundle()
+    assert bundle.market_state_available is True
+    assert bundle.portfolio_state_available is True
+    assert bundle.evaluator_verdicts_available is True
+    assert bundle.characterization_available is True
+    assert bundle.gaps == []
+
+
+@pytest.mark.asyncio
+async def test_assemble_flags_evaluators_unavailable_when_subscriber_missing(
+    fake_evaluator_subscriber,  # noqa: ARG001 — fixture present for parity
+):
+    """AC2.a + AC2.b — no evaluator subscriber wired flips the flag AND
+    records a structured gap ready for FR12 audit-trail persistence."""
+    builder = _make_builder_with_mocked_http(
+        characterization_status=200,
+        evaluator_subscriber=None,  # explicit missing wiring
+    )
+
+    bundle = await builder.assemble_pre_decision_context(
+        correlation_id="cid-ev-miss",
+        regime=RegimeResult(
+            regime=RegimeEnum.RANGING,
+            regime_confidence=ConfidenceLevel.MEDIUM,
+            volatility_level=VolatilityLevel.MEDIUM,
+            primary_signal="ok",
+            thought_trace="ok",
+        ),
+        market_signals=MarketSignals(
+            signal_summary="m",
+            current_price=1.0,
+            volatility_percentile=0.5,
+            trend_strength=0.0,
+            price_action_character="n",
+        ),
+        portfolio=PortfolioSummary(
+            gross_exposure=0.0,
+            same_asset_pct=0.0,
+            open_positions_count=0,
+        ),
+        env_stats={
+            "global_drawdown_pct": 0.0,
+            "available_capital_usd": 0.0,
+            "open_orders_global": 0,
+            "open_orders_symbol": 0,
+        },
+        strategy_id="strat-ev",
+        strategy_revision_id=None,
+    )
+
+    assert bundle.evaluator_verdicts == {}
+    assert bundle.evaluator_verdicts_available is False
+    # AC2.a — other surfaces stay True; gap is per-surface, not blanket.
+    assert bundle.market_state_available is True
+    assert bundle.portfolio_state_available is True
+    assert bundle.characterization_available is True
+    assert any(
+        g.surface == "evaluators" and "subscriber_not_wired" in g.reason
+        for g in bundle.gaps
+    )
+    await builder.close()
+
+
+@pytest.mark.asyncio
+async def test_assemble_flags_characterization_unavailable_on_endpoint_500(
+    fake_evaluator_subscriber,
+):
+    """AC2.a + AC2.b — data-manager 500 with a revision id flips the
+    flag and records a gap with the HTTP status in the reason."""
+    builder = _make_builder_with_mocked_http(
+        characterization_status=500,
+        evaluator_subscriber=fake_evaluator_subscriber,
+    )
+
+    bundle = await builder.assemble_pre_decision_context(
+        correlation_id="cid-char-500",
+        regime=RegimeResult(
+            regime=RegimeEnum.RANGING,
+            regime_confidence=ConfidenceLevel.MEDIUM,
+            volatility_level=VolatilityLevel.MEDIUM,
+            primary_signal="ok",
+            thought_trace="ok",
+        ),
+        market_signals=MarketSignals(
+            signal_summary="m",
+            current_price=1.0,
+            volatility_percentile=0.5,
+            trend_strength=0.0,
+            price_action_character="n",
+        ),
+        portfolio=PortfolioSummary(
+            gross_exposure=0.0,
+            same_asset_pct=0.0,
+            open_positions_count=0,
+        ),
+        env_stats={
+            "global_drawdown_pct": 0.0,
+            "available_capital_usd": 0.0,
+            "open_orders_global": 0,
+            "open_orders_symbol": 0,
+        },
+        strategy_id="strat-char",
+        strategy_revision_id="srev_aaaaaaaaaaaa_bbbbbbbbbbbb",
+    )
+
+    assert bundle.characterization is None
+    assert bundle.characterization_available is False
+    # legacy "no revision id" path is NOT a gap — make sure the gap
+    # reason actually mentions the endpoint status.
+    char_gaps = [g for g in bundle.gaps if g.surface == "characterization"]
+    assert len(char_gaps) == 1
+    assert "500" in char_gaps[0].reason
+    await builder.close()
+
+
+@pytest.mark.asyncio
+async def test_assemble_no_gap_when_no_revision_id(
+    fake_evaluator_subscriber,
+):
+    """AC2.a edge — legacy (no revision id) is the steady-state path:
+    characterization=None must stay flagged 'available' so consumers do
+    not mistake "intent is unrevisioned" for a missing surface."""
+    builder = _make_builder_with_mocked_http(
+        characterization_status=200,
+        evaluator_subscriber=fake_evaluator_subscriber,
+    )
+
+    bundle = await builder.assemble_pre_decision_context(
+        correlation_id="cid-legacy",
+        regime=RegimeResult(
+            regime=RegimeEnum.RANGING,
+            regime_confidence=ConfidenceLevel.MEDIUM,
+            volatility_level=VolatilityLevel.MEDIUM,
+            primary_signal="ok",
+            thought_trace="ok",
+        ),
+        market_signals=MarketSignals(
+            signal_summary="m",
+            current_price=1.0,
+            volatility_percentile=0.5,
+            trend_strength=0.0,
+            price_action_character="n",
+        ),
+        portfolio=PortfolioSummary(
+            gross_exposure=0.0,
+            same_asset_pct=0.0,
+            open_positions_count=0,
+        ),
+        env_stats={
+            "global_drawdown_pct": 0.0,
+            "available_capital_usd": 0.0,
+            "open_orders_global": 0,
+            "open_orders_symbol": 0,
+        },
+        strategy_id="strat-legacy",
+        strategy_revision_id=None,
+    )
+
+    assert bundle.characterization is None
+    assert bundle.characterization_available is True
+    assert not any(g.surface == "characterization" for g in bundle.gaps)
+    await builder.close()
+
+
+@pytest.mark.asyncio
+async def test_assemble_propagates_caller_availability_map(
+    fake_evaluator_subscriber,
+):
+    """AC2.a — when build() detected market/portfolio fetch failures it
+    passes an availability map; assemble() must surface those flags + the
+    gaps it received without dropping them."""
+    from cio.models import ContextGap
+
+    caller_gaps = [
+        ContextGap(surface="market", reason="fetch_error: simulated 500"),
+        ContextGap(surface="portfolio", reason="fetch_error: timeout"),
+    ]
+    caller_avail = {
+        "market": False,
+        "portfolio": False,
+        "evaluators": True,
+        "characterization": True,
+    }
+
+    builder = _make_builder_with_mocked_http(
+        characterization_status=200,
+        evaluator_subscriber=fake_evaluator_subscriber,
+    )
+
+    bundle = await builder.assemble_pre_decision_context(
+        correlation_id="cid-upstream-fail",
+        regime=RegimeResult(
+            regime=RegimeEnum.RANGING,
+            regime_confidence=ConfidenceLevel.MEDIUM,
+            volatility_level=VolatilityLevel.MEDIUM,
+            primary_signal="error",
+            thought_trace="upstream",
+        ),
+        market_signals=MarketSignals(
+            signal_summary="m",
+            current_price=1.0,
+            volatility_percentile=0.5,
+            trend_strength=0.0,
+            price_action_character="n",
+        ),
+        portfolio=PortfolioSummary(
+            gross_exposure=1.0,
+            same_asset_pct=1.0,
+            open_positions_count=999,
+        ),
+        env_stats={
+            "global_drawdown_pct": 1.0,
+            "available_capital_usd": 0.0,
+            "open_orders_global": 999,
+            "open_orders_symbol": 0,
+        },
+        strategy_id="strat-up",
+        strategy_revision_id=None,
+        gaps=caller_gaps,
+        availability=caller_avail,
+    )
+
+    assert bundle.market_state_available is False
+    assert bundle.portfolio_state_available is False
+    assert bundle.evaluator_verdicts_available is True
+    surfaces = {g.surface for g in bundle.gaps}
+    assert "market" in surfaces
+    assert "portfolio" in surfaces
+    await builder.close()
+
+
+@pytest.mark.asyncio
+async def test_fetch_regime_records_gap_on_data_manager_empty():
+    """AC2.b — the existing "200 OK with empty metadata" branch on the
+    Data Manager regime endpoint is a measurable outage from the bundle's
+    perspective; it should produce a `market` gap when collectors are
+    passed in."""
+    from cio.models import ContextGap
+
+    builder = _make_builder_with_mocked_http(
+        characterization_status=200,
+        evaluator_subscriber=None,
+    )
+    # Replace the AsyncMock get with one that returns the
+    # "No regime data" metadata signature.
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "pair": "BTCUSDT",
+        "metric": "regime",
+        "data": None,
+        "metadata": {"message": "No regime data available"},
+    }
+    builder.client.get = AsyncMock(return_value=mock_response)
+
+    gaps: list[ContextGap] = []
+    availability = {"market": True}
+    result = await builder._fetch_regime(
+        "BTCUSDT",
+        "cid-empty",
+        gaps=gaps,
+        availability=availability,
+    )
+    assert result.primary_signal == "data_manager_empty"
+    assert availability["market"] is False
+    assert any(g.surface == "market" for g in gaps)
+    await builder.close()

--- a/tests/unit/test_router_context_gap_publish.py
+++ b/tests/unit/test_router_context_gap_publish.py
@@ -1,0 +1,223 @@
+"""P1.4-AC2.b (#132) — OutputRouter publishes context-gap audit events.
+
+When the PreDecisionContext bundle carries one or more ContextGap entries
+(populated by ContextBuilder during assembly), the router must emit one
+``cio.context.gap.<surface>`` NATS message per gap at dispatch time so the
+data-manager FR12 audit-trail consumer can persist them keyed by
+``decision_id``. The decision itself must still proceed — gap publishing
+is best-effort and must not block dispatch on a NATS hiccup.
+
+Scope: producer-side only. The consumer (data-manager#179 follow-up)
+subscribes to ``cio.context.gap.>`` and is out of scope for this ticket.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cio.core.decision_store import DecisionStore
+from cio.core.router import OutputRouter
+from cio.models import (
+    ActionType,
+    ActivationRecommendation,
+    CharacterizationRef,
+    ConfidenceLevel,
+    ContextGap,
+    DecisionResult,
+    EvaluatorVerdict,
+    HealthStatus,
+    MarketState,
+    PortfolioState,
+    PreDecisionContext,
+    RegimeFit,
+    TriggerContext,
+)
+from cio.models.enums import RegimeEnum, VolatilityLevel
+
+
+def _make_decision(action: ActionType) -> DecisionResult:
+    return DecisionResult(
+        hard_blocked=False,
+        ev_passes=True,
+        cost_viable=True,
+        regime_confidence=ConfidenceLevel.HIGH,
+        regime_fit=RegimeFit.GOOD,
+        strategy_health=HealthStatus.HEALTHY,
+        activation_recommendation=ActivationRecommendation.RUN,
+        action=action,
+        justification="gap-publish test",
+        thought_trace="trace",
+    )
+
+
+def _make_bundle(*, with_gaps: bool) -> PreDecisionContext:
+    return PreDecisionContext(
+        market_state=MarketState(
+            regime=RegimeEnum.RANGING,
+            regime_confidence=ConfidenceLevel.MEDIUM,
+            volatility_level=VolatilityLevel.MEDIUM,
+            current_price=10000.0,
+            primary_signal="ok",
+        ),
+        portfolio_state=PortfolioState(
+            gross_exposure=0.1,
+            same_asset_pct=0.05,
+            open_positions_count=1,
+            global_drawdown_pct=0.0,
+            available_capital_usd=5000.0,
+            open_orders_global=0,
+            open_orders_symbol=0,
+        ),
+        evaluator_verdicts={
+            "ingest": EvaluatorVerdict(subsystem="ingest", verdict="healthy", reason="")
+        },
+        characterization=CharacterizationRef(
+            strategy_id="strat-gap",
+            strategy_revision_id="srev_aaaaaaaaaaaa_bbbbbbbbbbbb",
+        ),
+        evaluator_verdicts_available=not with_gaps,
+        characterization_available=True,
+        gaps=(
+            [
+                ContextGap(surface="evaluators", reason="subscriber_not_wired"),
+                ContextGap(surface="characterization", reason="endpoint_500"),
+            ]
+            if with_gaps
+            else []
+        ),
+    )
+
+
+def _make_context(*, bundle: PreDecisionContext | None) -> TriggerContext:
+    ctx = MagicMock(spec=TriggerContext)
+    ctx.strategy_id = "strat-gap"
+    ctx.decision_id = "decision-gap-132"
+    ctx.correlation_id = "corr-gap-132"
+    ctx.trigger_payload = {"symbol": "BTCUSDT"}
+    ctx.strategy_revision_id = "srev_aaaaaaaaaaaa_bbbbbbbbbbbb"
+    ctx.pre_decision_context = bundle
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_router_publishes_one_gap_event_per_surface():
+    """AC2.b — every ContextGap on the bundle becomes one NATS publish on
+    ``cio.context.gap.<surface>`` with a JSON payload containing
+    decision_id, correlation_id, strategy_id, surface, reason, observed_at."""
+    bundle = _make_bundle(with_gaps=True)
+    ctx = _make_context(bundle=bundle)
+    mock_nc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=AsyncMock(),
+        ta_bot_url="http://ta-bot",
+        decision_store=DecisionStore(),
+    )
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(ctx, _make_decision(ActionType.ADMIT))
+
+    gap_calls = [
+        c
+        for c in mock_nc.publish.call_args_list
+        if str(c.args[0]).startswith("cio.context.gap.")
+    ]
+    assert len(gap_calls) == 2
+    subjects = {c.args[0] for c in gap_calls}
+    assert subjects == {
+        "cio.context.gap.evaluators",
+        "cio.context.gap.characterization",
+    }
+    for call in gap_calls:
+        payload = json.loads(call.args[1].decode())
+        assert payload["decision_id"] == "decision-gap-132"
+        assert payload["correlation_id"] == "corr-gap-132"
+        assert payload["strategy_id"] == "strat-gap"
+        assert payload["surface"] in {"evaluators", "characterization"}
+        assert payload["reason"]
+        assert "observed_at" in payload
+
+
+@pytest.mark.asyncio
+async def test_router_does_not_publish_when_no_gaps():
+    """AC2.b — happy-path bundle (empty gaps list) emits zero context.gap
+    messages; the rest of the dispatch is unaffected."""
+    bundle = _make_bundle(with_gaps=False)
+    ctx = _make_context(bundle=bundle)
+    mock_nc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=AsyncMock(),
+        ta_bot_url="http://ta-bot",
+        decision_store=DecisionStore(),
+    )
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(ctx, _make_decision(ActionType.ADMIT))
+
+    gap_calls = [
+        c
+        for c in mock_nc.publish.call_args_list
+        if str(c.args[0]).startswith("cio.context.gap.")
+    ]
+    assert gap_calls == []
+
+
+@pytest.mark.asyncio
+async def test_router_swallows_publish_errors_on_gap_events():
+    """AC2.b — gap publication is best-effort: a NATS publish exception
+    must not propagate out of route() because the decision has already
+    been committed at this point."""
+    bundle = _make_bundle(with_gaps=True)
+    ctx = _make_context(bundle=bundle)
+    mock_nc = AsyncMock()
+
+    async def _publish_side_effect(subject: str, payload: bytes) -> None:
+        if subject.startswith("cio.context.gap."):
+            raise RuntimeError("simulated NATS outage")
+
+    mock_nc.publish.side_effect = _publish_side_effect
+
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=AsyncMock(),
+        ta_bot_url="http://ta-bot",
+        decision_store=DecisionStore(),
+    )
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        # Must not raise.
+        await router.route(ctx, _make_decision(ActionType.ADMIT))
+
+
+@pytest.mark.asyncio
+async def test_router_stores_bundle_on_decision_record():
+    """AC4.a — DecisionStore.record(...) captures the bundle so
+    /api/dashboard/decisions/recent can return it."""
+    bundle = _make_bundle(with_gaps=True)
+    ctx = _make_context(bundle=bundle)
+    store = DecisionStore()
+    router = OutputRouter(
+        nats_client=AsyncMock(),
+        vector_client=AsyncMock(),
+        ta_bot_url="http://ta-bot",
+        decision_store=store,
+    )
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(ctx, _make_decision(ActionType.ADMIT))
+
+    from datetime import datetime, timedelta
+
+    recent = store.recent(datetime.now(UTC) - timedelta(minutes=1))
+    assert len(recent) == 1
+    rec = recent[0]
+    assert rec.pre_decision_context is not None
+    assert rec.pre_decision_context.evaluator_verdicts_available is False
+    assert len(rec.pre_decision_context.gaps) == 2
+    assert rec.decision_id == "decision-gap-132"


### PR DESCRIPTION
## Summary

Implements **AC2** (missing-context handling) + **AC4** (operator dashboard inspection) of EPIC [petrosa-cio#122](https://github.com/PetroSa2/petrosa-cio/issues/122). Builds on top of [#131](https://github.com/PetroSa2/petrosa-cio/issues/131) (`PreDecisionContext` bundle assembly).

Closes #132.

### AC2.a — Per-surface availability flags
Adds `market_state_available`, `portfolio_state_available`, `evaluator_verdicts_available`, `characterization_available` (default `True`) to `PreDecisionContext`. When a surface fetch falls back to safe defaults, the corresponding flag flips to `False` and the typed field stays populated with the conservative snapshot so downstream personas + dashboard can tell live observation from fallback.

### AC2.b — Gap logged + persisted via FR12
`PreDecisionContext.gaps: list[ContextGap]` records each missing-surface event (`surface`, `reason`, `observed_at`). `OutputRouter.route` publishes one NATS message per gap on `cio.context.gap.<surface>` after the decision is committed, carrying `decision_id`, `correlation_id`, `strategy_id`, `surface`, `reason`, `observed_at`. Publish is **best-effort** — a NATS hiccup must not block the dispatch. data-manager FR12 audit-trail consumer (sibling work) subscribes to `cio.context.gap.>` and persists keyed by `decision_id`.

### AC4.a — Dashboard endpoint enrichment
`DecisionRecord` carries `pre_decision_context: PreDecisionContext | None`. `GET /api/dashboard/decisions/recent` returns the bundle verbatim per record. Pre-EPIC-#122 historical records (no bundle attached) render with `null` so the dashboard can show "context not recorded" deterministically. The bundle's `gaps` list is the back-link to FR12 audit events.

### AC4.b — Tests
- `test_pre_decision_context_bundle.py` — 6 new tests for AC2 detection paths (subscriber missing, endpoint 500, no-revision-id, upstream availability propagation, data-manager-empty regime).
- `test_router_context_gap_publish.py` — new file, 4 tests for AC2.b publish behavior and AC4.a bundle round-trip via `DecisionStore.record`.
- `test_dashboard_api.py` — 2 new tests for AC4.a (bundle survives the HTTP hop; legacy records return `null`).
- `test_nats_to_nats_loop.py` — integration now asserts the gap event publish (`cio.context.gap.evaluators`) when no evaluator subscriber is wired (mirrors today's `main.py` path).

## Test plan
- [x] `make pipeline` clean (clean → format → lint → test → security) — 283/283 tests pass, coverage 84%
- [x] Existing `test_pre_decision_context_bundle.py` happy-path tests still pass (no regression on AC1)
- [x] `test_cold_path.py` still passes (legacy `_fetch_regime("BTCUSDT", "test-correlation")` signature preserved via optional kwargs)
- [x] `test_router_authority.py`, `test_router_lifecycle_actions.py`, `test_router_governance_actions.py` still pass (`MagicMock(spec=TriggerContext).pre_decision_context` resolves to `None`, gap-publish loop short-circuits)
- [ ] Manual: smoke `/api/dashboard/decisions/recent` against a running CIO, verify `pre_decision_context` key present
- [ ] Manual: trigger a missing-subscriber path, verify `cio.context.gap.evaluators` is emitted on the NATS bus

🤖 Generated with [Claude Code](https://claude.com/claude-code)