### PR TITLE
feat(134): in-position ActionType + NATS dispatch + audit (P1.4-AC5+AC6, FR59)

### DIFF
--- a/cio/core/router.py
+++ b/cio/core/router.py
@@ -44,6 +44,20 @@ _LIFECYCLE_ACTIONS = frozenset(
     }
 )
 
+# P1.4-AC5 (#134, FR59): in-position governance actions. Each emits on
+# `cio.position.<action_value>.<strategy_id>` with the full DecisionResult
+# payload — downstream `petrosa-tradeengine` (consumer-side ticket, filed
+# as the AC5.c follow-up) translates each subject into a Binance order
+# modification / exit / partial-close. Audit copy is the generic
+# `cio.decision.audit.<action>` already emitted further down (AC6.a).
+_POSITION_ACTIONS = frozenset(
+    {
+        ActionType.MODIFY_STOPS,
+        ActionType.EXIT_NOW,
+        ActionType.SCALE_OUT,
+    }
+)
+
 
 class NATSClientProtocol(Protocol):
     """Structural protocol for NATS client to ensure testability."""
@@ -443,6 +457,18 @@ class OutputRouter:
             dispatch_tasks_data.append(
                 (
                     f"cio.lifecycle.{action.value}.{strategy_id}",
+                    decision.model_dump_json().encode(),
+                )
+            )
+        elif action in _POSITION_ACTIONS:
+            # P1.4-AC5 (#134, FR59): in-position governance actions emit on
+            # `cio.position.<kind>.<sid>`. tradeengine subscribers translate
+            # each subject into a Binance order modification / market exit /
+            # partial-close. The producer side is owned here; the consumer
+            # handlers in tradeengine are the AC5.c follow-up child ticket.
+            dispatch_tasks_data.append(
+                (
+                    f"cio.position.{action.value}.{strategy_id}",
                     decision.model_dump_json().encode(),
                 )
             )

--- a/cio/models/enums.py
+++ b/cio/models/enums.py
@@ -106,6 +106,18 @@ class ActionType(StrEnum):
     PROMOTE = "promote"
     DEMOTE = "demote"
     RETIRE = "retire"
+    # In-position governance actions (#134 P1.4-AC5 / FR59). Emitted by the
+    # CIO when an *open* position needs the engine to act — stop-loss /
+    # take-profit modification, immediate exit, or partial scale-out.
+    # Producer side here only; tradeengine subscriber is a follow-up.
+    # Subject family: `cio.position.<action>.<strategy_id>` (see router.py).
+    # In-position actions (per #134 P1.4-AC5, FR59). Emitted by the in-position
+    # governance loop (#135 / P1.4-AC7) once it lands; this layer only defines
+    # the vocabulary + emission paths. Each maps to a
+    # `cio.position.<kind>.<strategy_id>` subject — see cio/core/router.py.
+    MODIFY_STOPS = "modify_stops"
+    EXIT_NOW = "exit_now"
+    SCALE_OUT = "scale_out"
 
 
 class RejectionSource(StrEnum):

