### PR TITLE
test(136): end-to-end in-position loop integration test (P1.4-AC8 / FR60)

### DIFF
--- a/tests/integration/test_in_position_loop.py
+++ b/tests/integration/test_in_position_loop.py
@@ -1,0 +1,250 @@
+"""End-to-end integration test for the in-position re-evaluation loop (#136, AC8 / FR60).
+
+Exercises the loop that #134 (in-position ActionType + NATS dispatch + audit)
+and #135 (PositionReviewLoop cadence + backpressure) shipped — the two
+pieces that make up the P1.4 in-position governance pipeline producer side.
+
+Scope (AC8.a):
+    A position opens → simulated cadence tick fires SCHEDULED_REVIEW →
+    a runner (the integration's stand-in for the SignalArbiter +
+    OutputRouter wiring at app boot) dispatches an in-position action
+    via NATS → the audit copy lands on ``cio.decision.audit.<action>``
+    → operator-replay surface (dashboard ring buffer) carries the
+    decision.
+
+This test is deliberately in-process: instantiates the real
+``PositionReviewLoop`` + ``OutputRouter`` against a recording NATS
+client + an in-memory ``DecisionStore`` (the dashboard's ring buffer).
+Mirrors AC8.c assertions without booting Mongo, Redis, or a real NATS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cio.core.alerting.fr66_alerts import CIO_ALERT_ACTIONS
+from cio.core.position_review_loop import PositionKey, PositionReviewLoop
+from cio.core.router import OutputRouter
+from cio.models import (
+    ActionType,
+    ActivationRecommendation,
+    ConfidenceLevel,
+    DecisionResult,
+    HealthStatus,
+    RegimeFit,
+    TriggerContext,
+)
+
+
+class _RecordingNATS:
+    """Captures (subject, payload-dict) for every publish."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        try:
+            decoded = json.loads(payload.decode())
+        except (json.JSONDecodeError, AttributeError):
+            decoded = {"raw": payload.decode(errors="replace")}
+        self.published.append((subject, decoded))
+
+    def published_to(self, prefix: str) -> list[tuple[str, dict[str, Any]]]:
+        return [(s, p) for s, p in self.published if s.startswith(prefix)]
+
+
+class _RecordingDecisionStore:
+    """In-memory dashboard ring buffer — captures everything the router records."""
+
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+
+    def record(self, record) -> None:
+        self.records.append(record)
+
+
+def _build_router(nats, store=None) -> OutputRouter:
+    return OutputRouter(
+        nats_client=nats,
+        vector_client=AsyncMock(),
+        ta_bot_url=None,
+        realtime_strategies_url=None,
+        decision_store=store or _RecordingDecisionStore(),
+    )
+
+
+def _build_in_position_context(
+    *,
+    strategy_id: str = "momentum-v3",
+    position_id: str = "POS-1234",
+):
+    """A MagicMock(spec=TriggerContext) — same pattern as test_router_in_position_actions.py."""
+    ctx = MagicMock(spec=TriggerContext)
+    ctx.strategy_id = strategy_id
+    ctx.decision_id = f"dec-{position_id}"
+    ctx.correlation_id = f"corr-{position_id}"
+    ctx.trigger_payload = {"symbol": "BTCUSDT", "position_id": position_id}
+    ctx.pre_decision_context = None
+    return ctx
+
+
+def _build_in_position_decision(action: ActionType) -> DecisionResult:
+    """Real DecisionResult — same shape as test_router_in_position_actions.py."""
+    return DecisionResult(
+        hard_blocked=False,
+        ev_passes=True,
+        cost_viable=True,
+        regime_confidence=ConfidenceLevel.HIGH,
+        regime_fit=RegimeFit.GOOD,
+        strategy_health=HealthStatus.HEALTHY,
+        activation_recommendation=ActivationRecommendation.RUN,
+        action=action,
+        justification=f"scheduled_review action={action.value}",
+        thought_trace=f"in-position re-evaluation produced {action.value}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC8.c.2 — cadence fires per active position (integration angle on #135)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cadence_fires_one_review_per_active_position():
+    fired: list[PositionKey] = []
+
+    async def _runner(key: PositionKey, reason: str) -> None:
+        fired.append(key)
+
+    loop = PositionReviewLoop(runner=_runner, interval_seconds=0.05)
+    loop.add_position("momentum-v3", "POS-1")
+    loop.add_position("meanrev-v1", "POS-2")
+    await loop.start()
+    await asyncio.sleep(0.18)
+    await loop.stop()
+
+    fired_set = set(fired)
+    assert PositionKey("momentum-v3", "POS-1") in fired_set
+    assert PositionKey("meanrev-v1", "POS-2") in fired_set
+
+
+# ---------------------------------------------------------------------------
+# AC8.a + AC8.c.3 — in-position dispatch lands on NATS + audit channels
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_in_position_dispatch_publishes_position_subject_and_audit():
+    nats = _RecordingNATS()
+    store = _RecordingDecisionStore()
+    router = _build_router(nats, store)
+
+    context = _build_in_position_context()
+    decision = _build_in_position_decision(ActionType.MODIFY_STOPS)
+    await router.route(context, decision)
+
+    position_emits = nats.published_to(
+        f"cio.position.modify_stops.{context.strategy_id}"
+    )
+    assert len(position_emits) >= 1
+    payload = position_emits[0][1]
+    assert payload.get("action") == ActionType.MODIFY_STOPS.value
+
+    audit_emits = nats.published_to(
+        f"cio.decision.audit.{ActionType.MODIFY_STOPS.value}"
+    )
+    assert len(audit_emits) >= 1
+    audit_payload = audit_emits[0][1]
+    assert audit_payload.get("strategy_id") == context.strategy_id
+    assert audit_payload.get("action") == ActionType.MODIFY_STOPS.value
+
+
+@pytest.mark.asyncio
+async def test_exit_now_also_fires_fr66_governance_alert():
+    """EXIT_NOW is in CIO_ALERT_ACTIONS → in-position subject + alert subject must both fire."""
+    nats = _RecordingNATS()
+    router = _build_router(nats)
+
+    context = _build_in_position_context(strategy_id="momentum-v3", position_id="POS-7")
+    decision = _build_in_position_decision(ActionType.EXIT_NOW)
+    await router.route(context, decision)
+
+    assert nats.published_to("cio.position.exit_now.momentum-v3"), (
+        "in-position dispatch missing"
+    )
+    assert nats.published_to("alerts.cio.exit_now.momentum-v3"), (
+        "FR66 governance alert missing for EXIT_NOW"
+    )
+    assert "exit_now" in CIO_ALERT_ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# AC8.c.4 — operator replay (decision_store ring buffer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dashboard_decision_store_records_in_position_dispatch():
+    nats = _RecordingNATS()
+    store = _RecordingDecisionStore()
+    router = _build_router(nats, store)
+
+    context = _build_in_position_context(strategy_id="momentum-v3", position_id="POS-9")
+    decision = _build_in_position_decision(ActionType.SCALE_OUT)
+    await router.route(context, decision)
+
+    assert len(store.records) >= 1
+    rec = store.records[-1]
+    assert getattr(rec, "action", None) == ActionType.SCALE_OUT.value
+    assert getattr(rec, "strategy_id", None) == "momentum-v3"
+
+
+# ---------------------------------------------------------------------------
+# AC8.a closure — full end-to-end cadence → dispatch → replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_in_position_loop_cadence_to_dispatch_to_replay():
+    """
+    The headline AC8.a slice — one E2E pass through the in-position loop:
+      1. Position opens.
+      2. Cadence tick fires SCHEDULED_REVIEW (PositionReviewLoop).
+      3. Runner translates the cadence call into router.route(...) with
+         an in-position action.
+      4. Router publishes cio.position.<action> + cio.decision.audit.<action>.
+      5. Dashboard ring buffer records the decision for replay.
+    """
+    nats = _RecordingNATS()
+    store = _RecordingDecisionStore()
+    router = _build_router(nats, store)
+
+    async def _runner(key: PositionKey, reason: str) -> None:
+        context = _build_in_position_context(
+            strategy_id=key.strategy_id,
+            position_id=key.position_id,
+        )
+        decision = _build_in_position_decision(ActionType.MODIFY_STOPS)
+        await router.route(context, decision)
+
+    loop = PositionReviewLoop(runner=_runner, interval_seconds=0.05)
+    loop.add_position("momentum-v3", "POS-42")
+
+    await loop.start()
+    await asyncio.sleep(0.12)
+    await loop.stop()
+
+    assert nats.published_to("cio.position.modify_stops.momentum-v3"), (
+        "cadence never produced an in-position dispatch"
+    )
+    assert nats.published_to("cio.decision.audit.modify_stops"), (
+        "in-position dispatch produced no audit copy"
+    )
+    assert store.records, "dashboard ring buffer captured nothing"
+    rec = store.records[-1]
+    assert rec.action == ActionType.MODIFY_STOPS.value


### PR DESCRIPTION
## Summary

Closes petrosa-cio#136 — `[P1.4-AC8] End-to-end in-position loop integration test`.

5 integration tests exercising the full in-position governance pipeline in-process — the contracts that #134 (in-position ActionType + NATS dispatch + audit) and #135 (PositionReviewLoop cadence + backpressure) shipped, stitched end-to-end.

## ACs

- **AC8.a — Scenario**: position opens → cadence tick fires `SCHEDULED_REVIEW` → runner translates the tick into `router.route(context, decision)` → `cio.position.<action>.<sid>` + `cio.decision.audit.<action>` land on NATS → operator-replay surface (dashboard ring buffer) carries the dispatch. Covered by `test_full_in_position_loop_cadence_to_dispatch_to_replay`.
- **AC8.b — Test location**: `tests/integration/test_in_position_loop.py` (matches the existing `tests/integration/` layout from `test_nats_to_nats_loop.py`).
- **AC8.c — Assertions**:
  1. **Pre-decision context surfaces** — exercised via the existing #134 router tests that pass MagicMock(spec=TriggerContext); the bundle assembly itself is covered by #131 unit tests.
  2. **Cadence fires** — `test_cadence_fires_one_review_per_active_position` integration-angle re-assert of #135's PositionReviewLoop contract.
  3. **Audit records `decision_id` + position-shaped context** — `test_in_position_dispatch_publishes_position_subject_and_audit` asserts `cio.decision.audit.<action>` payload carries `strategy_id` + `action`.
  4. **`/api/dashboard/decisions/recent` returns assembled context** — `test_dashboard_decision_store_records_in_position_dispatch` asserts the ring buffer (which the dashboard endpoint reads verbatim) records the dispatched decision.

Extra coverage (overlap with the alert spine):

- `test_exit_now_also_fires_fr66_governance_alert` — confirms a single `EXIT_NOW` dispatch fires BOTH `cio.position.exit_now.<sid>` AND `alerts.cio.exit_now.<sid>` without any wiring change between #134 and #139.

## Files

- `tests/integration/test_in_position_loop.py` *(new, ~250 LoC, 5 tests)*

## Test results

```
.venv/bin/python -m pytest tests/integration/test_in_position_loop.py
5 passed in 0.98s

.venv/bin/python -m pytest tests/
382 passed, 1 warning in 25.10s

.venv/bin/python -m ruff check tests/integration/test_in_position_loop.py
All checks passed!
```

## Design notes

- **In-process, sub-second test**: recording NATS stub + ring-buffer `DecisionStore` + `AsyncMock` vector client. No Mongo, Redis, or real NATS server. Mirrors the existing `test_router_in_position_actions.py` pattern (which I shipped in PR #149 for #134).
- **Real PositionReviewLoop, real OutputRouter**: the integration is genuine — the cadence task spawns, the router's full T-junction emit happens, the dedup window is exercised. Only the boundaries (NATS, vector DB) are mocked.

## References

- Parent EPIC: petrosa-cio#122
- Hard dependencies (all MERGED 2026-05-29): petrosa-cio#134 (PR #149) + petrosa-cio#135 (PR #150) + petrosa-cio#139 (PR #147) + petrosa-cio#140 (PR #148)
- PRD: FR59 (in-position governance), FR60 (re-eval cadence)
