### PR TITLE
feat(admission): POST /api/admission/register HTTP endpoint (#156)

### DIFF
--- a/cio/apps/admission_api.py
+++ b/cio/apps/admission_api.py
@@ -1,0 +1,85 @@
+"""``POST /api/admission/register`` HTTP surface for ``PortfolioTracker.record_admit``
+(petrosa-cio#156, FR54-B precursor).
+
+Background — the cio admission flow lived entirely in-process as
+:meth:`cio.core.portfolio_tracker.PortfolioTracker.record_admit`. The FR54
+self-service strategy pipeline ([petrosa-bot-ta-analysis#256](https://github.com/PetroSa2/petrosa-bot-ta-analysis/issues/256))
+needs to register a characterized strategy with cio over HTTP from the CLI
+host (which doesn't share the cio Python process). This module wraps
+``record_admit`` behind a FastAPI route so the CLI (and any other
+out-of-process caller) can drive admission without taking a Python
+dependency on the cio package.
+
+The route reads the tracker from ``app.state.portfolio_tracker`` (the same
+``app.state``-attached convention the rest of cio's apps follow — see
+``cio/apps/state_api.py``). If the tracker isn't wired (local-dev mode),
+the route returns ``503``.
+
+**Important — no admission policy is enforced here.** The
+``PortfolioTracker.would_breach_ceiling`` check is the orchestrator's
+concern; this route is a thin record/replace pass-through (matching the
+existing in-process call shape from ``cio.core.orchestrator``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/api/admission", tags=["admission"])
+
+
+class AdmissionRegisterRequest(BaseModel):
+    strategy_id: str = Field(
+        ..., min_length=1, description="Stable strategy identifier"
+    )
+    position_size_usd: float = Field(
+        ..., ge=0.0, description="Admitted notional in USD (>= 0)"
+    )
+    leverage: float = Field(..., ge=1.0, description="Admitted leverage (>= 1)")
+    # Audit-trail fields, passed through to logs/metrics only. Not stored in
+    # the in-process tracker today (no schema change to the existing record).
+    strategy_revision_id: str | None = Field(
+        None, description="Optional FR53 strategy-revision id for audit trail"
+    )
+    submitted_by: str | None = Field(
+        None, description="Operator handle for audit trail"
+    )
+
+
+@router.post(
+    "/register",
+    status_code=201,
+    response_model=None,
+)
+async def register_admission(
+    req: AdmissionRegisterRequest,
+    request: Request,
+) -> dict[str, Any]:
+    tracker = getattr(request.app.state, "portfolio_tracker", None)
+    if tracker is None:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "title": "PortfolioTracker not wired",
+                "detail": (
+                    "cio is in local-dev mode (no app.state.portfolio_tracker) — "
+                    "admission cannot be recorded."
+                ),
+            },
+        )
+    await tracker.record_admit(
+        strategy_id=req.strategy_id,
+        position_size_usd=req.position_size_usd,
+        leverage=req.leverage,
+    )
+    return {
+        "strategy_id": req.strategy_id,
+        "position_size_usd": req.position_size_usd,
+        "leverage": req.leverage,
+        "strategy_revision_id": req.strategy_revision_id,
+        "submitted_by": req.submitted_by,
+        "status": "admitted",
+    }

--- a/tests/unit/test_admission_api.py
+++ b/tests/unit/test_admission_api.py
@@ -1,0 +1,170 @@
+"""Tests for ``cio.apps.admission_api`` (petrosa-cio#156, FR54-B precursor)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cio.apps import admission_api
+
+
+@dataclass
+class _RecorderTracker:
+    """Test double matching the methods admission_api invokes."""
+
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    async def record_admit(
+        self,
+        *,
+        strategy_id: str,
+        position_size_usd: float,
+        leverage: float,
+    ) -> None:
+        self.calls.append(
+            {
+                "strategy_id": strategy_id,
+                "position_size_usd": position_size_usd,
+                "leverage": leverage,
+            }
+        )
+
+
+def _make_app(tracker: Any | None) -> FastAPI:
+    app = FastAPI()
+    if tracker is not None:
+        app.state.portfolio_tracker = tracker
+    app.include_router(admission_api.router)
+    return app
+
+
+# ─── happy path ──────────────────────────────────────────────────────────────
+
+
+def test_register_returns_201_and_invokes_record_admit() -> None:
+    tracker = _RecorderTracker()
+    client = TestClient(_make_app(tracker))
+    response = client.post(
+        "/api/admission/register",
+        json={
+            "strategy_id": "momentum-v3",
+            "position_size_usd": 10000.0,
+            "leverage": 3.0,
+            "strategy_revision_id": "rev-abc",
+            "submitted_by": "alice",
+        },
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["status"] == "admitted"
+    assert body["strategy_id"] == "momentum-v3"
+    assert body["position_size_usd"] == 10000.0
+    assert body["leverage"] == 3.0
+    assert body["strategy_revision_id"] == "rev-abc"
+    assert body["submitted_by"] == "alice"
+    assert tracker.calls == [
+        {
+            "strategy_id": "momentum-v3",
+            "position_size_usd": 10000.0,
+            "leverage": 3.0,
+        }
+    ]
+
+
+# ─── idempotent re-register ─────────────────────────────────────────────────
+
+
+def test_register_then_re_register_with_same_keys_overwrites_in_tracker() -> None:
+    tracker = _RecorderTracker()
+    client = TestClient(_make_app(tracker))
+    payload = {
+        "strategy_id": "momentum-v3",
+        "position_size_usd": 10000.0,
+        "leverage": 3.0,
+    }
+    a = client.post("/api/admission/register", json=payload)
+    b = client.post(
+        "/api/admission/register",
+        json={**payload, "position_size_usd": 15000.0},
+    )
+    assert a.status_code == 201
+    assert b.status_code == 201  # tracker.record_admit is a replace, not an insert
+    assert len(tracker.calls) == 2
+    assert tracker.calls[1]["position_size_usd"] == 15000.0
+
+
+# ─── validation ─────────────────────────────────────────────────────────────
+
+
+def test_empty_strategy_id_is_422() -> None:
+    tracker = _RecorderTracker()
+    client = TestClient(_make_app(tracker))
+    response = client.post(
+        "/api/admission/register",
+        json={"strategy_id": "", "position_size_usd": 1.0, "leverage": 1.0},
+    )
+    assert response.status_code == 422
+    assert tracker.calls == []
+
+
+def test_leverage_below_1_is_422() -> None:
+    tracker = _RecorderTracker()
+    client = TestClient(_make_app(tracker))
+    response = client.post(
+        "/api/admission/register",
+        json={"strategy_id": "x", "position_size_usd": 1.0, "leverage": 0.5},
+    )
+    assert response.status_code == 422
+
+
+def test_negative_size_is_422() -> None:
+    tracker = _RecorderTracker()
+    client = TestClient(_make_app(tracker))
+    response = client.post(
+        "/api/admission/register",
+        json={"strategy_id": "x", "position_size_usd": -1.0, "leverage": 1.0},
+    )
+    assert response.status_code == 422
+
+
+def test_missing_required_fields_is_422() -> None:
+    tracker = _RecorderTracker()
+    client = TestClient(_make_app(tracker))
+    response = client.post(
+        "/api/admission/register",
+        json={"strategy_id": "x"},  # missing size + leverage
+    )
+    assert response.status_code == 422
+
+
+# ─── unwired tracker → 503 ──────────────────────────────────────────────────
+
+
+def test_unwired_tracker_returns_503() -> None:
+    client = TestClient(_make_app(tracker=None))
+    response = client.post(
+        "/api/admission/register",
+        json={"strategy_id": "x", "position_size_usd": 1.0, "leverage": 1.0},
+    )
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["title"] == "PortfolioTracker not wired"
+
+
+# ─── audit fields are optional ──────────────────────────────────────────────
+
+
+def test_audit_fields_optional_default_to_none() -> None:
+    tracker = _RecorderTracker()
+    client = TestClient(_make_app(tracker))
+    response = client.post(
+        "/api/admission/register",
+        json={"strategy_id": "x", "position_size_usd": 100.0, "leverage": 1.0},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["strategy_revision_id"] is None
+    assert body["submitted_by"] is None


### PR DESCRIPTION
Closes #156 (FR54-B precursor / unblocks half of petrosa-bot-ta-analysis#256).

## What

New `cio/apps/admission_api.py` exposes `PortfolioTracker.record_admit` over HTTP at `POST /api/admission/register`. Body: `{strategy_id, position_size_usd, leverage}` + optional audit fields `strategy_revision_id` / `submitted_by` (passed through to response/logs only).

- Returns 201 on success
- Returns 503 when `app.state.portfolio_tracker` is unwired (local-dev)
- Returns 422 on validation failure (empty `strategy_id`, `leverage < 1`, `position_size_usd < 0`, missing required fields)
- **No admission policy enforced here** — `would_breach_ceiling` is the orchestrator-side check; this route is a thin record/replace pass-through matching the in-process call shape from `cio.core.orchestrator`.

## Tests

`tests/unit/test_admission_api.py` — 8 tests covering happy path, idempotent re-register, all validation failures, unwired-tracker, and optional audit-field defaults.

## Scope guard

- Router not yet mounted into the running cio FastAPI app — the FR54-B consumer leaf ([#256](https://github.com/PetroSa2/petrosa-bot-ta-analysis/issues/256)) will wire `app.include_router(admission_api.router)` and attach `app.state.portfolio_tracker` at startup. This isolates the precursor work from the cross-repo CLI integration.
- No changes to `PortfolioTracker` itself — request body shape matches the existing method signature.