--- a/tests/unit/test_router_in_position_actions.py
+++ b/tests/unit/test_router_in_position_actions.py
@@ -1,0 +1,197 @@
+"""Tests for in-position router action dispatch (#134, P1.4-AC5 + AC6).
+
+Verifies the router emits MODIFY_STOPS / EXIT_NOW / SCALE_OUT on the
+dedicated ``cio.position.<kind>.<strategy_id>`` NATS subjects, that the
+shared audit copy on ``cio.decision.audit.<action>`` is published (AC6.a),
+and that EXIT_NOW additionally emits the FR66 governance alert family on
+``alerts.cio.exit_now.<strategy_id>`` (per #139).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cio.core.router import OutputRouter
+from cio.models import (
+    ActionType,
+    ActivationRecommendation,
+    ConfidenceLevel,
+    DecisionResult,
+    HealthStatus,
+    RegimeFit,
+    TriggerContext,
+)
+
+IN_POSITION_ACTIONS = [
+    ActionType.MODIFY_STOPS,
+    ActionType.EXIT_NOW,
+    ActionType.SCALE_OUT,
+]
+
+
+def _make_decision(action: ActionType) -> DecisionResult:
+    return DecisionResult(
+        hard_blocked=False,
+        ev_passes=True,
+        cost_viable=True,
+        regime_confidence=ConfidenceLevel.HIGH,
+        regime_fit=RegimeFit.GOOD,
+        strategy_health=HealthStatus.HEALTHY,
+        activation_recommendation=ActivationRecommendation.RUN,
+        action=action,
+        justification="in-position reasoning",
+        thought_trace="audit trace",
+    )
+
+
+def _make_context(strategy_id: str) -> TriggerContext:
+    ctx = MagicMock(spec=TriggerContext)
+    ctx.strategy_id = strategy_id
+    ctx.decision_id = "decision-134"
+    ctx.correlation_id = "corr-134"
+    ctx.trigger_payload = {"symbol": "BTCUSDT", "position_id": "POS-1"}
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# AC5.a — Enum vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_in_position_action_types_exposed():
+    """Enum carries the three in-position values added by #134."""
+    assert ActionType.MODIFY_STOPS.value == "modify_stops"
+    assert ActionType.EXIT_NOW.value == "exit_now"
+    assert ActionType.SCALE_OUT.value == "scale_out"
+
+
+# ---------------------------------------------------------------------------
+# AC5.b — NATS dispatch subjects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("action", "expected_subject"),
+    [
+        (ActionType.MODIFY_STOPS, "cio.position.modify_stops"),
+        (ActionType.EXIT_NOW, "cio.position.exit_now"),
+        (ActionType.SCALE_OUT, "cio.position.scale_out"),
+    ],
+)
+async def test_in_position_action_publishes_on_position_subject(
+    action: ActionType, expected_subject: str
+):
+    """Each in-position action publishes to cio.position.<kind>.<strategy_id>."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    strategy_id = "momentum_pulse"
+    context = _make_context(strategy_id)
+    decision = _make_decision(action)
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(context, decision)
+
+    calls = {c.args[0]: c.args[1] for c in mock_nc.publish.call_args_list}
+    full_subject = f"{expected_subject}.{strategy_id}"
+    assert full_subject in calls, (
+        f"Expected publish to {full_subject}, got {list(calls.keys())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC6.a — Per-action audit copy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", IN_POSITION_ACTIONS)
+async def test_in_position_action_emits_audit_copy(action: ActionType):
+    """Every in-position dispatch fires the shared cio.decision.audit.<action> copy
+    so data-manager's FR12 consumer (P7.1, #610) and the dashboard receive it."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    strategy_id = "momentum_pulse"
+    context = _make_context(strategy_id)
+    decision = _make_decision(action)
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(context, decision)
+
+    audit_subject = f"cio.decision.audit.{action.value}"
+    calls = {c.args[0]: c.args[1] for c in mock_nc.publish.call_args_list}
+    assert audit_subject in calls, (
+        f"Expected audit copy on {audit_subject}, got {list(calls.keys())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# EXIT_NOW additionally fires the FR66 alert family (#139)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exit_now_also_emits_fr66_governance_alert():
+    """EXIT_NOW is in CIO_ALERT_ACTIONS, so it must additionally publish to
+    alerts.cio.exit_now.<strategy_id> on top of the position dispatch + audit
+    copy."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    strategy_id = "momentum_pulse"
+    context = _make_context(strategy_id)
+    decision = _make_decision(ActionType.EXIT_NOW)
+
+    with patch.dict(os.environ, {"DRY_RUN": "false"}):
+        await router.route(context, decision)
+
+    subjects = {c.args[0] for c in mock_nc.publish.call_args_list}
+    assert f"cio.position.exit_now.{strategy_id}" in subjects
+    assert "cio.decision.audit.exit_now" in subjects
+    assert f"alerts.cio.exit_now.{strategy_id}" in subjects
+
+
+# ---------------------------------------------------------------------------
+# DRY_RUN must NOT publish (parity with other action families)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", IN_POSITION_ACTIONS)
+async def test_in_position_action_suppressed_under_dry_run(action: ActionType):
+    """Shadow mode must not emit any NATS publish."""
+    mock_nc = AsyncMock()
+    mock_vc = AsyncMock()
+    router = OutputRouter(
+        nats_client=mock_nc,
+        vector_client=mock_vc,
+        ta_bot_url="http://ta-bot",
+    )
+
+    context = _make_context("momentum_pulse")
+    decision = _make_decision(action)
+
+    with patch.dict(os.environ, {"DRY_RUN": "true"}):
+        await router.route(context, decision)
+
+    assert mock_nc.publish.call_count == 0


### PR DESCRIPTION
## Summary

Closes petrosa-cio#134 — `[P1.4-AC5+AC6] In-position ActionType + NATS dispatch + audit (FR59)`.

Adds three new in-position governance ActionType values plus their dispatch paths so the CIO can act on open positions, not just at admission time. These wire the producer side of FR59; the consumer side will be filed as a follow-up in petrosa-tradeengine (per AC5.c).

## ACs

- **AC5.a — ActionType extension** at `cio/models/enums.py`:
  - `MODIFY_STOPS = "modify_stops"`
  - `EXIT_NOW = "exit_now"`
  - `SCALE_OUT = "scale_out"`
  Existing values left untouched (backwards-compat).

- **AC5.b — NATS subjects + dispatch** in `cio/core/router.py`:
  - `cio.position.modify_stops.<strategy_id>`
  - `cio.position.exit_now.<strategy_id>`
  - `cio.position.scale_out.<strategy_id>`

  Each subject carries a typed `DecisionResult` JSON payload. `_POSITION_ACTIONS` frozenset added next to `_LIFECYCLE_ACTIONS` for consistent dispatch-set membership checks.

- **AC5.c — tradeengine handlers** are **out of scope** for this PR per the ticket body. A follow-up child ticket should be filed in `petrosa-tradeengine` for the consumer side that translates these subjects into Binance order modifications / exits / partial-closes.

- **AC6.a — Audit-trail per in-position action**: satisfied generically by the pre-existing `cio.decision.audit.<action>` emit (see `router.py` line ~437). data-manager's FR12 audit-trail consumer already subscribes to `cio.decision.audit.>`, so the three new actions get an audit row per dispatch automatically — no extra audit wiring required.

- **AC6.b — Tests**: 11 unit tests in `tests/unit/test_router_in_position_actions.py` cover:
  - ActionType exposure
  - Each emit path (parametrized across the three actions)
  - Audit-copy emit
  - `EXIT_NOW`'s overlap with the P8-AC2b governance alert family (`alerts.cio.exit_now.<strategy_id>`) — confirmed both subjects fire
  - Dry-run suppression for each action

## Test results

```
.venv/bin/python -m pytest tests/unit/test_router_in_position_actions.py
11 passed in 0.78s

.venv/bin/python -m pytest tests/
362 passed, 1 warning in 20.45s

.venv/bin/python -m ruff check cio/ tests/unit/test_router_in_position_actions.py
All checks passed!
```

## Follow-ups (not in this PR)

- File `petrosa-tradeengine` ticket for AC5.c — consumer handlers for the three new subjects.
- petrosa-cio#135 (P1.4-AC7 in-position re-evaluation loop) is the natural follow-on that emits these new ActionTypes from a periodic re-evaluation pass over open positions.

## References

- Parent EPIC: petrosa-cio#122
- Sibling: petrosa-cio#135 (re-evaluation loop, FR60) — depends on this PR
- PR #147 (cio#139): provides the `CIO_ALERT_ACTIONS` set + `alerts.cio.<action>.<strategy_id>` family that EXIT_NOW now hooks into
- PRD: FR59 (in-position governance), FR24 + FR27 (audit-trail)
