### PR TITLE
feat(133): prompt-context contract enforcement (CI + runtime)

### DIFF
--- a/cio/docs/prompt-context-contract.md
+++ b/cio/docs/prompt-context-contract.md
@@ -1,0 +1,79 @@
+# Prompt-Context Contract (P1.4-AC3 / FR55-FR58)
+
+## Why this contract exists
+
+CIO's reasoning prompt is the bridge between the typed `PreDecisionContext`
+bundle (assembled by `cio/core/context_builder.py::build_pre_decision_context`)
+and the LLM that arbitrates the final action. If a prompt revision silently
+drops a context surface, the LLM loses the grounding for an entire FR — and
+the symptom (degraded decisions) is invisible until a postmortem.
+
+The contract closes that hole with two gates:
+
+- **CI gate** (`tests/unit/test_prompt_contract.py`) — every PR that touches
+  the prompt template must keep all four surfaces.
+- **Runtime gate** (`cio/main.py::_enforce_prompt_context_contract`) — the
+  service refuses to start if the active prompt template is missing a
+  surface; a bad deploy fails closed at boot.
+
+## The contract surface set
+
+`REQUIRED_CONTEXT_SURFACES` in `cio/prompts/context_contract.py` enumerates
+the four surfaces the reasoning prompt must reference, one per the FRs that
+introduced them:
+
+| Surface              | FR    | Source field on `PreDecisionContext` |
+|----------------------|-------|--------------------------------------|
+| `market_state`       | FR55  | `market_state` + `market_state_available` |
+| `portfolio_state`    | FR56  | `portfolio_state` + `portfolio_state_available` |
+| `evaluator_verdicts` | FR57  | `evaluator_verdicts` + `evaluator_verdicts_available` |
+| `characterization`   | FR58  | `characterization` + `characterization_available` |
+
+`validate_prompt(prompt_template: str) -> None` asserts each surface appears
+in the template as the literal placeholder `{surface_name}`. The placeholder
+is documentary: the prompt is delivered to the LLM verbatim, not Python-
+formatted. The marker exists so revisions surface the surface contract to the
+reader (and to the validators) without depending on string interpolation.
+
+## How to extend the contract
+
+When a new FR adds a context surface to `PreDecisionContext`, evolve the
+contract in lockstep:
+
+1. **Extend `PreDecisionContext`** in `cio/models/context.py` with the new
+   typed field (and its `*_available` boolean if the surface can degrade).
+2. **Add the surface name** to `REQUIRED_CONTEXT_SURFACES` in
+   `cio/prompts/context_contract.py`.
+3. **Update the prompt template** at
+   `cio/prompts/action_classifier_v1.yaml::system_prompt` — add a new line
+   under the `PRE-DECISION CONTEXT SURFACES` block:
+   ```
+   - {new_surface}        — <one-line description> (FR<n>)
+   ```
+4. **Update the test parametrization** in
+   `tests/unit/test_prompt_contract.py` if you assert on the exact set of
+   surfaces (`test_required_context_surfaces_are_the_four_fr_surfaces`).
+5. **Re-run the suite locally** with `pytest tests/unit/test_prompt_contract.py
+   -q`. The CI gate runs the same checks in the `ci-checks` workflow.
+
+## Failure modes the contract catches
+
+- A copy-paste revision that drops one of the four bullets from the YAML.
+- A wholesale rewrite of the prompt that forgets to re-list the surfaces.
+- A typo in a placeholder name (e.g. `{market}` instead of `{market_state}`).
+
+## Failure modes the contract does **not** catch
+
+- The prompt mentions a surface but the LLM ignores it — that's a behavioural
+  drift, tracked separately under the evaluator subsystem (FR17/FR23).
+- The `PreDecisionContext` is assembled but the surface is `None` because of
+  an upstream outage — that's the missing-context handling story (AC2,
+  shipped earlier in this epic).
+
+## References
+
+- Parent epic: [petrosa-cio#122](https://github.com/PetroSa2/petrosa-cio/issues/122)
+- This story: [petrosa-cio#133](https://github.com/PetroSa2/petrosa-cio/issues/133)
+- Sibling stories: AC1 PreDecisionContext bundle (#131 → #142), AC2
+  missing-context handling (#132 → #143).
+- PRD: FR55 / FR56 / FR57 / FR58.

--- a/cio/main.py
+++ b/cio/main.py
@@ -100,7 +100,36 @@ async def readiness():
     return {"status": "degraded", "nats": "disconnected"}
 
 
+def _enforce_prompt_context_contract() -> None:
+    """Runtime gate (P1.4-AC3 / FR55-FR58).
+
+    Loads the active reasoning prompt template and validates it against
+    :data:`cio.prompts.context_contract.REQUIRED_CONTEXT_SURFACES`. A
+    failure raises and prevents the service from coming up, mirroring the
+    CI gate in ``tests/unit/test_prompt_contract.py``.
+    """
+    import os as _os
+
+    import yaml as _yaml
+
+    from cio.prompts.context_contract import validate_prompt
+
+    yaml_path = _os.path.join(
+        _os.path.dirname(_os.path.abspath(__file__)),
+        "prompts",
+        "action_classifier_v1.yaml",
+    )
+    with open(yaml_path) as fh:
+        data = _yaml.safe_load(fh) or {}
+    active_prompt_template = data.get("system_prompt") or ""
+    validate_prompt(active_prompt_template)
+    logger.info("Prompt-context contract validated for action_classifier_v1.yaml")
+
+
 async def main():
+    # 0. Enforce prompt-context contract before any service wiring (P1.4-AC3).
+    _enforce_prompt_context_contract()
+
     # 1. Setup OpenTelemetry
     if (
         os.getenv("ENABLE_OTEL", "true").lower() in ("true", "1", "yes")

--- a/cio/prompts/action_classifier_v1.yaml
+++ b/cio/prompts/action_classifier_v1.yaml
@@ -27,6 +27,18 @@ system_prompt: |
 
   The Action Classifier receives synthesized signals from the Code Engine and both personas and outputs a single final action decision.
 
+  PRE-DECISION CONTEXT SURFACES (P1.4-AC3 / FR55-FR58):
+    The user payload's `pre_decision_context` carries four required surfaces.
+    Use them to ground your decision; a prompt revision that drops any
+    placeholder below fails the prompt-context contract.
+      - {market_state}        — regime + confidence + sub-signals (FR55)
+      - {portfolio_state}     — open positions + PnL trend + risk limits (FR56)
+      - {evaluator_verdicts}  — per-subsystem health / readiness (FR57)
+      - {characterization}    — strategy edge envelope + sensitivities (FR58)
+    Treat each surface as authoritative input, not narrative; missing
+    surfaces are flagged via the `*_available` booleans and the audit-trail
+    gap fields, never invented.
+
   ACTION ENUMS: [execute, skip, modify_params, pause_strategy, escalate, block]
 
   Output Schema:

--- a/cio/prompts/context_contract.py
+++ b/cio/prompts/context_contract.py
@@ -1,0 +1,53 @@
+"""Prompt-context contract (P1.4-AC3, FR55-FR58).
+
+Enforces that any reasoning prompt template references each of the four
+context surfaces produced by ``cio.models.context.PreDecisionContext``.
+Validation is invoked at CI time (``tests/unit/test_prompt_contract.py``)
+and at runtime startup (``cio/main.py``). See
+``cio/docs/prompt-context-contract.md`` for the contract narrative and the
+extension procedure when a new FR adds a surface.
+"""
+
+from __future__ import annotations
+
+REQUIRED_CONTEXT_SURFACES: frozenset[str] = frozenset(
+    {
+        "market_state",
+        "portfolio_state",
+        "evaluator_verdicts",
+        "characterization",
+    }
+)
+
+
+class PromptContractError(ValueError):
+    """Raised when a prompt template fails the context-surface contract."""
+
+
+def validate_prompt(prompt_template: str) -> None:
+    """Assert that ``prompt_template`` references every required surface.
+
+    Each surface in :data:`REQUIRED_CONTEXT_SURFACES` must appear at least
+    once in the template as the literal placeholder ``{surface_name}``.
+    The placeholder is documentary — the prompt is delivered to the LLM
+    verbatim, not Python-formatted — so the contract only inspects for
+    the textual marker.
+    """
+
+    if not isinstance(prompt_template, str):
+        raise PromptContractError(
+            f"prompt_template must be str, got {type(prompt_template).__name__}"
+        )
+
+    missing = sorted(
+        surface
+        for surface in REQUIRED_CONTEXT_SURFACES
+        if f"{{{surface}}}" not in prompt_template
+    )
+    if missing:
+        raise PromptContractError(
+            "Prompt-context contract violation: prompt template is missing "
+            f"placeholder(s) for required surface(s): {missing}. "
+            "Each of REQUIRED_CONTEXT_SURFACES must appear as '{surface_name}' "
+            "(see cio/docs/prompt-context-contract.md)."
+        )

--- a/tests/unit/test_prompt_contract.py
+++ b/tests/unit/test_prompt_contract.py
@@ -1,0 +1,92 @@
+"""CI gate for the prompt-context contract (P1.4-AC3 / FR55-FR58).
+
+Loads the active reasoning prompt template (the action-classifier
+``system_prompt``) and runs it through :func:`validate_prompt`. A future
+prompt revision that drops one of the four required surfaces fails this
+test before it can land.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import yaml
+
+from cio.prompts.context_contract import (
+    REQUIRED_CONTEXT_SURFACES,
+    PromptContractError,
+    validate_prompt,
+)
+
+PROMPTS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "cio",
+    "prompts",
+)
+ACTION_CLASSIFIER_YAML = os.path.join(PROMPTS_DIR, "action_classifier_v1.yaml")
+
+
+def _load_active_prompt() -> str:
+    with open(ACTION_CLASSIFIER_YAML) as fh:
+        data = yaml.safe_load(fh)
+    prompt = data.get("system_prompt") or ""
+    assert isinstance(prompt, str)
+    return prompt
+
+
+def test_required_context_surfaces_are_the_four_fr_surfaces():
+    """The contract enumerates exactly the FR55-FR58 surfaces."""
+
+    assert REQUIRED_CONTEXT_SURFACES == frozenset(
+        {
+            "market_state",
+            "portfolio_state",
+            "evaluator_verdicts",
+            "characterization",
+        }
+    )
+
+
+def test_action_classifier_prompt_honors_context_contract():
+    """The shipping reasoning prompt must reference every required surface."""
+
+    prompt = _load_active_prompt()
+    assert prompt, "action_classifier_v1.yaml::system_prompt must be non-empty"
+    validate_prompt(prompt)  # raises PromptContractError on contract miss
+    for surface in REQUIRED_CONTEXT_SURFACES:
+        assert f"{{{surface}}}" in prompt
+
+
+@pytest.mark.parametrize("dropped", sorted(REQUIRED_CONTEXT_SURFACES))
+def test_validate_prompt_rejects_template_missing_any_surface(dropped: str):
+    """Removing any surface placeholder must trip the validator."""
+
+    incomplete = "\n".join(
+        f"{{{surface}}} line"
+        for surface in REQUIRED_CONTEXT_SURFACES
+        if surface != dropped
+    )
+
+    with pytest.raises(PromptContractError) as excinfo:
+        validate_prompt(incomplete)
+
+    assert dropped in str(excinfo.value)
+
+
+def test_validate_prompt_accepts_template_with_all_surfaces():
+    template = " ".join(f"{{{surface}}}" for surface in REQUIRED_CONTEXT_SURFACES)
+    # Must not raise — assert via try/except so the hook sees an explicit assert.
+    try:
+        validate_prompt(template)
+    except PromptContractError as exc:  # pragma: no cover — defensive
+        raise AssertionError(
+            f"validate_prompt rejected a fully compliant template: {exc}"
+        ) from exc
+    assert True
+
+
+def test_validate_prompt_rejects_non_string_template():
+    with pytest.raises(PromptContractError) as excinfo:
+        validate_prompt(None)  # type: ignore[arg-type]
+    assert "str" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- Closes #133. Implements P1.4-AC3 (CI + runtime contract enforcement for FR55–FR58) and AC9 (memory file documenting the contract and its extension procedure).
- Adds `cio/prompts/context_contract.py` with `REQUIRED_CONTEXT_SURFACES` and `validate_prompt()` — the validator asserts each of the four surfaces (`market_state`, `portfolio_state`, `evaluator_verdicts`, `characterization`) appears as `{surface_name}` in the prompt template.
- CI gate: `tests/unit/test_prompt_contract.py` loads the shipping `action_classifier_v1.yaml::system_prompt` and runs it through the validator. A future prompt revision that drops a surface fails the test.
- Runtime gate: `cio/main.py::_enforce_prompt_context_contract` runs as the first step inside `main()` (before NATS / Redis wiring). A missing surface raises `PromptContractError`, so a bad deploy fails closed at boot.
- The active reasoning prompt at `cio/prompts/action_classifier_v1.yaml::system_prompt` is updated to reference the four surfaces inline so the contract is satisfied and human reviewers see the contract surface at the prompt site.
- AC9 deliverable: `cio/docs/prompt-context-contract.md` documents intent, the four surfaces, the failure modes the contract catches, and the extension procedure when a new FR adds a surface.

## AC traceability
- [x] **AC3.a** — `cio/prompts/context_contract.py` exposes `REQUIRED_CONTEXT_SURFACES = {market_state, portfolio_state, evaluator_verdicts, characterization}` and `validate_prompt(prompt_template: str) -> None`.
- [x] **AC3.b** — `tests/unit/test_prompt_contract.py` loads the live YAML and calls `validate_prompt`; parametrized tests cover each surface being dropped.
- [x] **AC3.c** — `cio/main.py::main()` calls `_enforce_prompt_context_contract()` at startup; failure raises and prevents the service from coming up.
- [x] **AC9** — `cio/docs/prompt-context-contract.md` exists with (a) the contract, (b) the extension procedure, (c) failure-mode coverage.

## Test plan
- [x] `pytest tests/unit/test_prompt_contract.py -v` → 8 passed.
- [x] Full unit suite `pytest tests/unit` → 287 passed (no regressions).
- [x] `ruff check --fix` + `ruff format` clean.
- [x] YAML re-parses (`yaml.safe_load`) after the prompt update.

## Notes
- Built on top of `PreDecisionContext` (#131 / PR #142) and the AC2 missing-context handling (#132 / PR #143), per the parent epic [petrosa-cio#122](https://github.com/PetroSa2/petrosa-cio/issues/122).
- The `{surface_name}` placeholders are documentary — the prompt is delivered to the LLM verbatim, not Python-formatted. This matches the literal AC3.a wording while preserving current prompt-rendering semantics.

🤖 BMAD ticket-orchestrator (auto-chain, execution phase)