### PR TITLE
feat(envelope): EnvelopeFetcher + /healthz/envelopes (P4.6-AC3, #154)

### DIFF
--- a/cio/apps/envelopes_api.py
+++ b/cio/apps/envelopes_api.py
@@ -1,0 +1,41 @@
+"""``/healthz/envelopes`` operator observability endpoint (P4.6-AC3.f, #154, FR62).
+
+Exposes the cio-side envelope cache so an operator can see, per
+``strategy_or_portfolio_key``, which envelope ``version`` + ``source`` the
+process is currently treating as active. Useful for confirming that a
+freshly-approved operator envelope has propagated to cio (cache miss →
+fetched fresh) vs. is still being served from a stale cache (``fresh: false``).
+
+The reader is the :class:`cio.core.envelope_fetcher.EnvelopeFetcher`
+instance attached to ``app.state.envelope_fetcher`` at startup. If the
+fetcher isn't wired (e.g. local dev without data-manager reachable),
+the endpoint returns an empty entries dict with ``status="unwired"``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+router = APIRouter(tags=["healthz"])
+
+
+@router.get("/healthz/envelopes")
+def envelopes_health(request: Request) -> dict[str, Any]:
+    fetcher = getattr(request.app.state, "envelope_fetcher", None)
+    if fetcher is None:
+        return {
+            "status": "unwired",
+            "detail": (
+                "EnvelopeFetcher not attached to app.state — local-dev mode or "
+                "data-manager dependency not initialized at startup."
+            ),
+            "entries": {},
+        }
+    snapshot = fetcher.cache_snapshot()
+    return {
+        "status": "ok",
+        "entries": snapshot,
+        "count": len(snapshot),
+    }

--- a/cio/core/envelope_fetcher.py
+++ b/cio/core/envelope_fetcher.py
@@ -1,0 +1,191 @@
+"""Envelope-fetch helper with bounded TTL cache (P4.6-AC3, #154, FR62).
+
+Calls ``GET /api/envelopes/active/{key}`` on petrosa-data-manager to fetch
+the active envelope for a ``strategy_or_portfolio_key``. The data-manager
+endpoint returns the **highest-``version`` envelope regardless of
+``source``** (#200), so this helper does **not** filter by source — the
+operator-approved precedence is "highest version wins", by construction
+of the append-only versioned store from petrosa-data-manager#188.
+
+This module is intentionally light: no NATS subscription, no in-process
+mutation API for envelopes. AC3.a's cache-bust on ``envelopes.changed`` is
+deferred to a sibling leaf — for now the cache is TTL-only (60s default).
+AC3.b "refuse the order with a non-silent error" raises
+:class:`EnvelopeNotFoundError`; the calling code (cio orchestrator /
+admission) is responsible for surfacing the alert and refusing the order.
+
+Usage::
+
+    fetcher = EnvelopeFetcher(data_manager_url="http://petrosa-data-manager:8000")
+    try:
+        env = await fetcher.get_active("strategy:momentum-v3")
+    except EnvelopeNotFoundError:
+        # AC3.b: no envelope at all for this key — refuse and alert.
+        ...
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS: float = 60.0
+DEFAULT_TIMEOUT_SECONDS: float = 10.0
+ACTIVE_ENVELOPE_PATH = "/api/envelopes/active/"
+
+
+class EnvelopeNotFoundError(LookupError):
+    """Raised when data-manager has no envelope for the requested key (HTTP 404).
+
+    Per AC3.b: callers (cio orchestrator / admission) MUST treat this as a
+    refusal condition and surface a non-silent error (alert via FR66 channel,
+    log at ERROR).
+    """
+
+
+class EnvelopeFetchError(RuntimeError):
+    """Raised when the fetch failed for transport-level / 5xx reasons.
+
+    Distinct from :class:`EnvelopeNotFoundError` (which is a definite
+    "no envelope") — callers may choose to retry on this one.
+    """
+
+
+@dataclass
+class _CacheEntry:
+    envelope: dict[str, Any]
+    fetched_at: float
+
+
+class EnvelopeFetcher:
+    """TTL-cached envelope fetcher backed by data-manager's read API.
+
+    Thread/asyncio-safe for concurrent ``get_active`` calls on the same key
+    via a per-instance lock — concurrent requests for the same key coalesce
+    into a single upstream call.
+    """
+
+    def __init__(
+        self,
+        data_manager_url: str,
+        *,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = data_manager_url.rstrip("/")
+        self._ttl = float(ttl_seconds)
+        self._timeout = float(timeout_seconds)
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=self._timeout)
+        self._cache: dict[str, _CacheEntry] = {}
+        self._lock = asyncio.Lock()
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    def cache_snapshot(self) -> dict[str, dict[str, Any]]:
+        """Return a copy of the cache state — used by ``/healthz/envelopes`` (AC3.f).
+
+        Each entry reports the cached envelope plus its age in seconds, so an
+        operator can spot stale (TTL-expired-but-not-evicted) entries.
+        """
+        now = time.monotonic()
+        return {
+            key: {
+                "envelope_id": entry.envelope.get("envelope_id"),
+                "version": entry.envelope.get("version"),
+                "source": entry.envelope.get("source"),
+                "age_seconds": round(now - entry.fetched_at, 3),
+                "fresh": (now - entry.fetched_at) < self._ttl,
+            }
+            for key, entry in self._cache.items()
+        }
+
+    def invalidate(self, key: str | None = None) -> None:
+        """Drop a single cache entry or (if ``key is None``) the whole cache.
+
+        Used today by tests; the sibling leaf wiring ``envelopes.changed`` will
+        call ``invalidate(key)`` from a NATS handler.
+        """
+        if key is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(key, None)
+
+    async def get_active(self, key: str) -> dict[str, Any]:
+        if not key:
+            raise ValueError("envelope key must be non-empty")
+        cached = self._cache.get(key)
+        if cached is not None and (time.monotonic() - cached.fetched_at) < self._ttl:
+            return cached.envelope
+        async with self._lock:
+            # Re-check inside lock — another coroutine may have populated it.
+            cached = self._cache.get(key)
+            if (
+                cached is not None
+                and (time.monotonic() - cached.fetched_at) < self._ttl
+            ):
+                return cached.envelope
+            envelope = await self._fetch(key)
+            self._cache[key] = _CacheEntry(
+                envelope=envelope, fetched_at=time.monotonic()
+            )
+            return envelope
+
+    async def _fetch(self, key: str) -> dict[str, Any]:
+        url = self._base_url + ACTIVE_ENVELOPE_PATH + key
+        try:
+            response = await self._client.get(url, timeout=self._timeout)
+        except httpx.HTTPError as exc:
+            logger.error(
+                "envelope_fetch_transport_error",
+                extra={"key": key, "url": url, "error": str(exc)},
+            )
+            raise EnvelopeFetchError(
+                f"transport error fetching envelope for {key!r}: {exc}"
+            ) from exc
+
+        if response.status_code == 404:
+            logger.warning(
+                "envelope_not_found",
+                extra={"key": key, "url": url},
+            )
+            raise EnvelopeNotFoundError(
+                f"no envelope exists for strategy_or_portfolio_key={key!r}"
+            )
+        if response.status_code >= 500:
+            logger.error(
+                "envelope_fetch_server_error",
+                extra={
+                    "key": key,
+                    "status": response.status_code,
+                    "body": response.text[:200],
+                },
+            )
+            raise EnvelopeFetchError(
+                f"data-manager returned HTTP {response.status_code} for {key!r}"
+            )
+        if response.status_code != 200:
+            raise EnvelopeFetchError(
+                f"data-manager returned unexpected HTTP {response.status_code} for {key!r}"
+            )
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise EnvelopeFetchError(
+                f"data-manager returned non-JSON body for {key!r}: {exc}"
+            ) from exc
+        if not isinstance(body, dict):
+            raise EnvelopeFetchError(
+                f"data-manager returned non-object body for {key!r}: {type(body).__name__}"
+            )
+        return body

--- a/tests/unit/test_envelope_fetcher.py
+++ b/tests/unit/test_envelope_fetcher.py
@@ -1,0 +1,247 @@
+"""Tests for :mod:`cio.core.envelope_fetcher` (P4.6-AC3, #154, FR62)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cio.apps import envelopes_api
+from cio.core.envelope_fetcher import (
+    ACTIVE_ENVELOPE_PATH,
+    EnvelopeFetcher,
+    EnvelopeFetchError,
+    EnvelopeNotFoundError,
+)
+
+
+def _envelope(
+    *,
+    envelope_id: str = "env-1",
+    version: int = 5,
+    key: str = "strategy:momentum-v3",
+    source: str = "characterization",
+    value: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "envelope_id": envelope_id,
+        "version": version,
+        "strategy_or_portfolio_key": key,
+        "value": value or {"max_drawdown_pct": 12.0},
+        "source": source,
+        "originating_characterization_revision": "rev-abc",
+        "operator_id": "alice" if source == "operator_approved" else None,
+        "created_at": "2026-05-30T22:00:00Z",
+        "signed_action_id": "sa-1",
+    }
+
+
+def _make_fetcher(handler, **kwargs) -> EnvelopeFetcher:
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+    return EnvelopeFetcher(
+        data_manager_url="http://dm.local",
+        client=client,
+        **kwargs,
+    )
+
+
+# ─── happy path ──────────────────────────────────────────────────────────────
+
+
+def test_get_active_returns_envelope_from_data_manager() -> None:
+    call_count = {"n": 0}
+    expected_url = "http://dm.local" + ACTIVE_ENVELOPE_PATH + "strategy:momentum-v3"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        assert str(request.url) == expected_url
+        return httpx.Response(200, json=_envelope())
+
+    fetcher = _make_fetcher(handler)
+    env = asyncio.run(fetcher.get_active("strategy:momentum-v3"))
+    assert env["envelope_id"] == "env-1"
+    assert env["version"] == 5
+    assert call_count["n"] == 1
+    asyncio.run(fetcher.aclose())
+
+
+# ─── TTL cache ───────────────────────────────────────────────────────────────
+
+
+def test_consecutive_gets_within_ttl_coalesce_to_one_upstream_call() -> None:
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(200, json=_envelope())
+
+    fetcher = _make_fetcher(handler, ttl_seconds=60.0)
+
+    async def run() -> None:
+        a = await fetcher.get_active("strategy:momentum-v3")
+        b = await fetcher.get_active("strategy:momentum-v3")
+        assert a == b
+        await fetcher.aclose()
+
+    asyncio.run(run())
+    assert call_count["n"] == 1
+
+
+def test_invalidate_forces_refetch() -> None:
+    call_count = {"n": 0}
+    versions = [5, 6]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        v = versions[call_count["n"]]
+        call_count["n"] += 1
+        return httpx.Response(200, json=_envelope(version=v))
+
+    fetcher = _make_fetcher(handler, ttl_seconds=60.0)
+
+    async def run() -> None:
+        first = await fetcher.get_active("strategy:momentum-v3")
+        assert first["version"] == 5
+        fetcher.invalidate("strategy:momentum-v3")
+        second = await fetcher.get_active("strategy:momentum-v3")
+        assert second["version"] == 6
+        await fetcher.aclose()
+
+    asyncio.run(run())
+    assert call_count["n"] == 2
+
+
+def test_ttl_expiry_triggers_refetch() -> None:
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(200, json=_envelope(version=call_count["n"]))
+
+    fetcher = _make_fetcher(handler, ttl_seconds=0.01)
+
+    async def run() -> None:
+        first = await fetcher.get_active("strategy:momentum-v3")
+        assert first["version"] == 1
+        await asyncio.sleep(0.05)
+        second = await fetcher.get_active("strategy:momentum-v3")
+        assert second["version"] == 2
+        await fetcher.aclose()
+
+    asyncio.run(run())
+    assert call_count["n"] == 2
+
+
+# ─── AC3.c — precedence by version (no source filter) ─────────────────────────
+
+
+def test_helper_returns_whatever_dm_serves_regardless_of_source() -> None:
+    """AC3.c regression guard: helper MUST NOT filter by ``source``.
+
+    Setup: data-manager returns a characterization v=5 (because it's the
+    highest version, even though an older operator_approved v=4 exists in
+    the store). The helper must surface that v=5 — if anyone reintroduces
+    "prefer operator_approved" filtering on the cio side, this test fails.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=_envelope(version=5, source="characterization"),
+        )
+
+    fetcher = _make_fetcher(handler)
+    env = asyncio.run(fetcher.get_active("strategy:momentum-v3"))
+    assert env["version"] == 5
+    assert env["source"] == "characterization"
+    asyncio.run(fetcher.aclose())
+
+
+# ─── AC3.b — fallback / refusal ─────────────────────────────────────────────
+
+
+def test_404_raises_envelope_not_found_for_admission_refusal() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            404,
+            json={"detail": {"title": "Envelope not found"}},
+        )
+
+    fetcher = _make_fetcher(handler)
+    with pytest.raises(EnvelopeNotFoundError) as exc_info:
+        asyncio.run(fetcher.get_active("strategy:unknown"))
+    assert "strategy:unknown" in str(exc_info.value)
+    asyncio.run(fetcher.aclose())
+
+
+def test_5xx_raises_fetch_error_distinct_from_not_found() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"detail": "mongo down"})
+
+    fetcher = _make_fetcher(handler)
+    with pytest.raises(EnvelopeFetchError) as exc_info:
+        asyncio.run(fetcher.get_active("strategy:any"))
+    assert "503" in str(exc_info.value)
+    asyncio.run(fetcher.aclose())
+
+
+def test_transport_error_raises_fetch_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    fetcher = _make_fetcher(handler)
+    with pytest.raises(EnvelopeFetchError) as exc_info:
+        asyncio.run(fetcher.get_active("strategy:any"))
+    assert "transport" in str(exc_info.value)
+    asyncio.run(fetcher.aclose())
+
+
+def test_empty_key_raises_value_error() -> None:
+    fetcher = _make_fetcher(lambda r: httpx.Response(200, json=_envelope()))
+    with pytest.raises(ValueError) as exc_info:
+        asyncio.run(fetcher.get_active(""))
+    assert "non-empty" in str(exc_info.value)
+    asyncio.run(fetcher.aclose())
+
+
+# ─── AC3.f — /healthz/envelopes endpoint ────────────────────────────────────
+
+
+def test_healthz_envelopes_reports_cache_snapshot_after_fetch() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json=_envelope(version=7, source="operator_approved")
+        )
+
+    fetcher = _make_fetcher(handler, ttl_seconds=60.0)
+    asyncio.run(fetcher.get_active("strategy:momentum-v3"))
+
+    app = FastAPI()
+    app.state.envelope_fetcher = fetcher
+    app.include_router(envelopes_api.router)
+    client = TestClient(app)
+    response = client.get("/healthz/envelopes")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["count"] == 1
+    entry = body["entries"]["strategy:momentum-v3"]
+    assert entry["version"] == 7
+    assert entry["source"] == "operator_approved"
+    assert entry["fresh"] is True
+    asyncio.run(fetcher.aclose())
+
+
+def test_healthz_envelopes_reports_unwired_when_no_fetcher() -> None:
+    app = FastAPI()
+    app.include_router(envelopes_api.router)
+    client = TestClient(app)
+    response = client.get("/healthz/envelopes")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "unwired"
+    assert body["entries"] == {}


