### PR TITLE
feat(140): drawdown-envelope breach alert producer (P8-AC2c, FR66 c)

### DIFF
--- a/cio/core/alerting/drawdown_breach_emitter.py
+++ b/cio/core/alerting/drawdown_breach_emitter.py
@@ -1,0 +1,183 @@
+"""Drawdown-envelope breach emitter (P8-AC2c, #140).
+
+Owns the AC2.c.3 dedup window: a breach for the same
+``(strategy_id, position_id)`` re-fires only after that position
+exits AND a new one opens. The emitter does not subscribe to NATS
+itself — the live drawdown vs. envelope comparator (CIO portfolio
+tracker, eventually tradeengine position monitor) calls
+:meth:`check_and_emit` on every observation and :meth:`notify_position_closed`
+when the position lifecycle ends.
+
+State is per-process and in-memory: the dedup record refreshes from
+producer calls and a restart loses the "already alerted" set
+(NFR-R1's detection-time window applies — same convention as
+:class:`cio.core.evaluator_subscriber.EvaluatorSubscriber`).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from cio.core.alerting.fr66_alerts import (
+    SEVERITY_CRITICAL,
+    build_drawdown_breach_alert,
+    drawdown_breach_subject,
+    publish_fr66_alert,
+)
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+if TYPE_CHECKING:
+    from cio.core.alerting.fr66_alerts import _NATSPublisher
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BreachRecord:
+    """Last breach observation for one ``(strategy_id, position_id)`` pair."""
+
+    strategy_id: str
+    position_id: str
+    observed_drawdown: float
+    envelope_p99: float
+    fired_at: datetime
+
+
+class DrawdownBreachEmitter:
+    """Stateful emitter for ``alerts.drawdown.breach.<strategy_id>``.
+
+    Usage from a producer (CIO portfolio tracker, etc.)::
+
+        emitter = DrawdownBreachEmitter(nats_client=nc)
+        # On each drawdown observation:
+        await emitter.check_and_emit(
+            strategy_id="momentum-v3",
+            position_id="POS-1234",
+            realized_drawdown_pct=0.0712,
+            envelope_p99=0.06,
+            envelope_p100=0.082,
+        )
+        # When the position closes:
+        emitter.notify_position_closed("momentum-v3", "POS-1234")
+
+    The emitter is intentionally NATS-agnostic — pass any object that
+    satisfies :class:`cio.core.alerting.fr66_alerts._NATSPublisher` (the
+    structural protocol used across the FR66 producers).
+    """
+
+    def __init__(self, nats_client: _NATSPublisher | None = None) -> None:
+        self._nc = nats_client
+        # (strategy_id, position_id) → last breach record. Presence
+        # means "already alerted this position; suppress until close".
+        self._fired: dict[tuple[str, str], BreachRecord] = {}
+
+    async def check_and_emit(
+        self,
+        *,
+        strategy_id: str,
+        position_id: str,
+        realized_drawdown_pct: float,
+        envelope_p99: float,
+        envelope_p100: float | None = None,
+        severity: str = SEVERITY_CRITICAL,
+        observed_at: datetime | None = None,
+    ) -> bool:
+        """Emit a breach alert if realized > p99 AND not already alerted.
+
+        Returns ``True`` if an alert was emitted (or attempted — actual
+        NATS success is best-effort, see ``publish_fr66_alert``).
+        Returns ``False`` when no breach, or when the dedup window
+        suppresses a repeat for the same ``(strategy_id, position_id)``.
+        """
+        if realized_drawdown_pct <= envelope_p99:
+            return False
+
+        key = (strategy_id, position_id)
+        if key in self._fired:
+            logger.debug(
+                "drawdown_breach.dedupe_suppressed strategy_id=%s position_id=%s "
+                "realized=%.4f envelope_p99=%.4f",
+                strategy_id,
+                position_id,
+                realized_drawdown_pct,
+                envelope_p99,
+            )
+            return False
+
+        now = observed_at or datetime.now(UTC)
+        payload = build_drawdown_breach_alert(
+            strategy_id=strategy_id,
+            position_id=position_id,
+            observed_drawdown=realized_drawdown_pct,
+            envelope_p99=envelope_p99,
+            envelope_p100=envelope_p100,
+            severity=severity,
+            observed_at=now,
+        )
+        logger.info(
+            "drawdown_breach.detected strategy_id=%s position_id=%s "
+            "realized=%.4f envelope_p99=%.4f envelope_p100=%s",
+            strategy_id,
+            position_id,
+            realized_drawdown_pct,
+            envelope_p99,
+            envelope_p100,
+        )
+        await publish_fr66_alert(
+            self._nc,
+            subject=drawdown_breach_subject(strategy_id),
+            payload=payload,
+        )
+        self._fired[key] = BreachRecord(
+            strategy_id=strategy_id,
+            position_id=position_id,
+            observed_drawdown=realized_drawdown_pct,
+            envelope_p99=envelope_p99,
+            fired_at=now,
+        )
+        return True
+
+    def notify_position_closed(self, strategy_id: str, position_id: str) -> None:
+        """Clear the dedup record for a ``(strategy_id, position_id)`` pair.
+
+        Callers must fire this on every position exit (close, liquidation,
+        manual EXIT_NOW). Without this signal AC2.c.3 cannot re-arm — a
+        breach on the same identifier after a missed close would be
+        silently suppressed. Missing/duplicate calls are tolerated (this
+        is best-effort hygiene, not a contract).
+        """
+        key = (strategy_id, position_id)
+        if self._fired.pop(key, None) is not None:
+            logger.debug(
+                "drawdown_breach.dedupe_cleared strategy_id=%s position_id=%s",
+                strategy_id,
+                position_id,
+            )
+
+    def fired_keys(self) -> list[tuple[str, str]]:
+        """Snapshot of currently-suppressed ``(strategy_id, position_id)`` pairs."""
+        return sorted(self._fired.keys())
+
+    def snapshot(self) -> dict:
+        """State export for debug/diagnostics endpoints."""
+        return {
+            "fired": [
+                {
+                    "strategy_id": r.strategy_id,
+                    "position_id": r.position_id,
+                    "observed_drawdown": r.observed_drawdown,
+                    "envelope_p99": r.envelope_p99,
+                    "fired_at": r.fired_at.isoformat(),
+                }
+                for r in self._fired.values()
+            ],
+        }

--- a/cio/core/alerting/fr66_alerts.py
+++ b/cio/core/alerting/fr66_alerts.py
@@ -1,6 +1,6 @@
-"""FR66 alert producers (P8-AC2a + AC2b, #139).
+"""FR66 alert producers (P8-AC2a + AC2b, #139; P8-AC2c, #140).
 
-Two emit paths land in this module:
+Three emit paths land in this module:
 
 - ``alerts.evaluator.unhealthy.<subsystem>`` — fired by
   :class:`cio.core.evaluator_subscriber.EvaluatorSubscriber` when any
@@ -9,8 +9,14 @@ Two emit paths land in this module:
   :class:`cio.core.router.OutputRouter` after dispatching any of the
   governance ActionTypes ``VETO`` / ``DEMOTE`` / ``RETIRE`` /
   ``EXIT_NOW``.
+- ``alerts.drawdown.breach.<strategy_id>`` — fired wherever realized
+  drawdown is compared against the strategy's envelope (FR30 / FR62)
+  and the p99 ceiling is exceeded. Dedup is keyed on
+  ``(strategy_id, position_id)`` and resets when the position exits
+  and a new one opens; see
+  :class:`cio.core.alerting.drawdown_breach_emitter.DrawdownBreachEmitter`.
 
-Both paths share the AC2.c payload schema and the same
+All paths share the AC2.c payload schema and the same
 ``publish_fr66_alert`` helper, so a downstream NATS-to-Grafana bridge
 (AC2.d, infra-side) can match on a single subject family
 (``alerts.>``) and a single payload shape.
@@ -38,6 +44,8 @@ logger = logging.getLogger(__name__)
 # payload JSON renders the value verbatim.
 CATEGORY_EVALUATOR_UNHEALTHY = "evaluator_unhealthy"
 CATEGORY_CIO_GOVERNANCE_ACTION = "cio_governance_action"
+# P8-AC2c (#140) — drawdown vs. envelope breach (FR66 c / FR30 / FR62).
+CATEGORY_DRAWDOWN_ENVELOPE_BREACH = "drawdown_envelope_breach"
 
 # AC2.b — the four ActionType values that get an alert event.
 CIO_ALERT_ACTIONS: frozenset[str] = frozenset({"veto", "demote", "retire", "exit_now"})
@@ -63,7 +71,9 @@ class _NATSPublisher(Protocol):
 
 def _iso_utc(ts: datetime | None = None) -> str:
     ts = ts or datetime.utcnow()
-    return ts.replace(microsecond=0).isoformat() + "Z"
+    # Strip tzinfo so a tz-aware input doesn't render as "+00:00Z".
+    ts = ts.replace(microsecond=0, tzinfo=None)
+    return ts.isoformat() + "Z"
 
 
 def _dedupe_key(*parts: str) -> str:
@@ -123,6 +133,49 @@ def build_cio_action_alert(
     }
 
 
+def build_drawdown_breach_alert(
+    *,
+    strategy_id: str,
+    position_id: str,
+    observed_drawdown: float,
+    envelope_p99: float,
+    envelope_p100: float | None,
+    severity: str = SEVERITY_CRITICAL,
+    observed_at: datetime | None = None,
+) -> dict[str, Any]:
+    """AC2.c payload for ``alerts.drawdown.breach.<strategy_id>``.
+
+    Carries the AC2.c.2 envelope contract verbatim: ``observed_drawdown``
+    is the realized drawdown that exceeded ``envelope_p99``; the optional
+    ``envelope_p100`` is the historical worst-case the strategy's
+    drawdown envelope ever ran (FR62) so the receiver can rank severity.
+
+    The producer is expected to use
+    :class:`cio.core.alerting.drawdown_breach_emitter.DrawdownBreachEmitter`
+    to enforce AC2.c.3's dedup window (``(strategy_id, position_id)``
+    resets on position exit + new position open).
+    """
+    detected_at = _iso_utc(observed_at)
+    return {
+        "category": CATEGORY_DRAWDOWN_ENVELOPE_BREACH,
+        "severity": severity,
+        "strategy_id": strategy_id,
+        "position_id": position_id,
+        "observed_drawdown": observed_drawdown,
+        "envelope_p99": envelope_p99,
+        "envelope_p100": envelope_p100,
+        "message": (
+            f"Drawdown breach on strategy_id={strategy_id} position_id={position_id}: "
+            f"realized={observed_drawdown:.4f} > envelope.p99={envelope_p99:.4f}"
+        ),
+        "decision_id": None,
+        "timestamp": detected_at,
+        "dedupe_key": _dedupe_key(
+            "drawdown_breach", strategy_id, position_id, detected_at[:13]
+        ),
+    }
+
+
 def evaluator_unhealthy_subject(subsystem: str) -> str:
     safe = (subsystem or "unknown").strip() or "unknown"
     return f"alerts.evaluator.unhealthy.{safe}"
@@ -132,6 +185,12 @@ def cio_action_subject(action: str, strategy_id: str) -> str:
     safe_action = (action or "unknown").lower()
     safe_strategy = (strategy_id or "unknown").strip() or "unknown"
     return f"alerts.cio.{safe_action}.{safe_strategy}"
+
+
+def drawdown_breach_subject(strategy_id: str) -> str:
+    """AC2.c.2: ``alerts.drawdown.breach.<strategy_id>``."""
+    safe_strategy = (strategy_id or "unknown").strip() or "unknown"
+    return f"alerts.drawdown.breach.{safe_strategy}"
 
 
 async def publish_fr66_alert(

--- a/tests/unit/test_drawdown_breach_emitter.py
+++ b/tests/unit/test_drawdown_breach_emitter.py
@@ -1,0 +1,340 @@
+"""Tests for P8-AC2c (#140) — drawdown-envelope breach alert producer."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from cio.core.alerting.drawdown_breach_emitter import DrawdownBreachEmitter
+from cio.core.alerting.fr66_alerts import (
+    CATEGORY_DRAWDOWN_ENVELOPE_BREACH,
+    SEVERITY_CRITICAL,
+    build_drawdown_breach_alert,
+    drawdown_breach_subject,
+)
+
+
+class _RecordingNATS:
+    """Captures (subject, payload) tuples without needing nats-py."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict]] = []
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        self.published.append((subject, json.loads(payload.decode())))
+
+
+# ---------------------------------------------------------------------------
+# AC2.c.2 — payload / subject contract
+# ---------------------------------------------------------------------------
+
+
+def test_drawdown_breach_subject_uses_strategy_id():
+    assert (
+        drawdown_breach_subject("momentum-v3") == "alerts.drawdown.breach.momentum-v3"
+    )
+
+
+def test_drawdown_breach_subject_handles_empty_strategy_id():
+    assert drawdown_breach_subject("") == "alerts.drawdown.breach.unknown"
+    assert drawdown_breach_subject("   ") == "alerts.drawdown.breach.unknown"
+
+
+def test_build_drawdown_breach_alert_payload_shape():
+    observed_at = datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC)
+    payload = build_drawdown_breach_alert(
+        strategy_id="momentum-v3",
+        position_id="POS-1234",
+        observed_drawdown=0.0712,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+        observed_at=observed_at,
+    )
+
+    assert payload["category"] == CATEGORY_DRAWDOWN_ENVELOPE_BREACH
+    assert payload["severity"] == SEVERITY_CRITICAL
+    assert payload["strategy_id"] == "momentum-v3"
+    assert payload["position_id"] == "POS-1234"
+    assert payload["observed_drawdown"] == pytest.approx(0.0712)
+    assert payload["envelope_p99"] == pytest.approx(0.06)
+    assert payload["envelope_p100"] == pytest.approx(0.082)
+    assert payload["timestamp"] == "2026-05-28T12:00:00Z"
+    assert payload["dedupe_key"]  # non-empty stable string
+
+
+def test_build_drawdown_breach_alert_allows_missing_p100():
+    payload = build_drawdown_breach_alert(
+        strategy_id="s1",
+        position_id="p1",
+        observed_drawdown=0.1,
+        envelope_p99=0.05,
+        envelope_p100=None,
+    )
+    assert payload["envelope_p100"] is None
+
+
+# ---------------------------------------------------------------------------
+# AC2.c.1 — breach detection: fires when realized > p99
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_fires_on_breach_above_p99():
+    nats = _RecordingNATS()
+    emitter = DrawdownBreachEmitter(nats_client=nats)
+
+    fired = await emitter.check_and_emit(
+        strategy_id="momentum-v3",
+        position_id="POS-1",
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+
+    assert fired is True
+    assert len(nats.published) == 1
+    subject, payload = nats.published[0]
+    assert subject == "alerts.drawdown.breach.momentum-v3"
+    assert payload["observed_drawdown"] == pytest.approx(0.07)
+    assert payload["envelope_p99"] == pytest.approx(0.06)
+
+
+@pytest.mark.asyncio
+async def test_emit_silent_when_within_envelope():
+    nats = _RecordingNATS()
+    emitter = DrawdownBreachEmitter(nats_client=nats)
+
+    fired = await emitter.check_and_emit(
+        strategy_id="momentum-v3",
+        position_id="POS-1",
+        realized_drawdown_pct=0.05,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+
+    assert fired is False
+    assert nats.published == []
+
+
+@pytest.mark.asyncio
+async def test_emit_silent_when_exactly_at_p99():
+    """Spec is `>` not `>=` — exactly at p99 is not a breach."""
+    nats = _RecordingNATS()
+    emitter = DrawdownBreachEmitter(nats_client=nats)
+
+    fired = await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p",
+        realized_drawdown_pct=0.06,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+
+    assert fired is False
+    assert nats.published == []
+
+
+# ---------------------------------------------------------------------------
+# AC2.c.3 — dedup window: same (strategy_id, position_id) suppressed
+# until the position exits and a new one opens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dedupe_suppresses_repeat_breach_same_position():
+    nats = _RecordingNATS()
+    emitter = DrawdownBreachEmitter(nats_client=nats)
+
+    first = await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p",
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+    second = await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p",
+        realized_drawdown_pct=0.09,  # even worse — still suppressed
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+
+    assert first is True
+    assert second is False
+    assert len(nats.published) == 1
+
+
+@pytest.mark.asyncio
+async def test_dedupe_does_not_suppress_other_positions_same_strategy():
+    nats = _RecordingNATS()
+    emitter = DrawdownBreachEmitter(nats_client=nats)
+
+    await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p1",
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+    fired_p2 = await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p2",  # different position
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+
+    assert fired_p2 is True
+    assert len(nats.published) == 2
+
+
+@pytest.mark.asyncio
+async def test_dedupe_does_not_suppress_other_strategies_same_position_id():
+    """Different strategies happen to have the same position_id namespace
+    rarely, but the dedup key MUST be the (strategy_id, position_id) pair,
+    not position_id alone — otherwise a breach on strategy B is lost."""
+    nats = _RecordingNATS()
+    emitter = DrawdownBreachEmitter(nats_client=nats)
+
+    await emitter.check_and_emit(
+        strategy_id="s1",
+        position_id="POS-shared",
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+    fired = await emitter.check_and_emit(
+        strategy_id="s2",
+        position_id="POS-shared",
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+
+    assert fired is True
+    assert len(nats.published) == 2
+
+
+@pytest.mark.asyncio
+async def test_dedupe_resets_after_position_close_then_reopen():
+    nats = _RecordingNATS()
+    emitter = DrawdownBreachEmitter(nats_client=nats)
+
+    # First breach for (s, p) fires.
+    await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p",
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+    # Suppressed while position is still open.
+    await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p",
+        realized_drawdown_pct=0.09,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+    # Position exits.
+    emitter.notify_position_closed("s", "p")
+    # A "new position" (same logical id, re-opened after exit) can re-fire.
+    fired_again = await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p",
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+
+    assert fired_again is True
+    assert len(nats.published) == 2
+
+
+def test_notify_position_closed_is_tolerant_of_missing_keys():
+    """No-op on unknown (strategy_id, position_id) is acceptable hygiene."""
+    emitter = DrawdownBreachEmitter()
+    # Must not raise on an unknown key — and dedup state stays empty.
+    emitter.notify_position_closed("nope", "nope")
+    assert emitter.fired_keys() == []
+
+
+# ---------------------------------------------------------------------------
+# Best-effort NATS — emit succeeds even without a wired client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_with_no_nats_client_still_records_dedupe():
+    """Even when NATS is absent, the dedup record must lock — otherwise a
+    transient NATS outage would re-fire the same breach every tick."""
+    emitter = DrawdownBreachEmitter(nats_client=None)
+
+    first = await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p",
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+    second = await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p",
+        realized_drawdown_pct=0.08,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+
+    assert first is True
+    assert second is False
+    assert emitter.fired_keys() == [("s", "p")]
+
+
+@pytest.mark.asyncio
+async def test_emit_continues_when_nats_publish_raises():
+    """Producer must not break when the observability bus hiccups."""
+
+    class _BrokenNATS:
+        async def publish(self, subject, payload):
+            raise RuntimeError("nats down")
+
+    emitter = DrawdownBreachEmitter(nats_client=_BrokenNATS())
+    fired = await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p",
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+    # Best-effort: emitter reports it attempted an emit AND records the
+    # dedup so the next tick doesn't re-fire.
+    assert fired is True
+    assert emitter.fired_keys() == [("s", "p")]
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_snapshot_lists_active_dedupe_records():
+    emitter = DrawdownBreachEmitter()
+    await emitter.check_and_emit(
+        strategy_id="s",
+        position_id="p1",
+        realized_drawdown_pct=0.07,
+        envelope_p99=0.06,
+        envelope_p100=0.082,
+    )
+    snap = emitter.snapshot()
+    assert len(snap["fired"]) == 1
+    row = snap["fired"][0]
+    assert row["strategy_id"] == "s"
+    assert row["position_id"] == "p1"
+    assert row["observed_drawdown"] == pytest.approx(0.07)
+    assert row["envelope_p99"] == pytest.approx(0.06)
+    assert "fired_at" in row


### PR DESCRIPTION
## Summary

Closes petrosa-cio#140 — `[P8-AC2c] Alert emit: drawdown-envelope breach (FR66 c / FR30 / FR62)`.

Extends the FR66 alert family started in #147 (sibling petrosa-cio#139) with the third category from PRD parent EPIC petrosa_k8s#693:

- **AC2.c.1 — Breach detection**: a breach fires when `realized_drawdown_pct > envelope.p99` (strict `>`, exactly-at p99 is not a breach).
- **AC2.c.2 — Alert emit**: NATS subject `alerts.drawdown.breach.<strategy_id>` with payload `{strategy_id, position_id, observed_drawdown, envelope_p99, envelope_p100, severity=critical, message, decision_id, timestamp, dedupe_key, category}`.
- **AC2.c.3 — Dedup window**: same `(strategy_id, position_id)` re-fires only after `notify_position_closed(...)` is called and the next breach is observed (i.e. position exits and a new one opens).

## Files

- `cio/core/alerting/fr66_alerts.py` — adds `CATEGORY_DRAWDOWN_ENVELOPE_BREACH`, `build_drawdown_breach_alert(...)`, `drawdown_breach_subject(...)`.
- `cio/core/alerting/drawdown_breach_emitter.py` *(new)* — `DrawdownBreachEmitter` stateful producer owning the dedup window.
- `tests/unit/test_drawdown_breach_emitter.py` *(new)* — 15 unit tests covering all three ACs plus the best-effort NATS contract.

## Scope decisions / out of scope

- Wiring the emitter into the live drawdown vs. envelope comparator (CIO portfolio tracker; tradeengine position monitor) is **not** in this PR — same shipping style as #147 for #139. The cio half can adopt this producer when the envelope source materializes; the tradeengine half belongs in a separate ticket (none currently open).
- This PR is **chained on top of `feat/139-evaluator-cio-alert-emit`** because the `fr66_alerts.py` helper module (`_NATSPublisher`, `publish_fr66_alert`, `_dedupe_key`, severity constants, prometheus counter) landed there. Once #147 merges, this branch rebases cleanly onto main.

## Test results

```
.venv/bin/python -m pytest tests/unit/test_drawdown_breach_emitter.py
15 passed in 0.03s

.venv/bin/python -m pytest tests/
351 passed, 1 warning in 21.10s

.venv/bin/python -m ruff check cio/core/alerting/ tests/unit/test_drawdown_breach_emitter.py
All checks passed!
```

## References

- Parent EPIC: petrosa_k8s#693 (P8 alerting spine)
- Sibling: petrosa-cio#139 / PR #147 (AC2a + AC2b — evaluator-unhealthy + CIO governance actions)
- Sibling: petrosa-tradeengine#419 (DONE 2026-05-28 via PR #420 — halt suspected detector)
- Sibling: petrosa_k8s#737 (DONE 2026-05-28 via PR #747 — credential rotation)
- Sibling: petrosa-data-manager#183 (Backlog — reconciliation alert + audit)
- PRD: FR66 c, FR30, FR62
