### PR TITLE
feat(152): envelope-drift alert emitter (P4.6-AC5 / FR62 / FR66)

### DIFF
--- a/cio/core/alerting/envelope_drift_emitter.py
+++ b/cio/core/alerting/envelope_drift_emitter.py
@@ -1,0 +1,256 @@
+"""Envelope-drift alert emitter (P4.6-AC5, #152 — FR62 / FR66).
+
+Owns the AC5.a/b/c/d behaviour for envelope drift detection:
+
+* AC5.a — divergence is computed between a characterization-emitted
+  proposed envelope and the active operator-approved envelope; the
+  threshold is configurable (default 10%).
+* AC5.b — when divergence exceeds the threshold, emits
+  ``alerts.envelope.drift_detected.<strategy_key>`` on NATS with the
+  payload shaped by :func:`cio.core.alerting.fr66_alerts.build_envelope_drift_alert`.
+* AC5.c — alerts are rate-limited per ``strategy_key`` (default
+  ``1 / hour``) so a noisy characterization pipeline can't storm the
+  operator.
+* AC5.d — **by construction**: this emitter has no envelope-mutation
+  API. It only inspects values, computes divergence, and publishes
+  alerts. The active envelope can only change via the
+  petrosa-data-manager#187 operator-approval workflow.
+
+The emitter is process-local and in-memory (same NFR-R1 detection-time
+window convention as :class:`cio.core.alerting.drawdown_breach_emitter.DrawdownBreachEmitter`):
+the rate-limit table resets on restart, which biases toward "alert at
+least once after a restart" rather than "guaranteed no-storm under
+crash-loop". Acceptable for an operator-facing signal.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from cio.core.alerting.fr66_alerts import (
+    SEVERITY_WARNING,
+    build_envelope_drift_alert,
+    envelope_drift_subject,
+    publish_fr66_alert,
+)
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+if TYPE_CHECKING:
+    from cio.core.alerting.fr66_alerts import _NATSPublisher
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_DIVERGENCE_THRESHOLD = 0.10
+"""AC5.a default: a proposed value diverging by ≥ 10% from the approved
+value is "materially different"."""
+
+DEFAULT_RATE_LIMIT_WINDOW = timedelta(hours=1)
+"""AC5.c default: max one envelope-drift alert per ``strategy_key`` per hour."""
+
+
+def compute_max_divergence_pct(
+    current_value: dict[str, Any] | None,
+    proposed_value: dict[str, Any],
+) -> float:
+    """Return the maximum per-key divergence between current and proposed envelopes.
+
+    The schema of an envelope value is open (per
+    :mod:`data_manager.models.envelope`) — this helper only attempts to
+    measure divergence for **numeric** keys that exist on both sides.
+    Each shared numeric key contributes
+    ``abs(proposed - current) / max(abs(current), epsilon)``; the helper
+    returns the max across keys. Keys present on only one side are treated
+    as ``infinity`` divergence (returns ``float('inf')``), so a producer
+    adding/removing fields always crosses any sensible threshold.
+
+    Returns ``float('inf')`` when ``current_value is None`` — there's no
+    approved envelope to compare against, so AC5.a says "this should alert"
+    (the operator has to consciously accept the first envelope).
+    """
+    if current_value is None:
+        return float("inf")
+    if not proposed_value and not current_value:
+        return 0.0
+
+    current_keys = set(_numeric_keys(current_value))
+    proposed_keys = set(_numeric_keys(proposed_value))
+    only_current = current_keys - proposed_keys
+    only_proposed = proposed_keys - current_keys
+    shared = current_keys & proposed_keys
+
+    if only_current or only_proposed:
+        # Schema change is always material.
+        return float("inf")
+
+    if not shared:
+        # No numeric keys to compare — treat as max divergence so the
+        # operator still gets notified about the proposed value's shape.
+        return float("inf")
+
+    epsilon = 1e-12
+    max_div = 0.0
+    for key in shared:
+        cur = float(current_value[key])
+        prop = float(proposed_value[key])
+        denom = max(abs(cur), epsilon)
+        div = abs(prop - cur) / denom
+        if div > max_div:
+            max_div = div
+    return max_div
+
+
+def _numeric_keys(value: dict[str, Any]) -> list[str]:
+    """Return the keys of ``value`` whose value is numeric (int or float)."""
+    return [
+        k
+        for k, v in value.items()
+        if isinstance(v, int | float) and not isinstance(v, bool)
+    ]
+
+
+@dataclass(frozen=True)
+class DriftAlertRecord:
+    """Last alert event for one ``strategy_key`` (used by the rate-limiter)."""
+
+    strategy_key: str
+    fired_at: datetime
+    divergence_pct: float
+    originating_characterization_revision: str
+
+
+@dataclass
+class EnvelopeDriftEmitter:
+    """Stateful emitter for ``alerts.envelope.drift_detected.<strategy_key>``.
+
+    Usage from a producer (e.g. a future characterization-pipeline
+    consumer)::
+
+        emitter = EnvelopeDriftEmitter(nats_client=nc)
+        emitted = await emitter.check_and_emit(
+            strategy_key="strategy:btc_momentum_v3",
+            current_version=3,
+            current_value={"max_drawdown_pct": 5.0, "stop_loss_pct": 2.0},
+            proposed_value={"max_drawdown_pct": 8.0, "stop_loss_pct": 2.0},
+            originating_characterization_revision="char-rev-42",
+        )
+
+    No envelope is mutated by this class — emitting an alert is the only
+    side effect (AC5.d).
+    """
+
+    nats_client: _NATSPublisher | None = None
+    divergence_threshold: float = DEFAULT_DIVERGENCE_THRESHOLD
+    rate_limit_window: timedelta = DEFAULT_RATE_LIMIT_WINDOW
+    _last_fired: dict[str, DriftAlertRecord] = field(default_factory=dict, init=False)
+
+    async def check_and_emit(
+        self,
+        *,
+        strategy_key: str,
+        current_version: int | None,
+        current_value: dict[str, Any] | None,
+        proposed_value: dict[str, Any],
+        originating_characterization_revision: str,
+        severity: str = SEVERITY_WARNING,
+        observed_at: datetime | None = None,
+    ) -> bool:
+        """Emit a drift alert if divergence > threshold AND rate-limit window expired.
+
+        Returns ``True`` if an alert was emitted, ``False`` for any of:
+
+        * divergence ≤ threshold (AC5.a: not material), OR
+        * rate-limit window still active for this ``strategy_key`` (AC5.c).
+
+        NATS publish failures are best-effort and do not flip the return
+        to ``False`` — the rate-limit record is still updated because the
+        operator's "we considered alerting and won't repeat for a window"
+        intent doesn't depend on the bus being healthy.
+        """
+        divergence_pct = compute_max_divergence_pct(current_value, proposed_value)
+        now = observed_at or datetime.now(UTC)
+
+        if divergence_pct <= self.divergence_threshold:
+            logger.debug(
+                "envelope_drift.below_threshold strategy_key=%s divergence=%.4f "
+                "threshold=%.4f",
+                strategy_key,
+                divergence_pct,
+                self.divergence_threshold,
+            )
+            return False
+
+        last = self._last_fired.get(strategy_key)
+        if last is not None and (now - last.fired_at) < self.rate_limit_window:
+            logger.debug(
+                "envelope_drift.rate_limited strategy_key=%s divergence=%.4f "
+                "last_fired_at=%s window=%s",
+                strategy_key,
+                divergence_pct,
+                last.fired_at.isoformat(),
+                self.rate_limit_window,
+            )
+            return False
+
+        payload = build_envelope_drift_alert(
+            strategy_key=strategy_key,
+            current_version=current_version,
+            current_value=current_value,
+            proposed_value=proposed_value,
+            divergence_pct=divergence_pct,
+            originating_characterization_revision=originating_characterization_revision,
+            severity=severity,
+            observed_at=now,
+        )
+        logger.info(
+            "envelope_drift.detected strategy_key=%s divergence=%.4f "
+            "current_version=%s char_revision=%s",
+            strategy_key,
+            divergence_pct,
+            current_version,
+            originating_characterization_revision,
+        )
+        await publish_fr66_alert(
+            self.nats_client,
+            subject=envelope_drift_subject(strategy_key),
+            payload=payload,
+        )
+        self._last_fired[strategy_key] = DriftAlertRecord(
+            strategy_key=strategy_key,
+            fired_at=now,
+            divergence_pct=divergence_pct,
+            originating_characterization_revision=originating_characterization_revision,
+        )
+        return True
+
+    def last_fired_at(self, strategy_key: str) -> datetime | None:
+        """Diagnostic: return the last fire time for ``strategy_key``, or None."""
+        rec = self._last_fired.get(strategy_key)
+        return rec.fired_at if rec is not None else None
+
+    def snapshot(self) -> dict[str, Any]:
+        """State export for debug/diagnostics endpoints."""
+        return {
+            "fired": [
+                {
+                    "strategy_key": r.strategy_key,
+                    "fired_at": r.fired_at.isoformat(),
+                    "divergence_pct": r.divergence_pct,
+                    "originating_characterization_revision": (
+                        r.originating_characterization_revision
+                    ),
+                }
+                for r in self._last_fired.values()
+            ],
+            "threshold": self.divergence_threshold,
+            "rate_limit_window_seconds": self.rate_limit_window.total_seconds(),
+        }

--- a/cio/core/alerting/fr66_alerts.py
+++ b/cio/core/alerting/fr66_alerts.py
@@ -46,6 +46,8 @@ CATEGORY_EVALUATOR_UNHEALTHY = "evaluator_unhealthy"
 CATEGORY_CIO_GOVERNANCE_ACTION = "cio_governance_action"
 # P8-AC2c (#140) — drawdown vs. envelope breach (FR66 c / FR30 / FR62).
 CATEGORY_DRAWDOWN_ENVELOPE_BREACH = "drawdown_envelope_breach"
+# P4.6-AC5 (#152) — characterization-vs-approved envelope drift (FR62 / FR66).
+CATEGORY_ENVELOPE_DRIFT_DETECTED = "envelope_drift_detected"
 
 # AC2.b — the four ActionType values that get an alert event.
 CIO_ALERT_ACTIONS: frozenset[str] = frozenset({"veto", "demote", "retire", "exit_now"})
@@ -176,6 +178,66 @@ def build_drawdown_breach_alert(
     }
 
 
+def build_envelope_drift_alert(
+    *,
+    strategy_key: str,
+    current_version: int | None,
+    current_value: dict[str, Any] | None,
+    proposed_value: dict[str, Any],
+    divergence_pct: float,
+    originating_characterization_revision: str,
+    severity: str = SEVERITY_WARNING,
+    observed_at: datetime | None = None,
+) -> dict[str, Any]:
+    """AC5.b payload for ``alerts.envelope.drift_detected.<strategy_key>`` (P4.6-AC5).
+
+    Fires when a characterization-emitted envelope diverges from the active
+    operator-approved envelope by more than the configured threshold (default
+    10%). ``current_value=None`` / ``current_version=None`` means no prior
+    approved envelope exists — that branch alerts with the "first approval
+    required" semantic so the operator knows a producer is trying to seed
+    a fresh envelope without explicit consent.
+
+    AC5.d is enforced **by construction at the call site**: this payload
+    carries the proposed values for operator inspection, but the producer
+    never mutates the active Envelope. The operator workflow on
+    petrosa-data-manager (#187) is the only legitimate write path.
+    """
+    detected_at = _iso_utc(observed_at)
+    if current_value is None:
+        message = (
+            f"Envelope drift detected on strategy_key={strategy_key}: "
+            f"no operator-approved envelope yet exists; characterization "
+            f"revision {originating_characterization_revision} proposed a fresh value"
+        )
+    else:
+        message = (
+            f"Envelope drift detected on strategy_key={strategy_key}: "
+            f"proposed envelope diverges from approved v{current_version} "
+            f"by {divergence_pct:.1%} (characterization "
+            f"revision {originating_characterization_revision})"
+        )
+    return {
+        "category": CATEGORY_ENVELOPE_DRIFT_DETECTED,
+        "severity": severity,
+        "strategy_key": strategy_key,
+        "current_version": current_version,
+        "current_value": current_value,
+        "proposed_value": proposed_value,
+        "divergence_pct": divergence_pct,
+        "originating_characterization_revision": originating_characterization_revision,
+        "message": message,
+        "decision_id": None,
+        "timestamp": detected_at,
+        "dedupe_key": _dedupe_key(
+            "envelope_drift",
+            strategy_key,
+            originating_characterization_revision,
+            detected_at[:13],
+        ),
+    }
+
+
 def evaluator_unhealthy_subject(subsystem: str) -> str:
     safe = (subsystem or "unknown").strip() or "unknown"
     return f"alerts.evaluator.unhealthy.{safe}"
@@ -191,6 +253,18 @@ def drawdown_breach_subject(strategy_id: str) -> str:
     """AC2.c.2: ``alerts.drawdown.breach.<strategy_id>``."""
     safe_strategy = (strategy_id or "unknown").strip() or "unknown"
     return f"alerts.drawdown.breach.{safe_strategy}"
+
+
+def envelope_drift_subject(strategy_key: str) -> str:
+    """AC5.b: ``alerts.envelope.drift_detected.<strategy_key>`` (P4.6-AC5).
+
+    ``strategy_key`` is the flat-string partition key from
+    :mod:`data_manager.models.envelope` (``strategy:<id>`` or
+    ``portfolio:<id>``); the helper passes it through verbatim after the
+    same defensive ``strip()/unknown`` shaping the other subjects use.
+    """
+    safe = (strategy_key or "unknown").strip() or "unknown"
+    return f"alerts.envelope.drift_detected.{safe}"
 
 
 async def publish_fr66_alert(

--- a/tests/unit/test_envelope_drift_emitter.py
+++ b/tests/unit/test_envelope_drift_emitter.py
@@ -1,0 +1,328 @@
+"""Tests for the envelope-drift alert emitter (#152, P4.6-AC5 / FR62 / FR66).
+
+Coverage maps to ACs:
+
+* AC5.a — divergence detection with configurable threshold; below-threshold
+  is silent; above-threshold fires; missing approved envelope is treated as
+  divergence = infinity.
+* AC5.b — payload + subject shape contract via the
+  ``alerts.envelope.drift_detected.<strategy_key>`` subject.
+* AC5.c — rate-limit suppression per ``strategy_key``; window-expiry
+  re-arms the emitter.
+* AC5.d — non-mutation property: the emitter exposes no envelope-update
+  method; only inspection + alert publishing.
+* AC5.e — the three required branches are explicit tests below
+  (``no_approved`` / ``approved_below_threshold`` / ``approved_above_threshold``).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from cio.core.alerting.envelope_drift_emitter import (
+    DEFAULT_DIVERGENCE_THRESHOLD,
+    DEFAULT_RATE_LIMIT_WINDOW,
+    EnvelopeDriftEmitter,
+    compute_max_divergence_pct,
+)
+from cio.core.alerting.fr66_alerts import (
+    CATEGORY_ENVELOPE_DRIFT_DETECTED,
+    SEVERITY_WARNING,
+    build_envelope_drift_alert,
+    envelope_drift_subject,
+)
+
+
+class _RecordingNATS:
+    """Captures (subject, payload) tuples without needing nats-py."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict]] = []
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        self.published.append((subject, json.loads(payload.decode())))
+
+
+# ─── AC5.b — subject / payload contract ─────────────────────────────────────
+
+
+def test_envelope_drift_subject_shape() -> None:
+    assert (
+        envelope_drift_subject("strategy:btc")
+        == "alerts.envelope.drift_detected.strategy:btc"
+    )
+
+
+def test_envelope_drift_subject_handles_empty_key() -> None:
+    assert envelope_drift_subject("") == "alerts.envelope.drift_detected.unknown"
+    assert envelope_drift_subject("   ") == "alerts.envelope.drift_detected.unknown"
+
+
+def test_build_envelope_drift_alert_with_prior() -> None:
+    observed_at = datetime(2026, 5, 29, 12, 0, 0, tzinfo=UTC)
+    payload = build_envelope_drift_alert(
+        strategy_key="strategy:btc",
+        current_version=3,
+        current_value={"max_drawdown_pct": 5.0},
+        proposed_value={"max_drawdown_pct": 8.0},
+        divergence_pct=0.6,
+        originating_characterization_revision="char-rev-42",
+        observed_at=observed_at,
+    )
+    assert payload["category"] == CATEGORY_ENVELOPE_DRIFT_DETECTED
+    assert payload["severity"] == SEVERITY_WARNING
+    assert payload["strategy_key"] == "strategy:btc"
+    assert payload["current_version"] == 3
+    assert payload["current_value"] == {"max_drawdown_pct": 5.0}
+    assert payload["proposed_value"] == {"max_drawdown_pct": 8.0}
+    assert payload["divergence_pct"] == pytest.approx(0.6)
+    assert payload["originating_characterization_revision"] == "char-rev-42"
+    assert "v3" in payload["message"]
+    assert payload["timestamp"].startswith("2026-05-29T12:00:00")
+    assert "dedupe_key" in payload
+
+
+def test_build_envelope_drift_alert_no_prior() -> None:
+    """When no operator-approved envelope exists, message wording shifts."""
+    payload = build_envelope_drift_alert(
+        strategy_key="strategy:eth",
+        current_version=None,
+        current_value=None,
+        proposed_value={"max_drawdown_pct": 4.5},
+        divergence_pct=float("inf"),
+        originating_characterization_revision="char-rev-99",
+    )
+    assert payload["current_version"] is None
+    assert payload["current_value"] is None
+    assert "no operator-approved envelope" in payload["message"]
+
+
+# ─── AC5.a — divergence math ────────────────────────────────────────────────
+
+
+def test_compute_divergence_none_current_returns_infinity() -> None:
+    assert compute_max_divergence_pct(None, {"x": 1.0}) == float("inf")
+
+
+def test_compute_divergence_identical_values_returns_zero() -> None:
+    assert compute_max_divergence_pct({"x": 1.0}, {"x": 1.0}) == 0.0
+
+
+def test_compute_divergence_picks_max_across_keys() -> None:
+    current = {"a": 5.0, "b": 10.0}
+    proposed = {"a": 5.5, "b": 12.0}  # a: 10%, b: 20%
+    assert compute_max_divergence_pct(current, proposed) == pytest.approx(0.2)
+
+
+def test_compute_divergence_handles_zero_baseline() -> None:
+    """A current 0.0 → epsilon-denominator avoids div-by-zero (returns large finite)."""
+    div = compute_max_divergence_pct({"x": 0.0}, {"x": 0.01})
+    assert div > 1_000_000  # epsilon=1e-12 → 1e10-ish
+
+
+def test_compute_divergence_added_or_removed_key_is_infinity() -> None:
+    assert compute_max_divergence_pct({"x": 1.0}, {"x": 1.0, "y": 2.0}) == float("inf")
+    assert compute_max_divergence_pct({"x": 1.0, "y": 2.0}, {"x": 1.0}) == float("inf")
+
+
+def test_compute_divergence_ignores_non_numeric_keys() -> None:
+    """Numeric keys are compared; non-numeric keys don't drag the value."""
+    current = {"x": 1.0, "label": "old"}
+    proposed = {"x": 1.0, "label": "new"}
+    assert compute_max_divergence_pct(current, proposed) == 0.0
+
+
+# ─── AC5.e branch 1 — no_approved ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_branch_no_approved_fires_alert() -> None:
+    nats = _RecordingNATS()
+    emitter = EnvelopeDriftEmitter(nats_client=nats)
+    fired = await emitter.check_and_emit(
+        strategy_key="strategy:btc",
+        current_version=None,
+        current_value=None,
+        proposed_value={"max_drawdown_pct": 8.0},
+        originating_characterization_revision="char-rev-1",
+    )
+    assert fired is True
+    assert len(nats.published) == 1
+    subj, payload = nats.published[0]
+    assert subj == "alerts.envelope.drift_detected.strategy:btc"
+    assert payload["current_version"] is None
+    assert payload["divergence_pct"] == float("inf")
+
+
+# ─── AC5.e branch 2 — approved_below_threshold ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_branch_approved_below_threshold_is_silent() -> None:
+    nats = _RecordingNATS()
+    emitter = EnvelopeDriftEmitter(nats_client=nats)
+    fired = await emitter.check_and_emit(
+        strategy_key="strategy:btc",
+        current_version=3,
+        current_value={"max_drawdown_pct": 5.0},
+        proposed_value={"max_drawdown_pct": 5.4},  # 8% — below 10% default
+        originating_characterization_revision="char-rev-1",
+    )
+    assert fired is False
+    assert nats.published == []
+
+
+# ─── AC5.e branch 3 — approved_above_threshold ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_branch_approved_above_threshold_fires_alert() -> None:
+    nats = _RecordingNATS()
+    emitter = EnvelopeDriftEmitter(nats_client=nats)
+    fired = await emitter.check_and_emit(
+        strategy_key="strategy:btc",
+        current_version=3,
+        current_value={"max_drawdown_pct": 5.0},
+        proposed_value={"max_drawdown_pct": 6.0},  # 20% — above 10% default
+        originating_characterization_revision="char-rev-1",
+    )
+    assert fired is True
+    assert len(nats.published) == 1
+    _, payload = nats.published[0]
+    assert payload["divergence_pct"] == pytest.approx(0.2)
+    assert payload["current_version"] == 3
+
+
+# ─── AC5.c — rate-limit suppression ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_suppresses_within_window() -> None:
+    nats = _RecordingNATS()
+    emitter = EnvelopeDriftEmitter(
+        nats_client=nats, rate_limit_window=timedelta(hours=1)
+    )
+    t0 = datetime(2026, 5, 29, 12, 0, 0, tzinfo=UTC)
+
+    fired_1 = await emitter.check_and_emit(
+        strategy_key="strategy:btc",
+        current_version=3,
+        current_value={"x": 1.0},
+        proposed_value={"x": 2.0},
+        originating_characterization_revision="char-rev-1",
+        observed_at=t0,
+    )
+    fired_2 = await emitter.check_and_emit(
+        strategy_key="strategy:btc",
+        current_version=3,
+        current_value={"x": 1.0},
+        proposed_value={"x": 3.0},
+        originating_characterization_revision="char-rev-2",
+        observed_at=t0 + timedelta(minutes=30),  # still inside window
+    )
+
+    assert fired_1 is True
+    assert fired_2 is False
+    assert len(nats.published) == 1
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_re_arms_after_window() -> None:
+    nats = _RecordingNATS()
+    emitter = EnvelopeDriftEmitter(
+        nats_client=nats, rate_limit_window=timedelta(hours=1)
+    )
+    t0 = datetime(2026, 5, 29, 12, 0, 0, tzinfo=UTC)
+
+    await emitter.check_and_emit(
+        strategy_key="strategy:btc",
+        current_version=3,
+        current_value={"x": 1.0},
+        proposed_value={"x": 2.0},
+        originating_characterization_revision="char-rev-1",
+        observed_at=t0,
+    )
+    fired_2 = await emitter.check_and_emit(
+        strategy_key="strategy:btc",
+        current_version=3,
+        current_value={"x": 1.0},
+        proposed_value={"x": 3.0},
+        originating_characterization_revision="char-rev-2",
+        observed_at=t0 + timedelta(hours=2),  # outside window
+    )
+    assert fired_2 is True
+    assert len(nats.published) == 2
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_is_per_strategy_key() -> None:
+    """A different strategy_key is not suppressed by another strategy's recent alert."""
+    nats = _RecordingNATS()
+    emitter = EnvelopeDriftEmitter(nats_client=nats)
+    t0 = datetime(2026, 5, 29, 12, 0, 0, tzinfo=UTC)
+
+    await emitter.check_and_emit(
+        strategy_key="strategy:btc",
+        current_version=1,
+        current_value={"x": 1.0},
+        proposed_value={"x": 2.0},
+        originating_characterization_revision="char-rev-1",
+        observed_at=t0,
+    )
+    fired_eth = await emitter.check_and_emit(
+        strategy_key="strategy:eth",
+        current_version=1,
+        current_value={"x": 1.0},
+        proposed_value={"x": 2.0},
+        originating_characterization_revision="char-rev-1",
+        observed_at=t0,
+    )
+    assert fired_eth is True
+    assert len(nats.published) == 2
+
+
+# ─── AC5.d — non-mutation property ──────────────────────────────────────────
+
+
+def test_emitter_exposes_no_envelope_mutation_methods() -> None:
+    """AC5.d — the emitter must not provide a way to update the envelope.
+
+    Asserted by enumerating the emitter's public surface and checking
+    nothing looks like a write/update/set/save method.
+    """
+    public_methods = [m for m in dir(EnvelopeDriftEmitter) if not m.startswith("_")]
+    forbidden_prefixes = ("write", "update", "set_", "save", "put", "delete")
+    bad = [m for m in public_methods if m.startswith(forbidden_prefixes)]
+    assert bad == [], f"emitter exposes mutation-like methods: {bad}"
+
+
+# ─── AC5.b — default constants are public + sensible ────────────────────────
+
+
+def test_default_threshold_is_ten_percent() -> None:
+    assert DEFAULT_DIVERGENCE_THRESHOLD == pytest.approx(0.10)
+
+
+def test_default_rate_limit_window_is_one_hour() -> None:
+    assert DEFAULT_RATE_LIMIT_WINDOW == timedelta(hours=1)
+
+
+# ─── NATS-absent best-effort behaviour ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_emit_returns_true_even_without_nats_client() -> None:
+    """The emitter never crashes when nats_client is None — fires + records."""
+    emitter = EnvelopeDriftEmitter(nats_client=None)
+    fired = await emitter.check_and_emit(
+        strategy_key="strategy:btc",
+        current_version=1,
+        current_value={"x": 1.0},
+        proposed_value={"x": 2.0},
+        originating_characterization_revision="char-rev-1",
+    )
+    assert fired is True
+    assert emitter.last_fired_at("strategy:btc") is not None


### PR DESCRIPTION
## Summary

Closes #152 (P4.6-AC5 / FR62 / FR66) — alert producer that detects materially-divergent characterization-emitted envelopes against the active operator-approved envelope and emits `alerts.envelope.drift_detected.<strategy_key>` on the FR66 alert spine.

Mirrors the existing FR66 producer pattern (parallel structure to `DrawdownBreachEmitter` from #140 / P8-AC2c).

## Diff shape

| Path | Purpose |
| --- | --- |
| `cio/core/alerting/fr66_alerts.py` | +1 category constant, +1 builder, +1 subject helper |
| `cio/core/alerting/envelope_drift_emitter.py` (new) | `EnvelopeDriftEmitter` class + `compute_max_divergence_pct` |
| `tests/unit/test_envelope_drift_emitter.py` (new) | 20 unit tests |

## ACs

- [x] **AC5.a** Drift detection with configurable threshold (default 10%); `current_value=None` → divergence = infinity (forces first-approval alert); schema change (added/removed numeric keys) → infinity.
- [x] **AC5.b** `alerts.envelope.drift_detected.<strategy_key>` payload: `{strategy_key, current_version, current_value, proposed_value, divergence_pct, originating_characterization_revision, category, severity, message, timestamp, dedupe_key}`.
- [x] **AC5.c** Rate-limit suppression per `strategy_key` (default 1/hour). Window-expiry re-arms; per-strategy_key isolation (one strategy alerting doesn't suppress another).
- [x] **AC5.d** Non-mutation by construction. Explicit test enumerates the emitter's public surface and asserts no `write`/`update`/`set_`/`save`/`put`/`delete` methods exist.
- [x] **AC5.e** Three required branches covered as dedicated tests: `no_approved` / `approved_below_threshold` / `approved_above_threshold`. Plus rate-limit-within-window, rate-limit-window-expired, per-key isolation, nats-absent.

## Scope note

This PR adds the **detector + emitter** as a pure, NATS-agnostic unit. There is no existing characterization-envelope NATS consumer in cio to call it — that producer wiring is sibling-EPIC #692 scope (will pair with the operator-approval workflow shipped in petrosa-data-manager#187/PR #191). The emitter is intended to be invoked by that future consumer with `(current envelope value from data-manager EnvelopeRepository.get_active_envelope, proposed value from the characterization update, originating revision)` on each characterization event.

## Test results

- `pytest tests/`: **402 passed, 0 failed**
- 20 new tests in `tests/unit/test_envelope_drift_emitter.py`
- `ruff check`: clean
- `ruff format`: clean

## Risk

Detection-side only, no behaviour changes for existing producers. Nothing consumes the emitter until a future PR wires it in.