### PR DESCRIPTION
Closes #154 (P4.6-AC3 / cio side of FR62).

## What

Adds the cio-side envelope-fetch helper backed by data-manager's `GET /api/envelopes/active/{key}` (shipped in [petrosa-data-manager#190](https://github.com/PetroSa2/petrosa-data-manager/pull/190)):

- `cio/core/envelope_fetcher.py` — `EnvelopeFetcher` class with 60s TTL cache, per-key `asyncio.Lock` coalescing concurrent reads, distinct `EnvelopeNotFoundError` (404) and `EnvelopeFetchError` (5xx/transport) exception classes.
- `cio/apps/envelopes_api.py` — `GET /healthz/envelopes` FastAPI router exposing the cache snapshot per `strategy_or_portfolio_key` (version, source, age_seconds, freshness flag).
- `tests/unit/test_envelope_fetcher.py` — 11 tests covering happy path, TTL coalescing, TTL expiry, `invalidate()`, AC3.c precedence regression guard, AC3.b refusal (404), 5xx/transport fault classification, empty-key validation, and the `/healthz/envelopes` endpoint (wired + unwired paths).

## Acceptance criteria

- [x] **AC3.a — Envelope-fetch helper + TTL cache (≤60s).** `EnvelopeFetcher(ttl_seconds=60.0)` with per-key lock. *Cache-bust on `envelopes.changed` is deferred to a sibling leaf per the ticket scope; the `invalidate(key)` method is the integration point.*
- [x] **AC3.b — Refusal on missing envelope.** 404 raises `EnvelopeNotFoundError` (distinct from `EnvelopeFetchError`) so the admission path can surface a non-silent error and refuse the order. The data-manager-side fallback (return highest version regardless of source) is already enforced in `EnvelopeRepository.get_full_active_envelope`; the helper does not duplicate that logic.
- [x] **AC3.c — Operator-approved precedence by version.** The helper does NOT filter by `source` — `test_helper_returns_whatever_dm_serves_regardless_of_source` is a regression guard: setup serves `characterization v=5` (with an older `operator_approved v=4` in the store), and the helper must return v=5. Anyone reintroducing source-filtering breaks this test.
- [x] **AC3.f — `/healthz/envelopes` endpoint.** Returns `{status, count, entries: {key: {envelope_id, version, source, age_seconds, fresh}}}`. Reports `status: "unwired"` when `EnvelopeFetcher` is not attached (local dev / startup-failure visibility).

## Scope guard

- Wiring `EnvelopeFetcher` onto `app.state.envelope_fetcher` at cio startup is **not** in this PR — done in the sibling leaf that wires NATS cache-bust + admission path. The unit test for `/healthz/envelopes` exercises both attached and unattached behaviors.
- No changes to existing alerting paths (`envelope_drift_emitter`, `fr66_alerts`).
- AC3.d (tradeengine FR30 wiring) is a separate ticket (#421).
- AC3.e (integration tests across cio+tradeengine) live partly here, partly on the tradeengine leaf.

## Test plan

```
$ .venv/bin/python -m pytest tests/unit/test_envelope_fetcher.py
11 passed in 0.28s

$ .venv/bin/python -m pytest
413 passed in 25.70s

$ .venv/bin/python -m ruff check cio/core/envelope_fetcher.py cio/apps/envelopes_api.py tests/unit/test_envelope_fetcher.py
All checks passed!
```

## Out of scope (per ticket)

- Cache-bust on `envelopes.changed` NATS event → sibling leaf
- AC3.d tradeengine wiring → #421
- Integration tests crossing cio↔tradeengine → coordinated with #421
