### PR TITLE
[P1][BUG] fix(cio): independent LLM fallback routing + action distribution metric (#824)

### DIFF
--- a/cio/clients/llm_client.py
+++ b/cio/clients/llm_client.py
@@ -363,9 +363,13 @@ class LiteLLMClient(CIO_LLM_Client):
         primary_model = os.getenv("LLM_MODEL", DEFAULT_PRIMARY_MODEL)
         fallback_model = os.getenv("LLM_FALLBACK_MODEL", DEFAULT_FALLBACK_MODEL)
         api_base = os.getenv("LLM_API_BASE")
+        # LLM_FALLBACK_API_BASE allows the fallback to bypass a broken proxy
+        # (e.g. Requesty down) by routing directly to a different provider endpoint.
+        # Defaults to the same api_base so existing deployments are unaffected.
+        fallback_api_base = os.getenv("LLM_FALLBACK_API_BASE", api_base)
 
         routing_primary = _build_routing_model(primary_model, api_base)
-        routing_fallback = _build_routing_model(fallback_model, api_base)
+        routing_fallback = _build_routing_model(fallback_model, fallback_api_base)
 
         start_time = time.perf_counter()
 
@@ -415,7 +419,7 @@ class LiteLLMClient(CIO_LLM_Client):
             try:
                 fallback_response = await litellm.acompletion(
                     model=routing_fallback,
-                    api_base=api_base,
+                    api_base=fallback_api_base,
                     messages=[
                         {"role": "system", "content": system_prompt},
                         {"role": "user", "content": json.dumps(user_context)},
@@ -463,7 +467,8 @@ class LiteLLMClient(CIO_LLM_Client):
 
         fallback_model = os.getenv("LLM_FALLBACK_MODEL", DEFAULT_FALLBACK_MODEL)
         api_base = os.getenv("LLM_API_BASE")
-        routing_fallback = _build_routing_model(fallback_model, api_base)
+        fallback_api_base = os.getenv("LLM_FALLBACK_API_BASE", api_base)
+        routing_fallback = _build_routing_model(fallback_model, fallback_api_base)
 
         logger.info(
             "Schema fallback: retrying with fallback model",
@@ -474,7 +479,7 @@ class LiteLLMClient(CIO_LLM_Client):
             start_time = time.perf_counter()
             response = await litellm.acompletion(
                 model=routing_fallback,
-                api_base=api_base,
+                api_base=fallback_api_base,
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": json.dumps(user_context)},

--- a/cio/core/orchestrator.py
+++ b/cio/core/orchestrator.py
@@ -268,13 +268,15 @@ class Orchestrator:
                     "Executing final Action Classifier for hard-blocked trade",
                     extra={"correlation_id": context.correlation_id},
                 )
-                return await self.action_classifier.classify(
+                _blocked_decision = await self.action_classifier.classify(
                     context,
                     code_result,
                     bypass_regime,
                     bypass_strategy,
                     bypass_mode=not self.use_llm_reasoning,
                 )
+                self._emit_decision_action(_blocked_decision.action)
+                return _blocked_decision
 
             # NEW: DETERMINISTIC BYPASS (Ticket #334/337)
             if not self.use_llm_reasoning:
@@ -283,13 +285,15 @@ class Orchestrator:
                     extra={"correlation_id": context.correlation_id},
                 )
                 # In bypass mode we "blindly" trust the intent when risk gates pass.
-                return await self.action_classifier.classify(
+                _bypass_decision = await self.action_classifier.classify(
                     context,
                     code_result,
                     bypass_regime,
                     bypass_strategy,
                     bypass_mode=True,
                 )
+                self._emit_decision_action(_bypass_decision.action)
+                return _bypass_decision
 
             # 2. REGIME ANALYSIS (S3-S5)
             # Check cache first for HOT path
@@ -364,7 +368,7 @@ class Orchestrator:
                     "llm_provider": provider_name,
                 },
             )
-
+            self._emit_decision_action(decision.action)
             return decision
 
         except Exception as e:
@@ -372,7 +376,16 @@ class Orchestrator:
                 f"Critical failure in reasoning loop: {str(e)}",
                 extra={"correlation_id": context.correlation_id},
             )
+            self._emit_decision_action(SAFE_DECISION_RESULT.action)
             return SAFE_DECISION_RESULT
+
+    def _emit_decision_action(self, action: ActionType) -> None:
+        try:
+            from cio.core.metrics import DECISION_ACTIONS
+
+            DECISION_ACTIONS.add(1, {"action": str(action)})
+        except ImportError:
+            pass
 
     async def _check_spend_ceiling(self, correlation_id: str) -> None:
         """FR63 / AC4: check LLM spend ceiling; transition to deterministic bypass on breach.

--- a/tests/unit/test_llm_client.py
+++ b/tests/unit/test_llm_client.py
@@ -637,3 +637,127 @@ async def test_record_failure_trips_breaker_after_five_total_failures():
 
     assert client._failure_count >= 5
     assert client._breaker_open_until > 0
+
+
+# ---------------------------------------------------------------------------
+# LLM_FALLBACK_API_BASE — independent fallback routing (fixes #824)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fallback_uses_separate_api_base_when_env_set():
+    """
+    When LLM_FALLBACK_API_BASE is set, the fallback acompletion call must use
+    fallback_api_base, not the primary api_base, so a broken proxy does not
+    take down both models simultaneously.
+    """
+    client = LiteLLMClient()
+    primary_base = "https://broken-proxy.example.com/v1"
+    fallback_base = "https://direct.openai.com/v1"
+
+    call_log: list[dict] = []
+
+    async def _fake_acompletion(**kwargs):
+        call_log.append({"api_base": kwargs.get("api_base"), "model": kwargs["model"]})
+        if kwargs.get("api_base") == primary_base:
+            raise RuntimeError("proxy down")
+        ns = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content='{"action":"execute","justification":"ok","thought_trace":"t"}'
+                    )
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=10, completion_tokens=5, prompt_tokens_details=None
+            ),
+            model="openai/gpt-4o-mini",
+        )
+        return ns
+
+    fake_litellm = SimpleNamespace(
+        acompletion=AsyncMock(side_effect=_fake_acompletion),
+        get_supported_openai_params=MagicMock(return_value=[]),
+    )
+    fake_exceptions = SimpleNamespace(
+        RateLimitError=RuntimeError,
+        ServiceUnavailableError=RuntimeError,
+    )
+    env = {
+        "LLM_API_BASE": primary_base,
+        "LLM_FALLBACK_API_BASE": fallback_base,
+        "LLM_MODEL": "openai/gpt-4o",
+        "LLM_FALLBACK_MODEL": "openai/gpt-4o-mini",
+    }
+    with (
+        patch.dict(os.environ, env),
+        patch.dict(
+            sys.modules,
+            {"litellm": fake_litellm, "litellm.exceptions": fake_exceptions},
+        ),
+    ):
+        result = await client.complete("PETROSA_PROMPT_ACTION_CLASSIFIER", "sys", {})
+
+    assert result.error is None, (
+        f"Expected success on fallback, got error: {result.error}"
+    )
+    fallback_calls = [c for c in call_log if c["api_base"] == fallback_base]
+    assert len(fallback_calls) >= 1, "Fallback call must use LLM_FALLBACK_API_BASE"
+
+
+@pytest.mark.asyncio
+async def test_fallback_defaults_to_primary_api_base_when_env_unset():
+    """
+    When LLM_FALLBACK_API_BASE is not set, fallback inherits LLM_API_BASE
+    (legacy behaviour unchanged).
+    """
+    client = LiteLLMClient()
+    shared_base = "https://router.requesty.ai/v1"
+    call_log: list[dict] = []
+    call_count = 0
+
+    async def _fake_acompletion(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        call_log.append({"api_base": kwargs.get("api_base")})
+        if call_count == 1:
+            raise RuntimeError("primary fail")
+        ns = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content='{"action":"skip","justification":"ok","thought_trace":"t"}'
+                    )
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=5, completion_tokens=3, prompt_tokens_details=None
+            ),
+            model="openai/gpt-4o-mini",
+        )
+        return ns
+
+    fake_litellm = SimpleNamespace(
+        acompletion=AsyncMock(side_effect=_fake_acompletion),
+        get_supported_openai_params=MagicMock(return_value=[]),
+    )
+    fake_exceptions = SimpleNamespace(
+        RateLimitError=RuntimeError,
+        ServiceUnavailableError=RuntimeError,
+    )
+    env = {"LLM_API_BASE": shared_base, "LLM_FALLBACK_MODEL": "openai/gpt-4o-mini"}
+    # LLM_FALLBACK_API_BASE deliberately absent
+    with (
+        patch.dict(os.environ, env),
+        patch.dict(
+            sys.modules,
+            {"litellm": fake_litellm, "litellm.exceptions": fake_exceptions},
+        ),
+    ):
+        result = await client.complete("PETROSA_PROMPT_ACTION_CLASSIFIER", "sys", {})
+
+    assert all(c["api_base"] == shared_base for c in call_log), (
+        "Without LLM_FALLBACK_API_BASE, all calls must use the primary api_base"
+    )
+    assert result.error is None


### PR DESCRIPTION
## Summary

Fixes `petrosa_k8s#824` — cio orchestrator stuck at 100% `Action: skip` (silent trading halt).

### Root cause (AC2 confirmed)

`LLM_API_BASE=https://router.requesty.ai/v1` is set in the shared configmap. **Both** primary (`LLM_MODEL`) and fallback (`LLM_FALLBACK_MODEL`) were routing through the same Requesty proxy. When Requesty became unavailable, both models returned `litellm.ServiceUnavailableError`, which the circuit breaker eventually absorbed as `CIRCUIT_BREAKER_OPEN`. Every `complete_with_schema()` call then returned `SAFE_DEFAULTS → action=skip`.

### Changes

**`cio/clients/llm_client.py`**
- Add `LLM_FALLBACK_API_BASE` env var. When set, the fallback model uses a different proxy/endpoint so a single proxy outage cannot take both models down simultaneously.
- Both `LiteLLMClient.complete()` and `_schema_fallback()` use `fallback_api_base`, defaulting to `LLM_API_BASE` for full backwards compatibility when the env var is absent.

**`cio/core/orchestrator.py`**
- Wire `DECISION_ACTIONS` OTel counter (`cio_decision_actions_total`) at all four `Orchestrator.run()` return paths. This is the data source for the AC5 Grafana panel (`cio.orchestrator.action_distribution`).

**`tests/unit/test_llm_client.py`**
- 2 new tests: `test_fallback_uses_separate_api_base_when_env_set` and `test_fallback_defaults_to_primary_api_base_when_env_unset`.

### AC status

| AC | Status | Notes |
|----|--------|-------|
| AC1 | ✅ | `LLM_PARSE_FAILURE_SKIP` log + `LLM_FALLBACK_SKIPS` metric already identify the branch; `DECISION_ACTIONS` now exposes the action distribution for dashboard alerting |
| AC2 | ✅ | Root cause confirmed: Requesty proxy shared by primary + fallback |
| AC3 | ✅ (code) | `LLM_FALLBACK_API_BASE` gives fallback true independence; operator must set `LLM_FALLBACK_API_BASE` to a working direct-provider URL or empty (direct OpenAI) in the k8s secret/configmap — tracked as follow-up operator step |
| AC4 | Post-deploy | Alert volume should drop once `LLM_FALLBACK_API_BASE` is set in cluster |
| AC5 | ✅ (data) | `DECISION_ACTIONS` counter now emitted; Grafana panel creation is a follow-up operator step (add `cio_decision_actions_total` to the existing CIO dashboard) |

### Operator action required after merge

Set `LLM_FALLBACK_API_BASE` in `k8s/shared/configmaps/petrosa-common-config.yaml` (or a cio-specific secret) to a direct provider URL that bypasses the Requesty proxy, e.g.:
```yaml
LLM_FALLBACK_API_BASE: ""   # empty = litellm goes direct to provider using model prefix routing
```
Or point it to a second proxy for redundancy.

Closes petrosa_k8s#824

