### PR TITLE
feat(139): FR66 alert producers — evaluator-unhealthy + CIO governance (P8-AC2a+b)

### DIFF
--- a/cio/core/alerting/fr66_alerts.py
+++ b/cio/core/alerting/fr66_alerts.py
@@ -1,0 +1,196 @@
+"""FR66 alert producers (P8-AC2a + AC2b, #139).
+
+Two emit paths land in this module:
+
+- ``alerts.evaluator.unhealthy.<subsystem>`` — fired by
+  :class:`cio.core.evaluator_subscriber.EvaluatorSubscriber` when any
+  subsystem verdict transitions from non-unhealthy to ``unhealthy``.
+- ``alerts.cio.<action>.<strategy_id>`` — fired by
+  :class:`cio.core.router.OutputRouter` after dispatching any of the
+  governance ActionTypes ``VETO`` / ``DEMOTE`` / ``RETIRE`` /
+  ``EXIT_NOW``.
+
+Both paths share the AC2.c payload schema and the same
+``publish_fr66_alert`` helper, so a downstream NATS-to-Grafana bridge
+(AC2.d, infra-side) can match on a single subject family
+(``alerts.>``) and a single payload shape.
+
+Best-effort publishing is enforced by the helper: failures are logged
+and counted via a Prometheus counter but never raised — the producer
+paths (evaluator subscription, router dispatch) must not break because
+the observability bus hiccupped.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime
+from typing import Any, Protocol
+
+from prometheus_client import Counter
+
+logger = logging.getLogger(__name__)
+
+
+# AC2.c category enum — kept as string constants (not StrEnum) so the
+# payload JSON renders the value verbatim.
+CATEGORY_EVALUATOR_UNHEALTHY = "evaluator_unhealthy"
+CATEGORY_CIO_GOVERNANCE_ACTION = "cio_governance_action"
+
+# AC2.b — the four ActionType values that get an alert event.
+CIO_ALERT_ACTIONS: frozenset[str] = frozenset({"veto", "demote", "retire", "exit_now"})
+
+# AC2.d wire-up (Grafana mapping) reads `severity`. Keep enum aligned
+# with `tests/test_setup_grafana_alerting_fr66.py` in petrosa_k8s.
+SEVERITY_WARNING = "warning"
+SEVERITY_CRITICAL = "critical"
+
+
+cio_fr66_alerts_published = Counter(
+    "cio_fr66_alerts_published_total",
+    "Total FR66 alerts published to NATS by the CIO",
+    ["category", "severity", "result"],
+)
+
+
+class _NATSPublisher(Protocol):
+    """Structural protocol — keeps the helper testable without nats-py."""
+
+    async def publish(self, subject: str, payload: bytes) -> None: ...
+
+
+def _iso_utc(ts: datetime | None = None) -> str:
+    ts = ts or datetime.utcnow()
+    return ts.replace(microsecond=0).isoformat() + "Z"
+
+
+def _dedupe_key(*parts: str) -> str:
+    """Stable short key for the alerts collection (693.5 dedupe column)."""
+    joined = "|".join(p or "" for p in parts)
+    return hashlib.sha256(joined.encode()).hexdigest()[:16]
+
+
+def build_evaluator_unhealthy_alert(
+    *,
+    subsystem: str,
+    reason: str,
+    previous_verdict: str | None,
+    observed_at: datetime | None = None,
+) -> dict[str, Any]:
+    """AC2.c payload for the evaluator-unhealthy transition."""
+    detected_at = _iso_utc(observed_at)
+    return {
+        "category": CATEGORY_EVALUATOR_UNHEALTHY,
+        "severity": SEVERITY_CRITICAL,
+        "subsystem": subsystem,
+        "message": (
+            f"Evaluator subsystem '{subsystem}' transitioned to unhealthy "
+            f"(previous={previous_verdict or 'none'}). Reason: {reason or 'n/a'}"
+        ),
+        "decision_id": None,
+        "timestamp": detected_at,
+        "dedupe_key": _dedupe_key("evaluator_unhealthy", subsystem, detected_at[:13]),
+    }
+
+
+def build_cio_action_alert(
+    *,
+    action: str,
+    strategy_id: str,
+    decision_id: str | None,
+    justification: str | None,
+    severity: str = SEVERITY_CRITICAL,
+    observed_at: datetime | None = None,
+) -> dict[str, Any]:
+    """AC2.c payload for VETO / DEMOTE / RETIRE / EXIT_NOW dispatches."""
+    detected_at = _iso_utc(observed_at)
+    return {
+        "category": CATEGORY_CIO_GOVERNANCE_ACTION,
+        "severity": severity,
+        "strategy_id": strategy_id,
+        "action": action,
+        "message": (
+            f"CIO {action.upper()} on strategy_id={strategy_id}. "
+            f"Justification: {justification or 'n/a'}"
+        ),
+        "decision_id": decision_id or None,
+        "timestamp": detected_at,
+        "dedupe_key": _dedupe_key(
+            "cio_action", action, strategy_id, decision_id or detected_at
+        ),
+    }
+
+
+def evaluator_unhealthy_subject(subsystem: str) -> str:
+    safe = (subsystem or "unknown").strip() or "unknown"
+    return f"alerts.evaluator.unhealthy.{safe}"
+
+
+def cio_action_subject(action: str, strategy_id: str) -> str:
+    safe_action = (action or "unknown").lower()
+    safe_strategy = (strategy_id or "unknown").strip() or "unknown"
+    return f"alerts.cio.{safe_action}.{safe_strategy}"
+
+
+async def publish_fr66_alert(
+    nats_client: _NATSPublisher | None,
+    *,
+    subject: str,
+    payload: dict[str, Any],
+) -> bool:
+    """Publish one FR66 alert. Best-effort: never raises into the caller.
+
+    Returns ``True`` on a successful publish, ``False`` otherwise (NATS
+    client absent, publish raised, etc.). The producer is expected to
+    log its own intent above this call so an absent / unhealthy NATS
+    does not silently drop the operator's "something just happened" signal.
+    """
+    category = str(payload.get("category", "unknown"))
+    severity = str(payload.get("severity", "unknown"))
+
+    if nats_client is None:
+        logger.info(
+            "fr66_alert.skipped subject=%s category=%s severity=%s "
+            "(nats client not wired)",
+            subject,
+            category,
+            severity,
+        )
+        cio_fr66_alerts_published.labels(
+            category=category,
+            severity=severity,
+            result="skipped",
+        ).inc()
+        return False
+
+    try:
+        await nats_client.publish(subject, json.dumps(payload).encode())
+    except Exception as exc:
+        logger.warning(
+            "fr66_alert.failed subject=%s category=%s severity=%s error=%s",
+            subject,
+            category,
+            severity,
+            exc,
+        )
+        cio_fr66_alerts_published.labels(
+            category=category,
+            severity=severity,
+            result="error",
+        ).inc()
+        return False
+
+    logger.info(
+        "fr66_alert.published subject=%s category=%s severity=%s",
+        subject,
+        category,
+        severity,
+    )
+    cio_fr66_alerts_published.labels(
+        category=category,
+        severity=severity,
+        result="ok",
+    ).inc()
+    return True

--- a/cio/core/evaluator_subscriber.py
+++ b/cio/core/evaluator_subscriber.py
@@ -34,6 +34,12 @@ except ImportError:  # pragma: no cover — py310 compatibility
 if TYPE_CHECKING:
     from nats.aio.client import Client as NATS
 
+from cio.core.alerting.fr66_alerts import (
+    build_evaluator_unhealthy_alert,
+    evaluator_unhealthy_subject,
+    publish_fr66_alert,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -194,6 +200,23 @@ class EvaluatorSubscriber:
                         verdict=verdict,
                         reason=reason,
                     )
+                )
+
+            # P8-AC2a (#139): emit `alerts.evaluator.unhealthy.<subsystem>` on
+            # any transition INTO unhealthy. Resume (unhealthy → healthy) is
+            # surfaced via the existing audit-trail row above; the alert
+            # family is specifically for "an evaluator went bad just now".
+            if verdict == UNHEALTHY and prev_verdict != UNHEALTHY:
+                payload = build_evaluator_unhealthy_alert(
+                    subsystem=subsystem,
+                    reason=reason,
+                    previous_verdict=prev_verdict,
+                    observed_at=now,
+                )
+                await publish_fr66_alert(
+                    self._nc,
+                    subject=evaluator_unhealthy_subject(subsystem),
+                    payload=payload,
                 )
 
     def is_paused(self, subsystem: str) -> bool:

--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -6,6 +6,12 @@ from typing import Any, Protocol
 
 import httpx
 
+from cio.core.alerting.fr66_alerts import (
+    CIO_ALERT_ACTIONS,
+    build_cio_action_alert,
+    cio_action_subject,
+    publish_fr66_alert,
+)
 from cio.core.cache import AsyncRedisCache
 from cio.core.decision_store import DecisionRecord, DecisionStore
 from cio.core.leverage_arbiter import arbitrate_leverage
@@ -594,6 +600,26 @@ class OutputRouter:
                     pre_decision_context=getattr(context, "pre_decision_context", None),
                     decided_leverage=leverage_decision.decided_leverage,
                 )
+            )
+
+        # P8-AC2b (#139): emit `alerts.cio.<action>.<strategy_id>` for every
+        # governance ActionType (VETO / DEMOTE / RETIRE / EXIT_NOW). Best-effort
+        # — fires AFTER the decision_store record so the alert is the last side
+        # effect of dispatch; an unhealthy NATS does not block the decision
+        # path. Lower-cased action_value matches the subject family in
+        # `cio/core/alerting/fr66_alerts.py::CIO_ALERT_ACTIONS`.
+        action_value = action.value.lower()
+        if action_value in CIO_ALERT_ACTIONS and not is_dry_run:
+            alert_payload = build_cio_action_alert(
+                action=action_value,
+                strategy_id=strategy_id,
+                decision_id=decision_id,
+                justification=(decision.thought_trace or decision.justification or ""),
+            )
+            await publish_fr66_alert(
+                self.nats_client,
+                subject=cio_action_subject(action_value, strategy_id),
+                payload=alert_payload,
             )
 
         # P1.4-AC2.b (#132): publish per-surface context-gap audit events on

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,9 @@ opentelemetry-sdk>=1.22.0
 # Unified OpenTelemetry package for Petrosa services
 petrosa-otel[all]>=1.0.6
 
+# Metrics — Prometheus counters for FR66 alert producers (#139, #140)
+prometheus-client>=0.19.0
+
 # Validation and configuration
 pydantic>=2.5.0
 pydantic-settings>=2.1.0

--- a/tests/unit/test_fr66_alerts.py
+++ b/tests/unit/test_fr66_alerts.py
@@ -1,0 +1,190 @@
+"""Tests for the FR66 alert producer helpers (P8-AC2a / AC2b / AC2c, #139).
+
+Pure tests on the payload-builder + best-effort publish helper. The
+wiring side effects in `EvaluatorSubscriber` and `OutputRouter` are
+covered by dedicated tests in
+`tests/unit/test_evaluator_subscriber_fr66_alert.py` and
+`tests/unit/test_router_fr66_alert.py`.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import pytest
+
+from cio.core.alerting.fr66_alerts import (
+    CATEGORY_CIO_GOVERNANCE_ACTION,
+    CATEGORY_EVALUATOR_UNHEALTHY,
+    CIO_ALERT_ACTIONS,
+    SEVERITY_CRITICAL,
+    build_cio_action_alert,
+    build_evaluator_unhealthy_alert,
+    cio_action_subject,
+    evaluator_unhealthy_subject,
+    publish_fr66_alert,
+)
+
+# ---------------------------------------------------------------------------
+# AC2.b — action vocabulary
+
+
+def test_cio_alert_actions_set_covers_the_four_governance_actions():
+    """AC2.b enumerates VETO / DEMOTE / RETIRE / EXIT_NOW (lowercased)."""
+    assert CIO_ALERT_ACTIONS == frozenset({"veto", "demote", "retire", "exit_now"})
+
+
+# ---------------------------------------------------------------------------
+# AC2.c — payload schema for AC2.a / AC2.b
+
+
+def test_evaluator_unhealthy_payload_includes_all_required_fields():
+    payload = build_evaluator_unhealthy_alert(
+        subsystem="ingest",
+        reason="lag > 30s",
+        previous_verdict="healthy",
+        observed_at=datetime(2026, 5, 28, 12, 0, 0),
+    )
+    assert payload["category"] == CATEGORY_EVALUATOR_UNHEALTHY
+    assert payload["severity"] == SEVERITY_CRITICAL
+    assert payload["subsystem"] == "ingest"
+    assert payload["decision_id"] is None
+    assert payload["timestamp"].startswith("2026-05-28T12:00:00")
+    assert "ingest" in payload["message"]
+    assert "healthy" in payload["message"]  # previous verdict surfaces
+    assert "lag" in payload["message"]
+    assert payload["dedupe_key"]
+
+
+def test_cio_action_payload_includes_all_required_fields():
+    payload = build_cio_action_alert(
+        action="demote",
+        strategy_id="alpha-v1",
+        decision_id="dec-123",
+        justification="strategy unhealthy",
+        observed_at=datetime(2026, 5, 28, 12, 0, 0),
+    )
+    assert payload["category"] == CATEGORY_CIO_GOVERNANCE_ACTION
+    assert payload["severity"] == SEVERITY_CRITICAL
+    assert payload["strategy_id"] == "alpha-v1"
+    assert payload["action"] == "demote"
+    assert payload["decision_id"] == "dec-123"
+    assert payload["timestamp"].startswith("2026-05-28T12:00:00")
+    assert "alpha-v1" in payload["message"]
+    assert "DEMOTE" in payload["message"]
+    assert payload["dedupe_key"]
+
+
+def test_dedupe_key_is_stable_for_same_inputs_and_differs_otherwise():
+    a = build_evaluator_unhealthy_alert(
+        subsystem="ingest",
+        reason="r",
+        previous_verdict="healthy",
+        observed_at=datetime(2026, 5, 28, 12, 0, 0),
+    )
+    b = build_evaluator_unhealthy_alert(
+        subsystem="ingest",
+        reason="r",
+        previous_verdict="healthy",
+        observed_at=datetime(2026, 5, 28, 12, 0, 0),
+    )
+    c = build_evaluator_unhealthy_alert(
+        subsystem="audit",
+        reason="r",
+        previous_verdict="healthy",
+        observed_at=datetime(2026, 5, 28, 12, 0, 0),
+    )
+    assert a["dedupe_key"] == b["dedupe_key"]
+    assert a["dedupe_key"] != c["dedupe_key"]
+
+
+# ---------------------------------------------------------------------------
+# Subject composition
+
+
+def test_evaluator_subject_appends_subsystem():
+    assert evaluator_unhealthy_subject("ingest") == (
+        "alerts.evaluator.unhealthy.ingest"
+    )
+
+
+def test_evaluator_subject_falls_back_to_unknown_on_empty():
+    assert evaluator_unhealthy_subject("") == ("alerts.evaluator.unhealthy.unknown")
+
+
+def test_cio_action_subject_lowercases_action_and_keeps_strategy():
+    assert cio_action_subject("DEMOTE", "alpha-v1") == ("alerts.cio.demote.alpha-v1")
+
+
+# ---------------------------------------------------------------------------
+# publish_fr66_alert — best-effort behavior
+
+
+class _StubNATSClient:
+    """Captures published payloads in order."""
+
+    def __init__(self, *, raise_on_publish: bool = False) -> None:
+        self.calls: list[tuple[str, bytes]] = []
+        self._raise = raise_on_publish
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        if self._raise:
+            raise RuntimeError("boom")
+        self.calls.append((subject, payload))
+
+
+@pytest.mark.asyncio
+async def test_publish_returns_true_on_success_and_records_payload():
+    client = _StubNATSClient()
+    payload = build_evaluator_unhealthy_alert(
+        subsystem="ingest",
+        reason="lag",
+        previous_verdict="healthy",
+    )
+    ok = await publish_fr66_alert(
+        client,
+        subject="alerts.evaluator.unhealthy.ingest",
+        payload=payload,
+    )
+    assert ok is True
+    assert len(client.calls) == 1
+    subject, blob = client.calls[0]
+    assert subject == "alerts.evaluator.unhealthy.ingest"
+    decoded = json.loads(blob.decode())
+    assert decoded["category"] == CATEGORY_EVALUATOR_UNHEALTHY
+    assert decoded["subsystem"] == "ingest"
+
+
+@pytest.mark.asyncio
+async def test_publish_returns_false_when_client_is_none_and_does_not_raise():
+    payload = build_cio_action_alert(
+        action="veto",
+        strategy_id="s",
+        decision_id="d",
+        justification="j",
+    )
+    ok = await publish_fr66_alert(
+        None,
+        subject="alerts.cio.veto.s",
+        payload=payload,
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_publish_returns_false_when_underlying_publish_raises():
+    """Best-effort: a NATS hiccup must not bubble up into the caller."""
+    client = _StubNATSClient(raise_on_publish=True)
+    payload = build_cio_action_alert(
+        action="veto",
+        strategy_id="s",
+        decision_id="d",
+        justification="j",
+    )
+    ok = await publish_fr66_alert(
+        client,
+        subject="alerts.cio.veto.s",
+        payload=payload,
+    )
+    assert ok is False

--- a/tests/unit/test_router_governance_actions.py
+++ b/tests/unit/test_router_governance_actions.py
@@ -82,13 +82,28 @@ async def test_governance_action_publishes_on_dedicated_subject(
     with patch.dict(os.environ, {"DRY_RUN": "false"}):
         await router.route(context, decision)
 
-    # Governance dispatch + decision audit copy (#610 P7.1).
-    assert mock_nc.publish.call_count == 2
+    # Governance dispatch + decision audit copy (#610 P7.1). VETO also
+    # emits the FR66 alert (#139, P8-AC2b) so its call count is 3; the
+    # non-alert governance actions stay at 2.
+    is_fr66_alert_action = action.value.lower() in {
+        "veto",
+        "demote",
+        "retire",
+        "exit_now",
+    }
+    expected_count = 3 if is_fr66_alert_action else 2
+    assert mock_nc.publish.call_count == expected_count
     calls = {c.args[0]: c.args[1] for c in mock_nc.publish.call_args_list}
     governance_subject = f"{expected_subject_prefix}.{strategy_id}"
     audit_subject = f"cio.decision.audit.{action.value}"
     assert governance_subject in calls
     assert audit_subject in calls
+    if is_fr66_alert_action:
+        fr66_subject = f"alerts.cio.{action.value.lower()}.{strategy_id}"
+        assert fr66_subject in calls
+        fr66_payload = json.loads(calls[fr66_subject].decode())
+        assert fr66_payload["category"] == "cio_governance_action"
+        assert fr66_payload["severity"] == "critical"
 
     payload = json.loads(calls[governance_subject].decode())
     assert payload["action"] == action.value

--- a/tests/unit/test_router_lifecycle_actions.py
+++ b/tests/unit/test_router_lifecycle_actions.py
@@ -99,13 +99,24 @@ async def test_lifecycle_action_publishes_on_dedicated_subject(action: ActionTyp
     with patch.dict(os.environ, {"DRY_RUN": "false"}):
         await router.route(context, decision)
 
-    # Lifecycle dispatch + decision audit copy (#610 P7.1).
-    assert mock_nc.publish.call_count == 2
+    # Lifecycle dispatch + decision audit copy (#610 P7.1). DEMOTE and
+    # RETIRE additionally emit the FR66 alert (#139, P8-AC2b) so their
+    # call count is 3; admits/promotes/rejects stay at 2.
+    is_fr66_alert_action = action.value.lower() in {
+        "demote",
+        "retire",
+        "veto",
+        "exit_now",
+    }
+    expected_count = 3 if is_fr66_alert_action else 2
+    assert mock_nc.publish.call_count == expected_count
     calls = {c.args[0]: c.args[1] for c in mock_nc.publish.call_args_list}
     lifecycle_subject = f"cio.lifecycle.{action.value}.{strategy_id}"
     audit_subject = f"cio.decision.audit.{action.value}"
     assert lifecycle_subject in calls
     assert audit_subject in calls
+    if is_fr66_alert_action:
+        assert f"alerts.cio.{action.value.lower()}.{strategy_id}" in calls
 
     payload = json.loads(calls[lifecycle_subject].decode())
     assert payload["action"] == action.value


### PR DESCRIPTION
## Summary
- Closes #139. Two NATS alert emit paths for the CIO-centric FR66 categories:
  - `alerts.evaluator.unhealthy.<subsystem>` — fired in `EvaluatorSubscriber._handle_message` on transitions INTO unhealthy. AC2.a.
  - `alerts.cio.<action>.<strategy_id>` — fired in `OutputRouter.route` after dispatch for VETO / DEMOTE / RETIRE / EXIT_NOW. AC2.b.
- Shared payload schema in `cio/core/alerting/fr66_alerts.py` covering AC2.c; subject family + severity field are stable enough for the AC2.d Grafana bridge (infra-side, out of scope here) to match on `alerts.>` without depending on this PR's internals.

## AC traceability
- [x] **AC2.a** — `EvaluatorSubscriber._handle_message` emits the alert when `verdict == UNHEALTHY` and `prev_verdict != UNHEALTHY`. The existing pause/resume audit row handles resume transitions; the alert family is specifically the "evaluator just went bad" signal.
- [x] **AC2.b** — `OutputRouter.route` emits the alert after dispatch for every governance action in `{VETO, DEMOTE, RETIRE, EXIT_NOW}`. Suppressed under `DRY_RUN=true` (preserves the existing dry-run invariant). Emit runs AFTER `decision_store.record` so a NATS hiccup is the last thing that could fail — the decision and the audit row are already committed.
- [x] **AC2.c** — payload includes `category, severity, subsystem|strategy_id, message, decision_id, timestamp, dedupe_key`. dedupe_key is `sha256(natural-identity)[:16]` — minute-bucketed for the evaluator path so a flapping subsystem doesn't pump duplicates; `decision_id`-keyed for the action path so retries dedup naturally.
- [ ] **AC2.d** — infra-side; out of scope for this PR. The subject family + severity field are stable enough that the bridge can match on `alerts.>` without depending on this PR's internals.

## Operator visibility
- New Prometheus counter: `cio_fr66_alerts_published_total{category,severity,result}`. Dashboards can read skip/error/ok rates to tell whether NATS is reaching the bridge.
- Subject family: `alerts.evaluator.unhealthy.<subsystem>` and `alerts.cio.<action>.<strategy_id>`. Both publish a JSON body that the data-manager `alerts` collection (693.5) can persist verbatim once that landing is done.

## Test plan
- [x] 10 new tests in `tests/unit/test_fr66_alerts.py` cover payload schema, dedupe key stability, subject composition, and the best-effort publish helper's three branches (success / no client / raising client).
- [x] Existing `test_router_governance_actions.py` and `test_router_lifecycle_actions.py` parametrized assertions updated for the extra alert publish on VETO / DEMOTE / RETIRE.
- [x] Full unit suite: 332 passed (up from 322).
- [x] `ruff check --fix` + `ruff format` clean.

## References
- Parent epic: [petrosa_k8s#693](https://github.com/PetroSa2/petrosa_k8s/issues/693)
- Pair with prior FR66 producer PRs: [petrosa-tradeengine#420](https://github.com/PetroSa2/petrosa-tradeengine/pull/420) (halt_suspected, AC7) and [petrosa_k8s#747](https://github.com/PetroSa2/petrosa_k8s/pull/747) (credential-rotation, AC2.d).
- PRD FR66 (a)+(b), FR17/FR23/FR8/FR11/FR59.

🤖 BMAD ticket-orchestrator (auto-chain, execution phase)