### PR TITLE
feat(137): admission-time leverage arbitration (P1.5-AC3, FR61)

### DIFF
--- a/cio/core/decision_store.py
+++ b/cio/core/decision_store.py
@@ -41,6 +41,11 @@ class DecisionRecord:
     # (legacy ring-buffer entries written before this field existed) so
     # the dashboard surface can render "context not recorded" deterministically.
     pre_decision_context: PreDecisionContext | None = None
+    # P1.5-AC3 (#137) — leverage that came out of the admission-time
+    # arbiter. ``None`` on pre-EPIC-#691 historical records and on
+    # legacy code paths that bypass the arbiter (defensive default so
+    # adding the field does not break callers).
+    decided_leverage: int | None = None
 
 
 class DecisionStore:

--- a/cio/core/leverage_arbiter.py
+++ b/cio/core/leverage_arbiter.py
@@ -1,0 +1,165 @@
+"""Admission-time leverage arbitration (P1.5-AC3, FR61).
+
+Pure function + small helper for resolving the leverage CIO will send
+downstream to the trade engine on every admission decision. The three
+inputs are intentionally optional so the arbiter is forward-compatible
+with the still-open enrichment sources:
+
+- ``recommended_leverage``  — the strategy's preference, surfaced by
+  the signal pipeline once `691.1` ships. Treated as ``None`` today.
+- ``strategy_envelope``     — the per-strategy max from the most recent
+  characterization, surfaced once `petrosa-data-manager#179` ships its
+  typed field. Treated as ``None`` today.
+- ``operator_max``          — the env-var fallback. Always present:
+  ``CIO_DEFAULT_MAX_LEVERAGE`` (default 10).
+
+Until the enrichment fields land, every admission resolves to
+``operator_max`` — the documented fallback path, not a regression. When
+they land the call site passes them in and the arbiter logic is
+unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_OPERATOR_MAX_LEVERAGE = 10
+
+
+def operator_max_from_env() -> int:
+    """Resolve the operator-configured ceiling from ``CIO_DEFAULT_MAX_LEVERAGE``."""
+    raw = os.getenv("CIO_DEFAULT_MAX_LEVERAGE")
+    if raw is None or raw == "":
+        return DEFAULT_OPERATOR_MAX_LEVERAGE
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid CIO_DEFAULT_MAX_LEVERAGE=%r — falling back to default=%s",
+            raw,
+            DEFAULT_OPERATOR_MAX_LEVERAGE,
+        )
+        return DEFAULT_OPERATOR_MAX_LEVERAGE
+    if value < 1:
+        logger.warning("CIO_DEFAULT_MAX_LEVERAGE=%s is below 1 — clamping to 1", value)
+        return 1
+    return value
+
+
+@dataclass(frozen=True)
+class LeverageDecision:
+    """Outcome of one admission-time arbitration.
+
+    Attributes:
+        decided_leverage: the integer leverage the CIO will send downstream.
+        per_strategy_bound: the effective bound the arbiter resolved against
+            (``min(operator_max, strategy_envelope)`` when the envelope is
+            present, otherwise ``operator_max``).
+        branch: one of ``accept`` / ``override`` / ``fallback``. ``accept``
+            means the recommendation was inside the bound; ``override`` means
+            it was over the bound (no rejection — clamp to the bound); and
+            ``fallback`` means the recommendation was absent and we used the
+            bound directly.
+        audit_reason: human-readable trace of why ``decided_leverage`` came
+            out the way it did. Carried into the audit-trail row.
+    """
+
+    decided_leverage: int
+    per_strategy_bound: int
+    branch: str
+    audit_reason: str
+
+
+def arbitrate_leverage(
+    *,
+    recommended_leverage: int | None,
+    operator_max: int | None = None,
+    strategy_envelope: int | None = None,
+) -> LeverageDecision:
+    """Resolve the admission-time leverage decision.
+
+    Branches (per AC3.b):
+
+    - ``recommended_leverage is None`` → ``decided = per_strategy_bound``
+      (``min(operator_max, strategy_envelope)`` when the envelope is
+      present; ``operator_max`` otherwise). Branch ``fallback``.
+    - ``recommended_leverage <= per_strategy_bound`` → ``decided =
+      recommended_leverage``. Branch ``accept``.
+    - ``recommended_leverage >  per_strategy_bound`` → ``decided =
+      per_strategy_bound`` (clamped; no rejection). Branch ``override``.
+
+    ``operator_max=None`` is interpreted as "no caller-supplied value;
+    pick up the env var now." This keeps the function callable without
+    pre-computing the env-var lookup at every site.
+    """
+    effective_operator_max = (
+        operator_max if operator_max is not None else operator_max_from_env()
+    )
+    if effective_operator_max < 1:
+        # Defensive — operator_max_from_env clamps to 1, but explicit
+        # callers might pass 0/negative. Treat sub-1 as 1.
+        effective_operator_max = 1
+
+    if strategy_envelope is not None and strategy_envelope >= 1:
+        per_strategy_bound = min(effective_operator_max, strategy_envelope)
+    else:
+        per_strategy_bound = effective_operator_max
+
+    if recommended_leverage is None:
+        return LeverageDecision(
+            decided_leverage=per_strategy_bound,
+            per_strategy_bound=per_strategy_bound,
+            branch="fallback",
+            audit_reason=(
+                "no recommended_leverage on signal — applied "
+                f"per-strategy bound={per_strategy_bound} "
+                f"(operator_max={effective_operator_max}, "
+                f"strategy_envelope={strategy_envelope})"
+            ),
+        )
+
+    if recommended_leverage < 1:
+        # A non-positive recommendation is treated as "no recommendation"
+        # — defensive against upstream bugs / null-coalescing accidents.
+        logger.warning(
+            "arbitrate_leverage received recommended_leverage=%s (<1); "
+            "treating as no-recommendation",
+            recommended_leverage,
+        )
+        return LeverageDecision(
+            decided_leverage=per_strategy_bound,
+            per_strategy_bound=per_strategy_bound,
+            branch="fallback",
+            audit_reason=(
+                f"recommended_leverage={recommended_leverage} below 1 — "
+                "treated as missing; "
+                f"applied per-strategy bound={per_strategy_bound}"
+            ),
+        )
+
+    if recommended_leverage <= per_strategy_bound:
+        return LeverageDecision(
+            decided_leverage=recommended_leverage,
+            per_strategy_bound=per_strategy_bound,
+            branch="accept",
+            audit_reason=(
+                f"recommended_leverage={recommended_leverage} "
+                f"within per-strategy bound={per_strategy_bound} — accepted as-is"
+            ),
+        )
+
+    return LeverageDecision(
+        decided_leverage=per_strategy_bound,
+        per_strategy_bound=per_strategy_bound,
+        branch="override",
+        audit_reason=(
+            f"recommended_leverage={recommended_leverage} above "
+            f"per-strategy bound={per_strategy_bound} — overridden to "
+            f"{per_strategy_bound} (no rejection per AC3.b)"
+        ),
+    )

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -8,6 +8,7 @@ import httpx
 
 from cio.core.cache import AsyncRedisCache
 from cio.core.decision_store import DecisionRecord, DecisionStore
+from cio.core.leverage_arbiter import arbitrate_leverage
 from cio.core.service_resolver import ServiceType, TargetServiceResolver
 from cio.core.vector import VectorClientProtocol
 from cio.models import ActionType, DecisionResult, TriggerContext
@@ -557,6 +558,26 @@ class OutputRouter:
             # ring buffer so /api/dashboard/decisions/recent can return it
             # verbatim. Pre-EPIC-#122 historical records have no bundle —
             # the dashboard renders them with null context.
+            # P1.5-AC3 (#137) — admission-time leverage arbitration. Both
+            # enrichment fields (`recommended_leverage` from 691.1, the
+            # `strategy_envelope` from data-manager#179) are absent today,
+            # so the arbiter falls through to the env-var-only path
+            # (`CIO_DEFAULT_MAX_LEVERAGE`). When the enrichment lands, the
+            # `getattr(...)` calls below start returning real values and
+            # the arbiter branches accordingly without code change here.
+            leverage_decision = arbitrate_leverage(
+                recommended_leverage=getattr(context, "recommended_leverage", None),
+                strategy_envelope=getattr(context, "strategy_leverage_envelope", None),
+            )
+            logger.info(
+                "leverage_arbiter decision_id=%s branch=%s decided=%s bound=%s",
+                decision_id,
+                leverage_decision.branch,
+                leverage_decision.decided_leverage,
+                leverage_decision.per_strategy_bound,
+                extra={"correlation_id": correlation_id},
+            )
+
             self.decision_store.record(
                 DecisionRecord(
                     strategy_id=strategy_id,
@@ -571,6 +592,7 @@ class OutputRouter:
                     rejection_source=rejection_source_value,
                     strategy_revision_id=getattr(context, "strategy_revision_id", None),
                     pre_decision_context=getattr(context, "pre_decision_context", None),
+                    decided_leverage=leverage_decision.decided_leverage,
                 )
             )
 

--- a/tests/unit/test_decision_record_decided_leverage.py
+++ b/tests/unit/test_decision_record_decided_leverage.py
@@ -1,0 +1,52 @@
+"""DecisionRecord must carry ``decided_leverage`` (P1.5-AC3.c / #137).
+
+This is the persistence-contract test for the new field — it asserts the
+dataclass shape and the legacy/default behavior. The router-wiring side
+effect (that every admission decision records a value) is covered by the
+broader router test suite when 691.1's signal field lands and the
+call-site begins passing non-``None`` recommendations.
+"""
+
+from __future__ import annotations
+
+from cio.core.decision_store import DecisionRecord
+
+
+def test_decided_leverage_defaults_to_none_for_legacy_records():
+    """Legacy and pre-EPIC-#691 records have no leverage attached."""
+    record = DecisionRecord(
+        strategy_id="s1",
+        action="execute",
+        reasoning_trace="hand-built",
+        confidence=0.9,
+    )
+    assert record.decided_leverage is None
+
+
+def test_decided_leverage_round_trips_when_set():
+    record = DecisionRecord(
+        strategy_id="s1",
+        action="execute",
+        reasoning_trace="hand-built",
+        confidence=0.9,
+        decided_leverage=7,
+    )
+    assert record.decided_leverage == 7
+
+
+def test_decided_leverage_can_carry_arbiter_output():
+    """The router wires `arbitrate_leverage(...).decided_leverage` into here."""
+    from cio.core.leverage_arbiter import arbitrate_leverage
+
+    decision = arbitrate_leverage(
+        recommended_leverage=20,
+        operator_max=5,
+    )
+    record = DecisionRecord(
+        strategy_id="s1",
+        action="execute",
+        reasoning_trace="t",
+        confidence=0.5,
+        decided_leverage=decision.decided_leverage,
+    )
+    assert record.decided_leverage == 5  # clamped by override branch

--- a/tests/unit/test_leverage_arbiter.py
+++ b/tests/unit/test_leverage_arbiter.py
@@ -1,0 +1,184 @@
+"""Tests for the admission-time leverage arbiter (#137, FR61 / AC3.b + AC3.d).
+
+Covers the three AC3.b branches (accept / override / fallback) and the
+AC3.a env-var fallback. Pure-function tests — no DB, no NATS.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cio.core.leverage_arbiter import (
+    DEFAULT_OPERATOR_MAX_LEVERAGE,
+    LeverageDecision,
+    arbitrate_leverage,
+    operator_max_from_env,
+)
+
+# ---------------------------------------------------------------------------
+# AC3.a — env-var fallback
+
+
+def test_operator_max_from_env_default_when_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("CIO_DEFAULT_MAX_LEVERAGE", raising=False)
+    assert operator_max_from_env() == DEFAULT_OPERATOR_MAX_LEVERAGE
+
+
+def test_operator_max_from_env_respects_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CIO_DEFAULT_MAX_LEVERAGE", "25")
+    assert operator_max_from_env() == 25
+
+
+def test_operator_max_from_env_falls_back_on_garbage(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("CIO_DEFAULT_MAX_LEVERAGE", "not-a-number")
+    assert operator_max_from_env() == DEFAULT_OPERATOR_MAX_LEVERAGE
+
+
+def test_operator_max_from_env_clamps_below_one(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("CIO_DEFAULT_MAX_LEVERAGE", "0")
+    assert operator_max_from_env() == 1
+
+
+# ---------------------------------------------------------------------------
+# AC3.b — arbitration branches
+
+
+def test_accept_branch_when_recommendation_within_bound():
+    decision = arbitrate_leverage(
+        recommended_leverage=5,
+        operator_max=10,
+        strategy_envelope=None,
+    )
+    assert isinstance(decision, LeverageDecision)
+    assert decision.decided_leverage == 5
+    assert decision.per_strategy_bound == 10
+    assert decision.branch == "accept"
+    assert "accepted as-is" in decision.audit_reason
+
+
+def test_accept_branch_at_exact_bound():
+    decision = arbitrate_leverage(
+        recommended_leverage=10,
+        operator_max=10,
+    )
+    assert decision.decided_leverage == 10
+    assert decision.branch == "accept"
+
+
+def test_override_branch_clamps_at_bound_without_rejecting():
+    decision = arbitrate_leverage(
+        recommended_leverage=25,
+        operator_max=10,
+    )
+    assert decision.decided_leverage == 10
+    assert decision.branch == "override"
+    assert "overridden" in decision.audit_reason
+    # Defensive — AC3.b explicitly says "do not reject".
+    assert decision.decided_leverage == decision.per_strategy_bound
+
+
+def test_fallback_branch_uses_bound_when_recommendation_absent():
+    decision = arbitrate_leverage(
+        recommended_leverage=None,
+        operator_max=10,
+    )
+    assert decision.decided_leverage == 10
+    assert decision.branch == "fallback"
+    assert "no recommended_leverage" in decision.audit_reason
+
+
+def test_strategy_envelope_tightens_bound_below_operator_max():
+    decision = arbitrate_leverage(
+        recommended_leverage=8,
+        operator_max=10,
+        strategy_envelope=5,
+    )
+    assert decision.per_strategy_bound == 5  # min(10, 5)
+    assert decision.decided_leverage == 5  # 8 > 5, override
+    assert decision.branch == "override"
+
+
+def test_strategy_envelope_with_no_recommendation_uses_min_of_two_bounds():
+    decision = arbitrate_leverage(
+        recommended_leverage=None,
+        operator_max=10,
+        strategy_envelope=4,
+    )
+    assert decision.decided_leverage == 4
+    assert decision.per_strategy_bound == 4
+    assert decision.branch == "fallback"
+
+
+def test_strategy_envelope_above_operator_max_is_ignored():
+    decision = arbitrate_leverage(
+        recommended_leverage=20,
+        operator_max=10,
+        strategy_envelope=50,
+    )
+    assert decision.per_strategy_bound == 10  # min(10, 50)
+    assert decision.decided_leverage == 10
+    assert decision.branch == "override"
+
+
+# ---------------------------------------------------------------------------
+# Defensive paths
+
+
+def test_zero_recommendation_treated_as_missing():
+    decision = arbitrate_leverage(
+        recommended_leverage=0,
+        operator_max=10,
+    )
+    assert decision.branch == "fallback"
+    assert decision.decided_leverage == 10
+    assert "below 1" in decision.audit_reason
+
+
+def test_negative_recommendation_treated_as_missing():
+    decision = arbitrate_leverage(
+        recommended_leverage=-3,
+        operator_max=10,
+    )
+    assert decision.branch == "fallback"
+    assert decision.decided_leverage == 10
+
+
+def test_operator_max_below_one_is_clamped():
+    decision = arbitrate_leverage(
+        recommended_leverage=5,
+        operator_max=0,
+    )
+    assert decision.per_strategy_bound == 1
+    assert decision.decided_leverage == 1
+    assert decision.branch == "override"
+
+
+def test_no_explicit_operator_max_picks_up_env(monkeypatch: pytest.MonkeyPatch):
+    """AC3.a fallback path: when caller omits operator_max we read the env."""
+    monkeypatch.setenv("CIO_DEFAULT_MAX_LEVERAGE", "7")
+    decision = arbitrate_leverage(recommended_leverage=20)
+    assert decision.per_strategy_bound == 7
+    assert decision.decided_leverage == 7
+    assert decision.branch == "override"
+
+
+def test_default_when_env_unset_uses_module_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("CIO_DEFAULT_MAX_LEVERAGE", raising=False)
+    decision = arbitrate_leverage(recommended_leverage=None)
+    assert decision.decided_leverage == DEFAULT_OPERATOR_MAX_LEVERAGE
+
+
+def test_decision_is_immutable():
+    """LeverageDecision is a frozen dataclass — mutation raises FrozenInstanceError."""
+    import dataclasses
+
+    decision = arbitrate_leverage(recommended_leverage=5, operator_max=10)
+    with pytest.raises(dataclasses.FrozenInstanceError) as excinfo:
+        decision.decided_leverage = 99  # type: ignore[misc]
+    assert "decided_leverage" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- Closes #137. Implements the CIO-side leverage arbiter that decides what leverage to send TE on every admission. Ships the env-var fallback path (AC3.a) so this story lands without waiting on its peer enrichments (691.1 signal field, 691.2 / [data-manager#179](https://github.com/PetroSa2/petrosa-data-manager/issues/179) characterization envelope). When those land the call site passes real values; arbiter logic stays put.
- TE-side enforcement (FR64) already shipped at `petrosa-tradeengine/tradeengine/leverage_bound_guard.py` per the 2026-05-28 audit; this PR is the producer side that decides what to hand TE in the first place.

## AC traceability
- [x] **AC3.a — Per-strategy bound resolution.** `arbitrate_leverage(operator_max=None, ...)` reads `CIO_DEFAULT_MAX_LEVERAGE` (default 10) via `operator_max_from_env()` (env var ⇒ int with graceful fallback on bad input). When `strategy_envelope` arrives (data-manager#179), the arbiter tightens the bound to `min(operator_max, strategy_envelope)`. Until then it uses the env var only.
- [x] **AC3.b — Three-branch arbitration.** Pure function in `cio/core/leverage_arbiter.py`:
  - `recommended_leverage is None` → `decided = per_strategy_bound`, branch `fallback`.
  - `recommended_leverage <= per_strategy_bound` → `decided = recommended_leverage`, branch `accept`.
  - `recommended_leverage >  per_strategy_bound` → `decided = per_strategy_bound`, branch `override` (no rejection, per AC).
- [x] **AC3.c — `decided_leverage` on DecisionRecord.** Field added in `cio/core/decision_store.py::DecisionRecord` defaulting to `None` for legacy records (same shape as the existing `rejection_source` / `strategy_revision_id` additions). The router (`cio/core/router.py`) calls the arbiter once per dispatch and threads the value into the persisted record.
- [x] **AC3.d — Tests.** `tests/unit/test_leverage_arbiter.py` covers the three branches + the env-var fallback + defensive paths (zero / negative recommendations, sub-1 operator_max, env-var precedence over module default, immutability of the result dataclass). `tests/unit/test_decision_record_decided_leverage.py` pins the persistence contract.

## Test plan
- [x] `pytest tests/unit/test_leverage_arbiter.py tests/unit/test_decision_record_decided_leverage.py` → 20 passed.
- [x] Full unit suite `pytest tests/unit` → 307 passed (no regressions; up from 287 with the 20 new tests).
- [x] `ruff check` + `ruff format` clean.

## Notes
- The arbiter logs the branch + decided value at INFO with the correlation_id, so dashboards / Loki queries can answer "why did decision X end up at leverage Y" without grep-spelunking source.
- Each `LeverageDecision` carries an `audit_reason` field that downstream audit-trail rows can persist verbatim (FR12 follow-up).

## References
- Parent epic: [petrosa_k8s#691](https://github.com/PetroSa2/petrosa_k8s/issues/691)
- Unblocks: [petrosa-cio#138](https://github.com/PetroSa2/petrosa-cio/issues/138) (portfolio aggregate ceiling needs `decided_leverage` on each position).
- TE-side enforcement (already shipped): `petrosa-tradeengine/tradeengine/leverage_bound_guard.py`

🤖 BMAD ticket-orchestrator (auto-chain, execution phase)