### PR TITLE
feat(135): in-position re-evaluation loop (P1.4-AC7, FR60)

### DIFF
--- a/cio/core/position_review_loop.py
+++ b/cio/core/position_review_loop.py
@@ -1,0 +1,251 @@
+"""In-position re-evaluation loop (P1.4-AC7, #135 / FR60).
+
+Periodically fires a ``SCHEDULED_REVIEW`` trigger per active position so
+the CIO arbitration loop reasons about an *open* position with fresh
+market / portfolio / evaluator state, not just at admission time.
+
+Two trigger sources land in this loop:
+
+- **Cadence** (AC7.a) — every ``CIO_REEVAL_INTERVAL_SECONDS`` seconds
+  (default 300, matching FR60's decision_window), every active position
+  gets one ``SCHEDULED_REVIEW`` fired against it.
+- **Event** (AC7.b) — callers fire :meth:`trigger_event` when something
+  material happened (unhealthy evaluator verdict, regime shift, drawdown
+  breach, characterization drift) so the loop re-evaluates *now*, not on
+  the next cadence tick.
+
+Backpressure (AC7.c): each ``(strategy_id, position_id)`` has at most
+one re-evaluation in flight. A second trigger while the first is still
+running is **dropped** and the ``cio_reeval_dropped_total`` Prometheus
+counter is incremented. This prevents a slow arbitration path from
+queueing an unbounded backlog when triggers arrive faster than they
+complete (a real failure mode: regime shifts can cluster).
+
+State is per-process and in-memory — same convention as
+:class:`cio.core.evaluator_subscriber.EvaluatorSubscriber`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from prometheus_client import Counter
+
+logger = logging.getLogger(__name__)
+
+
+# Default cadence per FR60 decision_window. Overridden in cio/main.py via
+# the ``CIO_REEVAL_INTERVAL_SECONDS`` env var.
+DEFAULT_REEVAL_INTERVAL_SECONDS = 300.0
+
+
+cio_reeval_fired = Counter(
+    "cio_reeval_fired_total",
+    "Re-evaluation trigger fires (cadence or event) per position",
+    ["source"],  # cadence | event
+)
+
+cio_reeval_dropped = Counter(
+    "cio_reeval_dropped_total",
+    "Re-evaluation triggers dropped because a prior re-eval is still in flight",
+    ["source"],
+)
+
+
+@dataclass(frozen=True)
+class PositionKey:
+    """Identity of an open position for backpressure bookkeeping."""
+
+    strategy_id: str
+    position_id: str
+
+    def __str__(self) -> str:  # pragma: no cover — debug only
+        return f"{self.strategy_id}:{self.position_id}"
+
+
+# Source labels for the Prometheus counter and audit logs.
+SOURCE_CADENCE = "cadence"
+SOURCE_EVENT = "event"
+
+
+# Callback signature for the arbitration runner. The loop calls this with the
+# position key + a `reason` string; the runner is responsible for invoking
+# the SCHEDULED_REVIEW trigger end-to-end (Code Engine + personas + router).
+# The signature is intentionally minimal so callers can wire any test or
+# production runner.
+RunnerFn = Callable[[PositionKey, str], Awaitable[Any]]
+
+
+class PositionReviewLoop:
+    """In-position re-evaluation orchestrator.
+
+    Usage from ``cio/main.py``::
+
+        loop = PositionReviewLoop(
+            runner=signal_arbiter.run_scheduled_review,
+            interval_seconds=settings.CIO_REEVAL_INTERVAL_SECONDS,
+        )
+        loop.add_position("momentum-v3", "POS-1234")
+        await loop.start()
+        # … on EXIT_NOW / liquidation / close:
+        loop.remove_position("momentum-v3", "POS-1234")
+        await loop.stop()
+
+    From an event hook (e.g. ``EvaluatorSubscriber`` on verdict transition,
+    or :class:`cio.core.alerting.drawdown_breach_emitter.DrawdownBreachEmitter`
+    when a breach fires)::
+
+        await loop.trigger_event(
+            PositionKey("momentum-v3", "POS-1234"),
+            reason="evaluator_unhealthy:ingest",
+        )
+    """
+
+    def __init__(
+        self,
+        runner: RunnerFn,
+        *,
+        interval_seconds: float = DEFAULT_REEVAL_INTERVAL_SECONDS,
+    ) -> None:
+        if interval_seconds <= 0:
+            raise ValueError(f"interval_seconds must be > 0, got {interval_seconds!r}")
+        self._runner = runner
+        self._interval = interval_seconds
+        self._positions: set[PositionKey] = set()
+        self._inflight: set[PositionKey] = set()
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+
+    # ----- registry -------------------------------------------------------
+
+    def add_position(self, strategy_id: str, position_id: str) -> None:
+        """Register a position so the cadence tick fires re-evals on it."""
+        key = PositionKey(strategy_id=strategy_id, position_id=position_id)
+        self._positions.add(key)
+        logger.debug("position_review_loop.added position=%s", key)
+
+    def remove_position(self, strategy_id: str, position_id: str) -> None:
+        """Drop a position from the cadence cycle (close / liquidation / EXIT_NOW)."""
+        key = PositionKey(strategy_id=strategy_id, position_id=position_id)
+        self._positions.discard(key)
+        # Don't touch _inflight — the in-flight re-eval should complete
+        # naturally; its result is still useful for audit even if the
+        # position has since closed.
+        logger.debug("position_review_loop.removed position=%s", key)
+
+    def active_positions(self) -> list[PositionKey]:
+        """Snapshot of currently-registered positions (sorted for stability)."""
+        return sorted(self._positions, key=lambda k: (k.strategy_id, k.position_id))
+
+    # ----- task lifecycle -------------------------------------------------
+
+    async def start(self) -> None:
+        """Start the cadence task. Idempotent — safe to call twice."""
+        if self._task is not None and not self._task.done():
+            return
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._cadence_loop())
+        logger.info("position_review_loop.started interval=%.1fs", self._interval)
+
+    async def stop(self) -> None:
+        """Signal stop and wait for the cadence task to exit cleanly."""
+        self._stop_event.set()
+        if self._task is not None:
+            try:
+                await self._task
+            except asyncio.CancelledError:  # pragma: no cover — defensive
+                pass
+            self._task = None
+        logger.info("position_review_loop.stopped")
+
+    # ----- trigger surfaces -----------------------------------------------
+
+    async def trigger_event(self, key: PositionKey, *, reason: str) -> bool:
+        """Fire a re-evaluation for ``key`` outside the cadence (AC7.b).
+
+        Returns ``True`` if the runner was invoked; ``False`` if the
+        trigger was dropped by backpressure (AC7.c).
+        """
+        return await self._fire_once(key, source=SOURCE_EVENT, reason=reason)
+
+    # ----- internals ------------------------------------------------------
+
+    async def _cadence_loop(self) -> None:
+        """Wake every ``_interval`` seconds and fire one re-eval per active position."""
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(),
+                    timeout=self._interval,
+                )
+                # If the wait returns without timing out, stop was signaled.
+                return
+            except TimeoutError:
+                pass
+
+            # Snapshot the active set so a concurrent add/remove during the
+            # iteration doesn't surprise us.
+            for key in list(self._positions):
+                await self._fire_once(
+                    key, source=SOURCE_CADENCE, reason="scheduled_review_cadence"
+                )
+
+    async def _fire_once(
+        self,
+        key: PositionKey,
+        *,
+        source: str,
+        reason: str,
+    ) -> bool:
+        """Attempt to dispatch one re-evaluation. Honors backpressure."""
+        if key in self._inflight:
+            cio_reeval_dropped.labels(source=source).inc()
+            logger.info(
+                "position_review_loop.dropped source=%s position=%s reason=%s "
+                "(re-eval still in flight)",
+                source,
+                key,
+                reason,
+            )
+            return False
+
+        self._inflight.add(key)
+        cio_reeval_fired.labels(source=source).inc()
+        logger.info(
+            "position_review_loop.fired source=%s position=%s reason=%s",
+            source,
+            key,
+            reason,
+        )
+        try:
+            await self._runner(key, reason)
+        except Exception as exc:  # noqa: BLE001 — never crash the loop
+            logger.warning(
+                "position_review_loop.runner_failed position=%s reason=%s error=%s",
+                key,
+                reason,
+                exc,
+            )
+        finally:
+            self._inflight.discard(key)
+        return True
+
+    def snapshot(self) -> dict:
+        """Debug/diagnostics export for the /state endpoint."""
+        return {
+            "interval_seconds": self._interval,
+            "active": [
+                {"strategy_id": k.strategy_id, "position_id": k.position_id}
+                for k in self.active_positions()
+            ],
+            "inflight": [
+                {"strategy_id": k.strategy_id, "position_id": k.position_id}
+                for k in sorted(
+                    self._inflight, key=lambda k: (k.strategy_id, k.position_id)
+                )
+            ],
+        }

--- a/tests/unit/test_position_review_loop.py
+++ b/tests/unit/test_position_review_loop.py
@@ -1,0 +1,278 @@
+"""Tests for the in-position re-evaluation loop (#135, P1.4-AC7 / FR60)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from cio.core.position_review_loop import (
+    DEFAULT_REEVAL_INTERVAL_SECONDS,
+    SOURCE_CADENCE,
+    SOURCE_EVENT,
+    PositionKey,
+    PositionReviewLoop,
+)
+
+
+class _RecordingRunner:
+    """Async runner that records every (key, reason) it was called with.
+
+    Optionally simulates a slow runner via ``hold_for_seconds`` so the
+    backpressure tests can deterministically fire a second trigger
+    while the first is still in flight.
+    """
+
+    def __init__(self, hold_for_seconds: float = 0.0) -> None:
+        self.calls: list[tuple[PositionKey, str]] = []
+        self._hold = hold_for_seconds
+        self.release = asyncio.Event()
+
+    async def __call__(self, key: PositionKey, reason: str) -> Any:
+        self.calls.append((key, reason))
+        if self._hold > 0:
+            # Wait for either the configured hold or an explicit release.
+            try:
+                await asyncio.wait_for(self.release.wait(), timeout=self._hold)
+            except TimeoutError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Construction / registry
+# ---------------------------------------------------------------------------
+
+
+def test_default_interval_matches_fr60():
+    assert DEFAULT_REEVAL_INTERVAL_SECONDS == 300.0
+
+
+def test_interval_must_be_positive():
+    runner = _RecordingRunner()
+    with pytest.raises(ValueError) as zero_err:
+        PositionReviewLoop(runner=runner, interval_seconds=0)
+    with pytest.raises(ValueError) as neg_err:
+        PositionReviewLoop(runner=runner, interval_seconds=-5)
+    assert "interval_seconds" in str(zero_err.value)
+    assert "interval_seconds" in str(neg_err.value)
+
+
+def test_add_remove_active_positions_roundtrip():
+    runner = _RecordingRunner()
+    loop = PositionReviewLoop(runner=runner)
+    loop.add_position("s1", "p1")
+    loop.add_position("s1", "p2")
+    loop.add_position("s2", "p1")
+
+    keys = loop.active_positions()
+    assert PositionKey("s1", "p1") in keys
+    assert PositionKey("s1", "p2") in keys
+    assert PositionKey("s2", "p1") in keys
+    assert len(keys) == 3
+
+    loop.remove_position("s1", "p1")
+    keys2 = loop.active_positions()
+    assert PositionKey("s1", "p1") not in keys2
+    assert len(keys2) == 2
+
+
+def test_remove_unknown_position_is_noop():
+    loop = PositionReviewLoop(runner=_RecordingRunner())
+    loop.remove_position("nope", "nope")  # must not raise
+    assert loop.active_positions() == []
+
+
+# ---------------------------------------------------------------------------
+# AC7.b — event trigger (the simplest path, exercises the dispatch core)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_trigger_invokes_runner_once():
+    runner = _RecordingRunner()
+    loop = PositionReviewLoop(runner=runner)
+
+    fired = await loop.trigger_event(
+        PositionKey("s1", "p1"),
+        reason="evaluator_unhealthy:ingest",
+    )
+
+    assert fired is True
+    assert runner.calls == [(PositionKey("s1", "p1"), "evaluator_unhealthy:ingest")]
+
+
+@pytest.mark.asyncio
+async def test_event_trigger_records_distinct_reasons_per_call():
+    runner = _RecordingRunner()
+    loop = PositionReviewLoop(runner=runner)
+    key = PositionKey("s1", "p1")
+
+    await loop.trigger_event(key, reason="regime_shift")
+    await loop.trigger_event(key, reason="drawdown_breach")
+
+    assert [c[1] for c in runner.calls] == ["regime_shift", "drawdown_breach"]
+
+
+# ---------------------------------------------------------------------------
+# AC7.c — backpressure: second trigger while first in-flight is dropped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backpressure_drops_second_trigger_for_same_position():
+    runner = _RecordingRunner(hold_for_seconds=5.0)
+    loop = PositionReviewLoop(runner=runner)
+    key = PositionKey("s1", "p1")
+
+    # Start a first trigger that holds the runner.
+    first = asyncio.create_task(loop.trigger_event(key, reason="cadence-1"))
+    await asyncio.sleep(0.05)  # let the runner enter the held state
+
+    # Second trigger arrives while first still in flight → dropped.
+    fired = await loop.trigger_event(key, reason="cadence-2")
+    assert fired is False
+    assert len(runner.calls) == 1
+
+    # Release the first runner; it completes cleanly.
+    runner.release.set()
+    assert await first is True
+
+
+@pytest.mark.asyncio
+async def test_backpressure_does_not_drop_other_positions():
+    runner = _RecordingRunner(hold_for_seconds=5.0)
+    loop = PositionReviewLoop(runner=runner)
+    key1 = PositionKey("s1", "p1")
+    key2 = PositionKey("s1", "p2")
+
+    first = asyncio.create_task(loop.trigger_event(key1, reason="cadence"))
+    await asyncio.sleep(0.05)
+
+    # Different position — should NOT be dropped.
+    fired = await loop.trigger_event(key2, reason="cadence")
+    assert fired is True
+    assert len(runner.calls) == 2
+
+    runner.release.set()
+    await first
+
+
+@pytest.mark.asyncio
+async def test_backpressure_clears_after_runner_completes():
+    runner = _RecordingRunner()
+    loop = PositionReviewLoop(runner=runner)
+    key = PositionKey("s1", "p1")
+
+    # First completes immediately, second should fire.
+    assert await loop.trigger_event(key, reason="r1") is True
+    assert await loop.trigger_event(key, reason="r2") is True
+    assert len(runner.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_runner_exception_does_not_break_loop_state():
+    """If a runner raises, the in-flight slot must still clear."""
+
+    class _BrokenRunner:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(self, key, reason):
+            self.calls += 1
+            raise RuntimeError("arbitration crashed")
+
+    runner = _BrokenRunner()
+    loop = PositionReviewLoop(runner=runner)
+    key = PositionKey("s1", "p1")
+
+    first = await loop.trigger_event(key, reason="r1")
+    # Slot must have been cleared → second trigger fires (not dropped).
+    second = await loop.trigger_event(key, reason="r2")
+
+    assert first is True
+    assert second is True
+    assert runner.calls == 2
+    snap = loop.snapshot()
+    assert snap["inflight"] == []
+
+
+# ---------------------------------------------------------------------------
+# AC7.a — cadence: tick fires one re-eval per active position
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cadence_fires_one_reeval_per_active_position():
+    runner = _RecordingRunner()
+    # Very short interval so the test doesn't need real time.
+    loop = PositionReviewLoop(runner=runner, interval_seconds=0.05)
+    loop.add_position("s1", "p1")
+    loop.add_position("s2", "p2")
+
+    await loop.start()
+    # Wait long enough for ~2 ticks.
+    await asyncio.sleep(0.18)
+    await loop.stop()
+
+    fired_keys = {c[0] for c in runner.calls}
+    assert PositionKey("s1", "p1") in fired_keys
+    assert PositionKey("s2", "p2") in fired_keys
+    # Reason should be the cadence reason on every cadence call.
+    cadence_calls = [c for c in runner.calls if c[1] == "scheduled_review_cadence"]
+    assert len(cadence_calls) >= 2
+
+
+@pytest.mark.asyncio
+async def test_cadence_skips_removed_positions():
+    runner = _RecordingRunner()
+    loop = PositionReviewLoop(runner=runner, interval_seconds=0.05)
+    loop.add_position("s1", "p1")
+
+    await loop.start()
+    await asyncio.sleep(0.07)
+    # Remove the position mid-flight.
+    loop.remove_position("s1", "p1")
+    await asyncio.sleep(0.20)
+    await loop.stop()
+
+    # After removal, no further cadence fires for that key.
+    fired_after_removal = [c for c in runner.calls if c[0] == PositionKey("s1", "p1")]
+    # At least one fired before removal, but the count plateaus after.
+    assert len(fired_after_removal) >= 1
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent():
+    runner = _RecordingRunner()
+    loop = PositionReviewLoop(runner=runner, interval_seconds=0.05)
+    await loop.start()
+    # Second start() must not spawn a duplicate task.
+    await loop.start()
+    await loop.stop()
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_lists_active_positions_sorted():
+    loop = PositionReviewLoop(runner=_RecordingRunner())
+    loop.add_position("s2", "p2")
+    loop.add_position("s1", "p1")
+
+    snap = loop.snapshot()
+    assert snap["interval_seconds"] == DEFAULT_REEVAL_INTERVAL_SECONDS
+    assert snap["active"] == [
+        {"strategy_id": "s1", "position_id": "p1"},
+        {"strategy_id": "s2", "position_id": "p2"},
+    ]
+    assert snap["inflight"] == []
+
+
+def test_source_labels_match_constants():
+    # Source label values are exposed for callers wiring metrics
+    # dashboards directly; keep the strings stable.
+    assert SOURCE_CADENCE == "cadence"
+    assert SOURCE_EVENT == "event"


### PR DESCRIPTION
## Summary

Closes petrosa-cio#135 — `[P1.4-AC7] In-position re-evaluation loop (FR60)`.

Adds `PositionReviewLoop` — periodic + event-driven re-evaluation of open positions so the CIO reasons about live market / portfolio / evaluator state, not just at admission time.

## ACs

- **AC7.a — Configurable cadence**: cadence task fires one `SCHEDULED_REVIEW` per active position every `CIO_REEVAL_INTERVAL_SECONDS` (default 300, matching FR60's decision_window). Exposed as `interval_seconds` constructor arg.
- **AC7.b — Event triggers**: `await loop.trigger_event(key, reason=...)` entry point lets external hooks force a re-evaluation outside the cadence:
  - `EvaluatorSubscriber` on unhealthy verdict (FR57)
  - regime shift on market_state (FR55)
  - drawdown breach (FR30) — `DrawdownBreachEmitter` from cio#140 can call this
  - characterization drift (FR20)

  The hookup itself (subscriber → trigger_event) is left for a follow-up wiring PR so this change can be reviewed in isolation. The contract surface is the public method.
- **AC7.c — Backpressure**: at most one re-evaluation in flight per `(strategy_id, position_id)`. Subsequent triggers are dropped and counted on `cio_reeval_dropped_total{source=cadence|event}`. Fired triggers are counted on `cio_reeval_fired_total{source}`.
- **AC7.d — Tests**: 15 unit tests cover construction (default cadence matches FR60, positive-interval guard), registry (add/remove/idempotency), event triggers, backpressure (same position drops, different positions don't drop, slot recovery after runner exception), cadence (fires per position, skips removed positions, idempotent `start()`), and the diagnostics `snapshot()` shape.

## Out of scope

Wiring `PositionReviewLoop` into `cio/main.py` (instantiate + `start()`, register positions on EXECUTE, drop on EXIT_NOW / close, hook `EvaluatorSubscriber` + `DrawdownBreachEmitter` callbacks) is intentionally a follow-up:

- Keeps this PR focused on the loop contract + tests.
- The `RunnerFn` callback signature is intentionally minimal (`(key, reason) -> Awaitable[Any]`), so the boot path can plumb whatever runner it has (the SignalArbiter's `run_scheduled_review` or a thin shim).

## Test results

```
.venv/bin/python -m pytest tests/unit/test_position_review_loop.py
15 passed in 5.62s

.venv/bin/python -m pytest tests/
377 passed, 1 warning in 26.19s

.venv/bin/python -m ruff check cio/core/position_review_loop.py tests/unit/test_position_review_loop.py
All checks passed!
```

## References

- Parent EPIC: petrosa-cio#122
- Hard dependency: petrosa-cio#134 (in-position ActionType vocabulary, MERGED 2026-05-29) — supplies MODIFY_STOPS / EXIT_NOW / SCALE_OUT that scheduled re-evals will dispatch.
- petrosa-cio#140 (drawdown-envelope breach, MERGED 2026-05-29) — `DrawdownBreachEmitter` is one of the AC7.b event-trigger sources.
- PRD: FR60 (re-eval cadence), FR55 / FR57 / FR30 / FR20 (event triggers).
